### PR TITLE
Improve Discord gateway reconnect resiliency

### DIFF
--- a/BeanBot.Tests/Services/DiscordConnectionHealthTests.cs
+++ b/BeanBot.Tests/Services/DiscordConnectionHealthTests.cs
@@ -1,0 +1,37 @@
+using BeanBot.Services;
+
+using Discord.WebSocket;
+
+using Xunit;
+
+namespace BeanBot.Tests.Services;
+
+public class DiscordConnectionHealthTests
+{
+    [Fact]
+    public void MarkReady_PreservesMostRecentDisconnectReasonForDiagnostics()
+    {
+        using var discordClient = new DiscordSocketClient();
+        var health = new DiscordConnectionHealth();
+        health.MarkDisconnected(new InvalidOperationException("Temporary DNS failure"));
+
+        health.MarkReady();
+        var snapshot = health.CreateSnapshot(discordClient);
+
+        Assert.Equal("Temporary DNS failure", snapshot.MostRecentDisconnectReason);
+        Assert.Null(snapshot.UnhealthySinceAtUtc);
+    }
+
+    [Fact]
+    public void MarkDisconnected_ReplacesMostRecentDisconnectReason()
+    {
+        using var discordClient = new DiscordSocketClient();
+        var health = new DiscordConnectionHealth();
+        health.MarkDisconnected(new InvalidOperationException("First failure"));
+
+        health.MarkDisconnected(new InvalidOperationException("Latest failure"));
+        var snapshot = health.CreateSnapshot(discordClient);
+
+        Assert.Equal("Latest failure", snapshot.MostRecentDisconnectReason);
+    }
+}

--- a/BeanBot.Tests/Services/DiscordGatewayRecoveryServiceTests.cs
+++ b/BeanBot.Tests/Services/DiscordGatewayRecoveryServiceTests.cs
@@ -1,0 +1,198 @@
+using BeanBot.Services;
+
+using System.Collections.Concurrent;
+
+using Xunit;
+
+namespace BeanBot.Tests.Services;
+
+public class DiscordGatewayRecoveryServiceTests
+{
+    private static readonly DiscordGatewayRecoveryOptions TestOptions = new(
+        TimeSpan.FromMinutes(5),
+        TimeSpan.FromSeconds(30),
+        TimeSpan.FromMinutes(2));
+
+    [Fact]
+    public async Task TemporaryDisconnect_ReachesReadyBeforeManualRecovery()
+    {
+        var state = new FakeHealthState();
+        var lifecycle = new FakeLifecycle();
+        var delay = new ControlledDelay();
+        var exitCodes = new List<int>();
+        await using var recovery = CreateService(state, lifecycle, delay, exitCodes);
+
+        Assert.True(recovery.StartMonitoring());
+        await delay.WaitForRequestCountAsync(1);
+
+        state.MarkHealthy();
+        recovery.NotifyReady();
+        await recovery.WaitForIdleAsync();
+
+        Assert.Equal(0, lifecycle.ReconnectCount);
+        Assert.Empty(exitCodes);
+    }
+
+    [Fact]
+    public async Task RepeatedDisconnects_StartOnlyOneRecoveryMonitor()
+    {
+        var state = new FakeHealthState();
+        var lifecycle = new FakeLifecycle();
+        var delay = new ControlledDelay();
+        var exitCodes = new List<int>();
+        await using var recovery = CreateService(state, lifecycle, delay, exitCodes);
+
+        Assert.True(recovery.StartMonitoring());
+        Assert.False(recovery.StartMonitoring());
+        Assert.False(recovery.StartMonitoring());
+
+        await delay.WaitForRequestCountAsync(1);
+        Assert.Equal(1, delay.RequestCount);
+        Assert.Equal(0, lifecycle.ReconnectCount);
+    }
+
+    [Fact]
+    public async Task ReadyAfterManualReconnect_CancelsFailureEscalation()
+    {
+        var state = new FakeHealthState();
+        var lifecycle = new FakeLifecycle();
+        var delay = new ControlledDelay();
+        var exitCodes = new List<int>();
+        await using var recovery = CreateService(state, lifecycle, delay, exitCodes);
+
+        recovery.StartMonitoring();
+        await delay.WaitForRequestCountAsync(1);
+        delay.CompleteNext();
+        await lifecycle.ReconnectCalled.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await delay.WaitForRequestCountAsync(1);
+
+        state.MarkHealthy();
+        recovery.NotifyReady();
+        await recovery.WaitForIdleAsync();
+
+        Assert.Equal(1, lifecycle.ReconnectCount);
+        Assert.Empty(exitCodes);
+    }
+
+    [Fact]
+    public async Task FailedRecovery_RequestsProcessRestart()
+    {
+        var state = new FakeHealthState();
+        var lifecycle = new FakeLifecycle();
+        var delay = new ControlledDelay();
+        var exitCodes = new List<int>();
+        await using var recovery = CreateService(state, lifecycle, delay, exitCodes);
+
+        recovery.StartMonitoring();
+        await delay.WaitForRequestCountAsync(1);
+        delay.CompleteNext();
+        await lifecycle.ReconnectCalled.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await delay.WaitForRequestCountAsync(1);
+        delay.CompleteNext();
+        await recovery.WaitForIdleAsync();
+
+        Assert.Equal(1, lifecycle.ReconnectCount);
+        Assert.Equal(new[] { 1 }, exitCodes);
+    }
+
+    [Fact]
+    public async Task ApplicationShutdown_DoesNotRequestProcessRestart()
+    {
+        var state = new FakeHealthState();
+        var lifecycle = new FakeLifecycle();
+        var delay = new ControlledDelay();
+        var exitCodes = new List<int>();
+        var recovery = CreateService(state, lifecycle, delay, exitCodes);
+
+        recovery.StartMonitoring();
+        await delay.WaitForRequestCountAsync(1);
+        await recovery.DisposeAsync();
+
+        Assert.Equal(0, lifecycle.ReconnectCount);
+        Assert.Empty(exitCodes);
+    }
+
+    private static DiscordGatewayRecoveryService CreateService(
+        FakeHealthState state,
+        FakeLifecycle lifecycle,
+        ControlledDelay delay,
+        List<int> exitCodes)
+        => new(
+            state.CreateSnapshot,
+            lifecycle,
+            TestOptions,
+            delay,
+            exitCodes.Add);
+
+    private sealed class FakeHealthState
+    {
+        private bool _healthy;
+        private readonly DateTimeOffset _unhealthySince = DateTimeOffset.UtcNow;
+
+        public void MarkHealthy() => _healthy = true;
+
+        public DiscordHealthSnapshot CreateSnapshot()
+            => new(
+                _healthy,
+                _healthy ? "Connected" : "Disconnected",
+                "LoggedIn",
+                _healthy ? "Connected" : "Disconnected",
+                _healthy ? DateTimeOffset.UtcNow : null,
+                _healthy ? null : _unhealthySince,
+                _healthy ? null : _unhealthySince,
+                _healthy ? null : "Test disconnect");
+    }
+
+    private sealed class FakeLifecycle : IDiscordGatewayLifecycle
+    {
+        private int _reconnectCount;
+
+        public int ReconnectCount => Volatile.Read(ref _reconnectCount);
+        public TaskCompletionSource<bool> ReconnectCalled { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task ReconnectAsync(CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _reconnectCount);
+            ReconnectCalled.TrySetResult(true);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ControlledDelay : IRecoveryDelay
+    {
+        private readonly ConcurrentQueue<TaskCompletionSource<bool>> _requests = new();
+
+        public int RequestCount => _requests.Count;
+
+        public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+        {
+            var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var registration = cancellationToken.Register(() => completion.TrySetCanceled(cancellationToken));
+            _ = completion.Task.ContinueWith(
+                _ => registration.Dispose(),
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+            _requests.Enqueue(completion);
+            return completion.Task;
+        }
+
+        public void CompleteNext()
+        {
+            Assert.True(_requests.TryDequeue(out var completion));
+            completion.TrySetResult(true);
+        }
+
+        public async Task WaitForRequestCountAsync(int expectedCount)
+        {
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+            while (_requests.Count < expectedCount && DateTime.UtcNow < deadline)
+            {
+                await Task.Yield();
+            }
+
+            Assert.True(_requests.Count >= expectedCount, "The recovery delay was not requested in time.");
+        }
+    }
+}

--- a/BeanBot.Tests/Services/HealthCheckServerTests.cs
+++ b/BeanBot.Tests/Services/HealthCheckServerTests.cs
@@ -140,6 +140,8 @@ public class HealthCheckServerTests
 
         Assert.StartsWith("HTTP/1.1 503 Service Unavailable", response);
         Assert.Contains("\"status\":\"unhealthy\"", response);
+        Assert.Contains("\"mostRecentDisconnectReason\":null", response);
+        Assert.DoesNotContain("\"lastDisconnectReason\"", response);
     }
 
     [Fact]

--- a/BeanBot/Program.cs
+++ b/BeanBot/Program.cs
@@ -23,6 +23,7 @@ namespace BeanBot
     {
         private DiscordSocketClient _discordClient;
         private DiscordConnectionHealth _discordConnectionHealth;
+        private DiscordGatewayRecoveryService _discordGatewayRecovery;
         private CommandService _commandService;
         private CommandHandler _commandHandler;
         private NewMemberHandler _newMemberHandler;
@@ -65,6 +66,7 @@ namespace BeanBot
             _healthCheckServer?.Start();
 
             await LogIntoDiscord();
+            _discordGatewayRecovery.StartMonitoring();
             await InstantiateCommandServices();
             _discordClient.Log += LogHandler.LogMessages;
             _autoPunPoster = new PunHandler(_discordClient, _options);
@@ -105,6 +107,12 @@ namespace BeanBot
                 _commandHandler?.Dispose();
                 _services?.Dispose();
                 _discordClient.Log -= LogHandler.LogMessages;
+
+                if (_discordGatewayRecovery is not null)
+                {
+                    await _discordGatewayRecovery.DisposeAsync();
+                }
+
                 _discordClient.Ready -= OnDiscordReadyAsync;
                 _discordClient.Disconnected -= OnDiscordDisconnectedAsync;
 
@@ -151,6 +159,14 @@ namespace BeanBot
             _ownerErrorNotifier = new DiscordOwnerErrorNotifier(_discordClient);
             LogHandler.CreateLoggerConfiguration(_ownerErrorNotifier);
             _options = BeanBotOptionsLoader.LoadFromEnvironment();
+            var recoveryOptions = DiscordGatewayRecoveryOptions.Default;
+            _discordGatewayRecovery = new DiscordGatewayRecoveryService(
+                () => _discordConnectionHealth.CreateSnapshot(_discordClient),
+                new DiscordGatewayLifecycle(
+                    _discordClient,
+                    _options.BotToken,
+                    recoveryOptions.LifecycleOperationTimeout),
+                recoveryOptions);
 
             Log.Information("Configuring MongoDB client");
             var mongoClient = new MongoClient(_options.MongoConnectionString);
@@ -235,21 +251,37 @@ namespace BeanBot
         private Task OnDiscordReadyAsync()
         {
             _discordConnectionHealth.MarkReady();
-            Log.Information("Bean Bot successfully connected");
+            _discordGatewayRecovery.NotifyReady();
+            Log.Information(
+                "BeanBot Discord gateway reached Ready. LoginState={LoginState}, ConnectionState={ConnectionState}",
+                _discordClient.LoginState,
+                _discordClient.ConnectionState);
             return Task.CompletedTask;
         }
 
         private Task OnDiscordDisconnectedAsync(Exception exception)
         {
             _discordConnectionHealth.MarkDisconnected(exception);
+            var snapshot = _discordConnectionHealth.CreateSnapshot(_discordClient);
             if (exception is null)
             {
-                Log.Warning("Bean Bot disconnected from Discord");
+                Log.Warning(
+                    "BeanBot disconnected from Discord. LoginState={LoginState}, ConnectionState={ConnectionState}, LastDisconnectReason={LastDisconnectReason}",
+                    snapshot.LoginState,
+                    snapshot.ConnectionState,
+                    snapshot.LastDisconnectReason);
             }
             else
             {
-                Log.Warning(exception, "Bean Bot disconnected from Discord");
+                Log.Warning(
+                    exception,
+                    "BeanBot disconnected from Discord. LoginState={LoginState}, ConnectionState={ConnectionState}, LastDisconnectReason={LastDisconnectReason}",
+                    snapshot.LoginState,
+                    snapshot.ConnectionState,
+                    snapshot.LastDisconnectReason);
             }
+
+            _discordGatewayRecovery.StartMonitoring();
 
             return Task.CompletedTask;
         }

--- a/BeanBot/Program.cs
+++ b/BeanBot/Program.cs
@@ -266,19 +266,19 @@ namespace BeanBot
             if (exception is null)
             {
                 Log.Warning(
-                    "BeanBot disconnected from Discord. LoginState={LoginState}, ConnectionState={ConnectionState}, LastDisconnectReason={LastDisconnectReason}",
+                    "BeanBot disconnected from Discord. LoginState={LoginState}, ConnectionState={ConnectionState}, MostRecentDisconnectReason={MostRecentDisconnectReason}",
                     snapshot.LoginState,
                     snapshot.ConnectionState,
-                    snapshot.LastDisconnectReason);
+                    snapshot.MostRecentDisconnectReason);
             }
             else
             {
                 Log.Warning(
                     exception,
-                    "BeanBot disconnected from Discord. LoginState={LoginState}, ConnectionState={ConnectionState}, LastDisconnectReason={LastDisconnectReason}",
+                    "BeanBot disconnected from Discord. LoginState={LoginState}, ConnectionState={ConnectionState}, MostRecentDisconnectReason={MostRecentDisconnectReason}",
                     snapshot.LoginState,
                     snapshot.ConnectionState,
-                    snapshot.LastDisconnectReason);
+                    snapshot.MostRecentDisconnectReason);
             }
 
             _discordGatewayRecovery.StartMonitoring();

--- a/BeanBot/Services/DiscordConnectionHealth.cs
+++ b/BeanBot/Services/DiscordConnectionHealth.cs
@@ -11,6 +11,7 @@ namespace BeanBot.Services
         private bool _gatewayReady;
         private DateTimeOffset? _lastReadyAtUtc;
         private DateTimeOffset? _lastDisconnectedAtUtc;
+        private DateTimeOffset? _unhealthySinceAtUtc;
         private string _lastDisconnectReason;
 
         public void MarkReady()
@@ -19,7 +20,7 @@ namespace BeanBot.Services
             {
                 _gatewayReady = true;
                 _lastReadyAtUtc = DateTimeOffset.UtcNow;
-                _lastDisconnectReason = null;
+                _unhealthySinceAtUtc = null;
             }
         }
 
@@ -27,8 +28,10 @@ namespace BeanBot.Services
         {
             lock (_syncRoot)
             {
+                var disconnectedAtUtc = DateTimeOffset.UtcNow;
                 _gatewayReady = false;
-                _lastDisconnectedAtUtc = DateTimeOffset.UtcNow;
+                _lastDisconnectedAtUtc = disconnectedAtUtc;
+                _unhealthySinceAtUtc ??= disconnectedAtUtc;
                 _lastDisconnectReason = exception?.Message ?? "Discord gateway disconnected.";
             }
         }
@@ -50,6 +53,7 @@ namespace BeanBot.Services
                     connectionState.ToString(),
                     _lastReadyAtUtc,
                     _lastDisconnectedAtUtc,
+                    _unhealthySinceAtUtc,
                     _lastDisconnectReason);
             }
         }
@@ -89,6 +93,7 @@ namespace BeanBot.Services
             string connectionState,
             DateTimeOffset? lastReadyAtUtc,
             DateTimeOffset? lastDisconnectedAtUtc,
+            DateTimeOffset? unhealthySinceAtUtc,
             string lastDisconnectReason)
         {
             IsHealthy = isHealthy;
@@ -97,6 +102,7 @@ namespace BeanBot.Services
             ConnectionState = connectionState;
             LastReadyAtUtc = lastReadyAtUtc;
             LastDisconnectedAtUtc = lastDisconnectedAtUtc;
+            UnhealthySinceAtUtc = unhealthySinceAtUtc;
             LastDisconnectReason = lastDisconnectReason;
         }
 
@@ -106,6 +112,7 @@ namespace BeanBot.Services
         public string ConnectionState { get; }
         public DateTimeOffset? LastReadyAtUtc { get; }
         public DateTimeOffset? LastDisconnectedAtUtc { get; }
+        public DateTimeOffset? UnhealthySinceAtUtc { get; }
         public string LastDisconnectReason { get; }
     }
 }

--- a/BeanBot/Services/DiscordConnectionHealth.cs
+++ b/BeanBot/Services/DiscordConnectionHealth.cs
@@ -12,7 +12,7 @@ namespace BeanBot.Services
         private DateTimeOffset? _lastReadyAtUtc;
         private DateTimeOffset? _lastDisconnectedAtUtc;
         private DateTimeOffset? _unhealthySinceAtUtc;
-        private string _lastDisconnectReason;
+        private string _mostRecentDisconnectReason;
 
         public void MarkReady()
         {
@@ -32,7 +32,7 @@ namespace BeanBot.Services
                 _gatewayReady = false;
                 _lastDisconnectedAtUtc = disconnectedAtUtc;
                 _unhealthySinceAtUtc ??= disconnectedAtUtc;
-                _lastDisconnectReason = exception?.Message ?? "Discord gateway disconnected.";
+                _mostRecentDisconnectReason = exception?.Message ?? "Discord gateway disconnected.";
             }
         }
 
@@ -54,7 +54,7 @@ namespace BeanBot.Services
                     _lastReadyAtUtc,
                     _lastDisconnectedAtUtc,
                     _unhealthySinceAtUtc,
-                    _lastDisconnectReason);
+                    _mostRecentDisconnectReason);
             }
         }
 
@@ -65,9 +65,9 @@ namespace BeanBot.Services
                 return "BeanBot is connected to Discord.";
             }
 
-            if (_lastDisconnectReason is not null)
+            if (_mostRecentDisconnectReason is not null)
             {
-                return $"{_lastDisconnectReason} Current state: login={loginState}, connection={connectionState}.";
+                return $"{_mostRecentDisconnectReason} Current state: login={loginState}, connection={connectionState}.";
             }
 
             if (!_gatewayReady)
@@ -94,7 +94,7 @@ namespace BeanBot.Services
             DateTimeOffset? lastReadyAtUtc,
             DateTimeOffset? lastDisconnectedAtUtc,
             DateTimeOffset? unhealthySinceAtUtc,
-            string lastDisconnectReason)
+            string mostRecentDisconnectReason)
         {
             IsHealthy = isHealthy;
             StatusMessage = statusMessage;
@@ -103,7 +103,7 @@ namespace BeanBot.Services
             LastReadyAtUtc = lastReadyAtUtc;
             LastDisconnectedAtUtc = lastDisconnectedAtUtc;
             UnhealthySinceAtUtc = unhealthySinceAtUtc;
-            LastDisconnectReason = lastDisconnectReason;
+            MostRecentDisconnectReason = mostRecentDisconnectReason;
         }
 
         public bool IsHealthy { get; }
@@ -113,6 +113,6 @@ namespace BeanBot.Services
         public DateTimeOffset? LastReadyAtUtc { get; }
         public DateTimeOffset? LastDisconnectedAtUtc { get; }
         public DateTimeOffset? UnhealthySinceAtUtc { get; }
-        public string LastDisconnectReason { get; }
+        public string MostRecentDisconnectReason { get; }
     }
 }

--- a/BeanBot/Services/DiscordGatewayRecoveryService.cs
+++ b/BeanBot/Services/DiscordGatewayRecoveryService.cs
@@ -1,0 +1,389 @@
+using Discord;
+using Discord.WebSocket;
+
+using Serilog;
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BeanBot.Services
+{
+    internal sealed class DiscordGatewayRecoveryOptions
+    {
+        public static DiscordGatewayRecoveryOptions Default { get; } = new(
+            TimeSpan.FromMinutes(5),
+            TimeSpan.FromSeconds(30),
+            TimeSpan.FromMinutes(2));
+
+        public DiscordGatewayRecoveryOptions(
+            TimeSpan builtInRecoveryGracePeriod,
+            TimeSpan lifecycleOperationTimeout,
+            TimeSpan readyTimeout)
+        {
+            BuiltInRecoveryGracePeriod = builtInRecoveryGracePeriod;
+            LifecycleOperationTimeout = lifecycleOperationTimeout;
+            ReadyTimeout = readyTimeout;
+        }
+
+        public TimeSpan BuiltInRecoveryGracePeriod { get; }
+        public TimeSpan LifecycleOperationTimeout { get; }
+        public TimeSpan ReadyTimeout { get; }
+    }
+
+    internal interface IDiscordGatewayLifecycle
+    {
+        Task ReconnectAsync(CancellationToken cancellationToken);
+    }
+
+    internal interface IRecoveryDelay
+    {
+        Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken);
+    }
+
+    internal sealed class TaskRecoveryDelay : IRecoveryDelay
+    {
+        public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+            => Task.Delay(delay, cancellationToken);
+    }
+
+    internal sealed class DiscordGatewayLifecycle : IDiscordGatewayLifecycle
+    {
+        private readonly DiscordSocketClient _client;
+        private readonly string _botToken;
+        private readonly TimeSpan _operationTimeout;
+
+        public DiscordGatewayLifecycle(
+            DiscordSocketClient client,
+            string botToken,
+            TimeSpan operationTimeout)
+        {
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+            _botToken = botToken ?? throw new ArgumentNullException(nameof(botToken));
+            _operationTimeout = operationTimeout;
+        }
+
+        public async Task ReconnectAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await RunBoundedAsync(_client.StopAsync(), "stop");
+            cancellationToken.ThrowIfCancellationRequested();
+            await RunBoundedAsync(_client.LogoutAsync(), "logout");
+            cancellationToken.ThrowIfCancellationRequested();
+            await RunBoundedAsync(
+                _client.LoginAsync(TokenType.Bot, _botToken),
+                "login");
+            cancellationToken.ThrowIfCancellationRequested();
+            await RunBoundedAsync(_client.StartAsync(), "start");
+        }
+
+        private async Task RunBoundedAsync(
+            Task operation,
+            string operationName)
+        {
+            try
+            {
+                // Once a Discord lifecycle operation starts, let it finish (or time out)
+                // instead of abandoning it midway and racing normal shutdown cleanup.
+                await operation.WaitAsync(_operationTimeout);
+            }
+            catch
+            {
+                if (!operation.IsCompleted)
+                {
+                    ObserveLateFailure(operation, operationName);
+                }
+
+                throw;
+            }
+        }
+
+        private static void ObserveLateFailure(Task operation, string operationName)
+        {
+            _ = operation.ContinueWith(
+                completedTask => Log.Error(
+                    completedTask.Exception,
+                    "Discord gateway {Operation} operation failed after its recovery wait ended",
+                    operationName),
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
+    }
+
+    internal sealed class DiscordGatewayRecoveryService : IAsyncDisposable
+    {
+        private readonly object _syncRoot = new();
+        private readonly Func<DiscordHealthSnapshot> _createHealthSnapshot;
+        private readonly IDiscordGatewayLifecycle _lifecycle;
+        private readonly DiscordGatewayRecoveryOptions _options;
+        private readonly IRecoveryDelay _delay;
+        private readonly Action<int> _exitProcess;
+        private readonly CancellationTokenSource _shutdown = new();
+        private TaskCompletionSource<bool> _readySignal;
+        private Task _monitorTask;
+        private bool _disposed;
+
+        public DiscordGatewayRecoveryService(
+            Func<DiscordHealthSnapshot> createHealthSnapshot,
+            IDiscordGatewayLifecycle lifecycle,
+            DiscordGatewayRecoveryOptions options = null,
+            IRecoveryDelay delay = null,
+            Action<int> exitProcess = null)
+        {
+            _createHealthSnapshot = createHealthSnapshot ?? throw new ArgumentNullException(nameof(createHealthSnapshot));
+            _lifecycle = lifecycle ?? throw new ArgumentNullException(nameof(lifecycle));
+            _options = options ?? DiscordGatewayRecoveryOptions.Default;
+            _delay = delay ?? new TaskRecoveryDelay();
+            _exitProcess = exitProcess ?? Environment.Exit;
+        }
+
+        public bool StartMonitoring()
+        {
+            lock (_syncRoot)
+            {
+                if (_disposed || _shutdown.IsCancellationRequested || (_monitorTask?.IsCompleted == false))
+                {
+                    return false;
+                }
+
+                var snapshot = _createHealthSnapshot();
+                if (snapshot.IsHealthy)
+                {
+                    return false;
+                }
+
+                _readySignal = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                _monitorTask = MonitorAsync(snapshot);
+                return true;
+            }
+        }
+
+        public void NotifyReady()
+        {
+            lock (_syncRoot)
+            {
+                _readySignal?.TrySetResult(true);
+            }
+        }
+
+        internal Task WaitForIdleAsync()
+        {
+            lock (_syncRoot)
+            {
+                return _monitorTask ?? Task.CompletedTask;
+            }
+        }
+
+        private async Task MonitorAsync(DiscordHealthSnapshot initialSnapshot)
+        {
+            var unhealthySince = initialSnapshot.UnhealthySinceAtUtc ?? DateTimeOffset.UtcNow;
+            Log.Warning(
+                "Discord gateway recovery grace period started. LoginState={LoginState}, ConnectionState={ConnectionState}, GracePeriod={GracePeriod}, LastDisconnectReason={LastDisconnectReason}",
+                initialSnapshot.LoginState,
+                initialSnapshot.ConnectionState,
+                _options.BuiltInRecoveryGracePeriod,
+                initialSnapshot.LastDisconnectReason);
+
+            try
+            {
+                if (await WaitForReadyAsync(
+                    _options.BuiltInRecoveryGracePeriod,
+                    _shutdown.Token))
+                {
+                    LogNaturalRecovery(unhealthySince);
+                    return;
+                }
+
+                if (_shutdown.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                var snapshot = _createHealthSnapshot();
+                if (snapshot.IsHealthy)
+                {
+                    LogNaturalRecovery(unhealthySince);
+                    return;
+                }
+
+                Log.Warning(
+                    "Discord gateway remained unhealthy for {UnhealthyDuration}; beginning one manual reconnect cycle. LoginState={LoginState}, ConnectionState={ConnectionState}, LastDisconnectReason={LastDisconnectReason}",
+                    DateTimeOffset.UtcNow - unhealthySince,
+                    snapshot.LoginState,
+                    snapshot.ConnectionState,
+                    snapshot.LastDisconnectReason);
+
+                try
+                {
+                    await _lifecycle.ReconnectAsync(_shutdown.Token);
+                }
+                catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
+                {
+                    return;
+                }
+                catch (Exception exception)
+                {
+                    snapshot = _createHealthSnapshot();
+                    Log.Error(
+                        exception,
+                        "Discord manual reconnect cycle failed. LoginState={LoginState}, ConnectionState={ConnectionState}, LastDisconnectReason={LastDisconnectReason}",
+                        snapshot.LoginState,
+                        snapshot.ConnectionState,
+                        snapshot.LastDisconnectReason);
+                }
+
+                if (await WaitForReadyAsync(
+                    _options.ReadyTimeout,
+                    _shutdown.Token))
+                {
+                    snapshot = _createHealthSnapshot();
+                    Log.Information(
+                        "Discord manual reconnect succeeded after {UnhealthyDuration}. LoginState={LoginState}, ConnectionState={ConnectionState}",
+                        DateTimeOffset.UtcNow - unhealthySince,
+                        snapshot.LoginState,
+                        snapshot.ConnectionState);
+                    return;
+                }
+
+                if (_shutdown.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                snapshot = _createHealthSnapshot();
+                if (snapshot.IsHealthy)
+                {
+                    Log.Information(
+                        "Discord manual reconnect succeeded after {UnhealthyDuration}. LoginState={LoginState}, ConnectionState={ConnectionState}",
+                        DateTimeOffset.UtcNow - unhealthySince,
+                        snapshot.LoginState,
+                        snapshot.ConnectionState);
+                    return;
+                }
+
+                Log.Error(
+                    "Discord manual reconnect failed to reach Ready after {UnhealthyDuration}. LoginState={LoginState}, ConnectionState={ConnectionState}, LastDisconnectReason={LastDisconnectReason}",
+                    DateTimeOffset.UtcNow - unhealthySince,
+                    snapshot.LoginState,
+                    snapshot.ConnectionState,
+                    snapshot.LastDisconnectReason);
+
+                if (_shutdown.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                Log.Fatal(
+                    "Discord gateway recovery was exhausted; exiting with code 1 so Docker can restart BeanBot");
+                _exitProcess(1);
+            }
+            catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
+            {
+            }
+            catch (Exception exception)
+            {
+                Log.Fatal(exception, "Discord gateway recovery monitor failed unexpectedly");
+                if (!_shutdown.IsCancellationRequested)
+                {
+                    Log.Fatal(
+                        "Exiting with code 1 because the Discord gateway recovery monitor cannot continue safely");
+                    _exitProcess(1);
+                }
+            }
+        }
+
+        private async Task<bool> WaitForReadyAsync(
+            TimeSpan timeout,
+            CancellationToken cancellationToken)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            while (true)
+            {
+                if (_createHealthSnapshot().IsHealthy)
+                {
+                    return true;
+                }
+
+                TaskCompletionSource<bool> readySignal;
+                lock (_syncRoot)
+                {
+                    readySignal = _readySignal;
+                }
+
+                var remaining = timeout - stopwatch.Elapsed;
+                if (remaining <= TimeSpan.Zero)
+                {
+                    return false;
+                }
+
+                using var delayCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                var timeoutTask = _delay.DelayAsync(remaining, delayCancellation.Token);
+                var completedTask = await Task.WhenAny(readySignal.Task, timeoutTask);
+                delayCancellation.Cancel();
+
+                try
+                {
+                    await completedTask;
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+
+                if (completedTask == timeoutTask)
+                {
+                    return _createHealthSnapshot().IsHealthy;
+                }
+
+                if (_createHealthSnapshot().IsHealthy)
+                {
+                    return true;
+                }
+
+                lock (_syncRoot)
+                {
+                    if (ReferenceEquals(_readySignal, readySignal))
+                    {
+                        _readySignal = new TaskCompletionSource<bool>(
+                            TaskCreationOptions.RunContinuationsAsynchronously);
+                    }
+                }
+            }
+        }
+
+        private void LogNaturalRecovery(DateTimeOffset unhealthySince)
+        {
+            var snapshot = _createHealthSnapshot();
+            Log.Information(
+                "Discord gateway recovered naturally after {UnhealthyDuration}; manual reconnect was not needed. LoginState={LoginState}, ConnectionState={ConnectionState}",
+                DateTimeOffset.UtcNow - unhealthySince,
+                snapshot.LoginState,
+                snapshot.ConnectionState);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Task monitorTask;
+            lock (_syncRoot)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                _shutdown.Cancel();
+                monitorTask = _monitorTask;
+            }
+
+            if (monitorTask is not null)
+            {
+                await monitorTask;
+            }
+
+            _shutdown.Dispose();
+        }
+    }
+}

--- a/BeanBot/Services/DiscordGatewayRecoveryService.cs
+++ b/BeanBot/Services/DiscordGatewayRecoveryService.cs
@@ -180,11 +180,11 @@ namespace BeanBot.Services
         {
             var unhealthySince = initialSnapshot.UnhealthySinceAtUtc ?? DateTimeOffset.UtcNow;
             Log.Warning(
-                "Discord gateway recovery grace period started. LoginState={LoginState}, ConnectionState={ConnectionState}, GracePeriod={GracePeriod}, LastDisconnectReason={LastDisconnectReason}",
+                "Discord gateway recovery grace period started. LoginState={LoginState}, ConnectionState={ConnectionState}, GracePeriod={GracePeriod}, MostRecentDisconnectReason={MostRecentDisconnectReason}",
                 initialSnapshot.LoginState,
                 initialSnapshot.ConnectionState,
                 _options.BuiltInRecoveryGracePeriod,
-                initialSnapshot.LastDisconnectReason);
+                initialSnapshot.MostRecentDisconnectReason);
 
             try
             {
@@ -209,11 +209,11 @@ namespace BeanBot.Services
                 }
 
                 Log.Warning(
-                    "Discord gateway remained unhealthy for {UnhealthyDuration}; beginning one manual reconnect cycle. LoginState={LoginState}, ConnectionState={ConnectionState}, LastDisconnectReason={LastDisconnectReason}",
+                    "Discord gateway remained unhealthy for {UnhealthyDuration}; beginning one manual reconnect cycle. LoginState={LoginState}, ConnectionState={ConnectionState}, MostRecentDisconnectReason={MostRecentDisconnectReason}",
                     DateTimeOffset.UtcNow - unhealthySince,
                     snapshot.LoginState,
                     snapshot.ConnectionState,
-                    snapshot.LastDisconnectReason);
+                    snapshot.MostRecentDisconnectReason);
 
                 try
                 {
@@ -228,10 +228,10 @@ namespace BeanBot.Services
                     snapshot = _createHealthSnapshot();
                     Log.Error(
                         exception,
-                        "Discord manual reconnect cycle failed. LoginState={LoginState}, ConnectionState={ConnectionState}, LastDisconnectReason={LastDisconnectReason}",
+                        "Discord manual reconnect cycle failed. LoginState={LoginState}, ConnectionState={ConnectionState}, MostRecentDisconnectReason={MostRecentDisconnectReason}",
                         snapshot.LoginState,
                         snapshot.ConnectionState,
-                        snapshot.LastDisconnectReason);
+                        snapshot.MostRecentDisconnectReason);
                 }
 
                 if (await WaitForReadyAsync(
@@ -264,11 +264,11 @@ namespace BeanBot.Services
                 }
 
                 Log.Error(
-                    "Discord manual reconnect failed to reach Ready after {UnhealthyDuration}. LoginState={LoginState}, ConnectionState={ConnectionState}, LastDisconnectReason={LastDisconnectReason}",
+                    "Discord manual reconnect failed to reach Ready after {UnhealthyDuration}. LoginState={LoginState}, ConnectionState={ConnectionState}, MostRecentDisconnectReason={MostRecentDisconnectReason}",
                     DateTimeOffset.UtcNow - unhealthySince,
                     snapshot.LoginState,
                     snapshot.ConnectionState,
-                    snapshot.LastDisconnectReason);
+                    snapshot.MostRecentDisconnectReason);
 
                 if (_shutdown.IsCancellationRequested)
                 {

--- a/BeanBot/Services/HealthCheckServer.cs
+++ b/BeanBot/Services/HealthCheckServer.cs
@@ -396,6 +396,7 @@ namespace BeanBot.Services
                             connectionState = healthSnapshot.ConnectionState,
                             lastReadyAtUtc = healthSnapshot.LastReadyAtUtc,
                             lastDisconnectedAtUtc = healthSnapshot.LastDisconnectedAtUtc,
+                            unhealthySinceAtUtc = healthSnapshot.UnhealthySinceAtUtc,
                             lastDisconnectReason = healthSnapshot.LastDisconnectReason
                         },
                         isHeadRequest,

--- a/BeanBot/Services/HealthCheckServer.cs
+++ b/BeanBot/Services/HealthCheckServer.cs
@@ -397,7 +397,7 @@ namespace BeanBot.Services
                             lastReadyAtUtc = healthSnapshot.LastReadyAtUtc,
                             lastDisconnectedAtUtc = healthSnapshot.LastDisconnectedAtUtc,
                             unhealthySinceAtUtc = healthSnapshot.UnhealthySinceAtUtc,
-                            lastDisconnectReason = healthSnapshot.LastDisconnectReason
+                            mostRecentDisconnectReason = healthSnapshot.MostRecentDisconnectReason
                         },
                         isHeadRequest,
                         requestToken);


### PR DESCRIPTION
## Summary

- add a centralized, race-safe Discord gateway recovery monitor that reuses `DiscordConnectionHealth`
- allow Discord.Net five minutes to recover naturally before performing one deliberate stop/logout/login/start cycle
- bound each lifecycle operation to 30 seconds and wait up to two additional minutes for the real `Ready` event
- exit with code 1 only after recovery is exhausted so Docker's existing `restart: unless-stopped` policy can restart BeanBot
- preserve independent REST-based services such as the daily pun scheduler
- expose the continuous unhealthy duration through the existing `/healthz` payload

## Failure mode

During the August 3, 2026 DNS/network outage, Discord.Net remained logged in while its gateway connection stayed disconnected. The process and REST scheduler were still alive, so Docker's restart policy had no process exit to react to even though `/healthz` correctly returned HTTP 503.

This change gives Discord.Net a generous grace period for ordinary transient reconnects, serializes recovery so repeated disconnect events cannot start competing attempts, and cancels escalation when the gateway reaches the actual `Ready` state. If one explicit reconnect cycle still does not restore `Ready`, BeanBot logs the final state and intentionally terminates with a non-zero exit code.

Normal shutdown cancels and awaits the recovery monitor, and the exit path is guarded so intentional shutdown cannot trigger a restart decision.

## Docker healthcheck

No Docker `HEALTHCHECK` was added. The current `mcr.microsoft.com/dotnet/runtime:8.0` image does not include an HTTP client, and adding curl solely for this probe would add package and image overhead. More importantly, Docker does not restart an unhealthy container under `restart: unless-stopped`; the bounded application-level exit is what closes the production recovery gap. The existing `/healthz` endpoint remains available to external health monitoring.

## Tests

Added deterministic state-machine tests covering:

- natural recovery before escalation
- suppression of concurrent recovery monitors
- `Ready` after manual reconnect canceling failure escalation
- failed recovery requesting exit code 1
- normal shutdown suppressing failure escalation

Validation:

- `dotnet build BeanBot.sln -c Release` — succeeded with 0 warnings and 0 errors
- `dotnet test BeanBot.sln -c Release` — 228 passed, 0 failed, 0 skipped

## Limitations

The manual recovery policy intentionally performs only one reconnect cycle. Persistent Discord, DNS, credential, or host-network failures will still cause the container to restart and rely on the deployment's restart backoff/operational monitoring.