### PR TITLE
Persist Discord outage recovery notifications

### DIFF
--- a/BeanBot.Tests/Services/DiscordGatewayRecoveryServiceTests.cs
+++ b/BeanBot.Tests/Services/DiscordGatewayRecoveryServiceTests.cs
@@ -20,7 +20,8 @@ public class DiscordGatewayRecoveryServiceTests
         var lifecycle = new FakeLifecycle();
         var delay = new ControlledDelay();
         var exitCodes = new List<int>();
-        await using var recovery = CreateService(state, lifecycle, delay, exitCodes);
+        var outageStore = new FakeOutageStore();
+        await using var recovery = CreateService(state, lifecycle, delay, exitCodes, outageStore);
 
         Assert.True(recovery.StartMonitoring());
         await delay.WaitForRequestCountAsync(1);
@@ -31,6 +32,7 @@ public class DiscordGatewayRecoveryServiceTests
 
         Assert.Equal(0, lifecycle.ReconnectCount);
         Assert.Empty(exitCodes);
+        Assert.Null(outageStore.CurrentOutage);
     }
 
     [Fact]
@@ -40,7 +42,8 @@ public class DiscordGatewayRecoveryServiceTests
         var lifecycle = new FakeLifecycle();
         var delay = new ControlledDelay();
         var exitCodes = new List<int>();
-        await using var recovery = CreateService(state, lifecycle, delay, exitCodes);
+        var outageStore = new FakeOutageStore();
+        await using var recovery = CreateService(state, lifecycle, delay, exitCodes, outageStore);
 
         Assert.True(recovery.StartMonitoring());
         Assert.False(recovery.StartMonitoring());
@@ -58,7 +61,8 @@ public class DiscordGatewayRecoveryServiceTests
         var lifecycle = new FakeLifecycle();
         var delay = new ControlledDelay();
         var exitCodes = new List<int>();
-        await using var recovery = CreateService(state, lifecycle, delay, exitCodes);
+        var outageStore = new FakeOutageStore();
+        await using var recovery = CreateService(state, lifecycle, delay, exitCodes, outageStore);
 
         recovery.StartMonitoring();
         await delay.WaitForRequestCountAsync(1);
@@ -72,6 +76,8 @@ public class DiscordGatewayRecoveryServiceTests
 
         Assert.Equal(1, lifecycle.ReconnectCount);
         Assert.Empty(exitCodes);
+        Assert.True(outageStore.CurrentOutage?.ManualRecoveryAttempted);
+        Assert.False(outageStore.CurrentOutage?.ProcessRestartRequested);
     }
 
     [Fact]
@@ -81,7 +87,8 @@ public class DiscordGatewayRecoveryServiceTests
         var lifecycle = new FakeLifecycle();
         var delay = new ControlledDelay();
         var exitCodes = new List<int>();
-        await using var recovery = CreateService(state, lifecycle, delay, exitCodes);
+        var outageStore = new FakeOutageStore();
+        await using var recovery = CreateService(state, lifecycle, delay, exitCodes, outageStore);
 
         recovery.StartMonitoring();
         await delay.WaitForRequestCountAsync(1);
@@ -93,6 +100,9 @@ public class DiscordGatewayRecoveryServiceTests
 
         Assert.Equal(1, lifecycle.ReconnectCount);
         Assert.Equal(new[] { 1 }, exitCodes);
+        Assert.True(outageStore.CurrentOutage?.ManualRecoveryAttempted);
+        Assert.True(outageStore.CurrentOutage?.ProcessRestartRequested);
+        Assert.Equal(new[] { "manual", "restart", "exit" }, outageStore.StateTransitions);
     }
 
     [Fact]
@@ -102,7 +112,8 @@ public class DiscordGatewayRecoveryServiceTests
         var lifecycle = new FakeLifecycle();
         var delay = new ControlledDelay();
         var exitCodes = new List<int>();
-        var recovery = CreateService(state, lifecycle, delay, exitCodes);
+        var outageStore = new FakeOutageStore();
+        var recovery = CreateService(state, lifecycle, delay, exitCodes, outageStore);
 
         recovery.StartMonitoring();
         await delay.WaitForRequestCountAsync(1);
@@ -110,19 +121,83 @@ public class DiscordGatewayRecoveryServiceTests
 
         Assert.Equal(0, lifecycle.ReconnectCount);
         Assert.Empty(exitCodes);
+        Assert.Null(outageStore.CurrentOutage);
     }
 
     private static DiscordGatewayRecoveryService CreateService(
         FakeHealthState state,
         FakeLifecycle lifecycle,
         ControlledDelay delay,
-        List<int> exitCodes)
+        List<int> exitCodes,
+        FakeOutageStore outageStore)
         => new(
             state.CreateSnapshot,
             lifecycle,
+            outageStore,
             TestOptions,
             delay,
-            exitCodes.Add);
+            exitCode =>
+            {
+                outageStore.StateTransitions.Add("exit");
+                exitCodes.Add(exitCode);
+            });
+
+    private sealed class FakeOutageStore : IDiscordOutageStore
+    {
+        public DiscordOutage? CurrentOutage { get; private set; }
+        public List<string> StateTransitions { get; } = new();
+
+        public Task<DiscordOutage?> ReadAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(CurrentOutage);
+
+        public Task OpenAsync(
+            DateTimeOffset disconnectedAtUtc,
+            string mostRecentDisconnectReason,
+            CancellationToken cancellationToken = default)
+        {
+            CurrentOutage ??= CreateOutage(disconnectedAtUtc, mostRecentDisconnectReason);
+            return Task.CompletedTask;
+        }
+
+        public Task MarkManualRecoveryAttemptedAsync(
+            DateTimeOffset disconnectedAtUtc,
+            string mostRecentDisconnectReason,
+            CancellationToken cancellationToken = default)
+        {
+            CurrentOutage ??= CreateOutage(disconnectedAtUtc, mostRecentDisconnectReason);
+            CurrentOutage.MostRecentDisconnectReason = mostRecentDisconnectReason;
+            CurrentOutage.ManualRecoveryAttempted = true;
+            StateTransitions.Add("manual");
+            return Task.CompletedTask;
+        }
+
+        public Task MarkProcessRestartRequestedAsync(
+            DateTimeOffset disconnectedAtUtc,
+            string mostRecentDisconnectReason,
+            CancellationToken cancellationToken = default)
+        {
+            Assert.NotNull(CurrentOutage);
+            CurrentOutage.MostRecentDisconnectReason = mostRecentDisconnectReason;
+            CurrentOutage.ProcessRestartRequested = true;
+            StateTransitions.Add("restart");
+            return Task.CompletedTask;
+        }
+
+        public Task ClearAsync(CancellationToken cancellationToken = default)
+        {
+            CurrentOutage = null;
+            return Task.CompletedTask;
+        }
+
+        private static DiscordOutage CreateOutage(
+            DateTimeOffset disconnectedAtUtc,
+            string mostRecentDisconnectReason)
+            => new()
+            {
+                DisconnectedAtUtc = disconnectedAtUtc,
+                MostRecentDisconnectReason = mostRecentDisconnectReason
+            };
+    }
 
     private sealed class FakeHealthState
     {

--- a/BeanBot.Tests/Services/DiscordOutageRecoveryNotifierTests.cs
+++ b/BeanBot.Tests/Services/DiscordOutageRecoveryNotifierTests.cs
@@ -1,0 +1,146 @@
+using BeanBot.Services;
+using BeanBot.Util;
+
+using Xunit;
+
+namespace BeanBot.Tests.Services;
+
+public class DiscordOutageRecoveryNotifierTests
+{
+    [Fact]
+    public async Task NoPersistedOutage_DoesNotDeliverNotification()
+    {
+        var store = new InMemoryOutageStore();
+        var delivery = new RecordingDelivery();
+        using var notifier = CreateNotifier(store, delivery);
+
+        await notifier.NotifyIfOutageRecoveredAsync(DateTimeOffset.UtcNow);
+
+        Assert.Empty(delivery.Messages);
+    }
+
+    [Fact]
+    public async Task PersistedOutage_DeliversNotificationAndClearsOutage()
+    {
+        var outage = CreateOutage();
+        var store = new InMemoryOutageStore(outage);
+        var delivery = new RecordingDelivery();
+        using var notifier = CreateNotifier(store, delivery);
+
+        await notifier.NotifyIfOutageRecoveredAsync(outage.DisconnectedAtUtc.AddMinutes(8).AddSeconds(13));
+
+        var message = Assert.Single(delivery.Messages);
+        Assert.Contains("BeanBot recovered from a Discord outage", message);
+        Assert.Contains("2026-08-12 07:42:15 UTC", message);
+        Assert.Contains("8m 13s", message);
+        Assert.Contains("Gateway timed out", message);
+        Assert.Null(store.CurrentOutage);
+    }
+
+    [Fact]
+    public async Task FailedDelivery_RetainsPersistedOutage()
+    {
+        var store = new InMemoryOutageStore(CreateOutage());
+        var delivery = new RecordingDelivery(alwaysFail: true);
+        using var notifier = CreateNotifier(store, delivery);
+
+        await notifier.NotifyIfOutageRecoveredAsync(DateTimeOffset.UtcNow);
+
+        Assert.Equal(DiscordOutageRecoveryNotifier.MaximumDeliveryAttempts, delivery.AttemptCount);
+        Assert.NotNull(store.CurrentOutage);
+    }
+
+    [Fact]
+    public async Task RepeatedReadyEvents_DoNotDuplicateDeliveredNotification()
+    {
+        var store = new InMemoryOutageStore(CreateOutage());
+        var delivery = new RecordingDelivery();
+        using var notifier = CreateNotifier(store, delivery);
+
+        await Task.WhenAll(
+            notifier.NotifyIfOutageRecoveredAsync(DateTimeOffset.UtcNow),
+            notifier.NotifyIfOutageRecoveredAsync(DateTimeOffset.UtcNow));
+
+        Assert.Single(delivery.Messages);
+    }
+
+    [Fact]
+    public async Task RestartedProcessOutage_IsClearlyReported()
+    {
+        var outage = CreateOutage();
+        outage.ProcessRestartRequested = true;
+        var store = new InMemoryOutageStore(outage);
+        var delivery = new RecordingDelivery();
+        using var notifier = CreateNotifier(store, delivery);
+
+        await notifier.NotifyIfOutageRecoveredAsync(DateTimeOffset.UtcNow);
+
+        var message = Assert.Single(delivery.Messages);
+        Assert.Contains("Container restart requested: yes", message);
+        Assert.Contains("persisted across a requested process/container restart", message);
+    }
+
+    private static DiscordOutageRecoveryNotifier CreateNotifier(
+        InMemoryOutageStore store,
+        RecordingDelivery delivery)
+        => new(store, delivery, _ => TimeSpan.Zero);
+
+    private static DiscordOutage CreateOutage()
+        => new()
+        {
+            DisconnectedAtUtc = new DateTimeOffset(2026, 8, 12, 7, 42, 15, TimeSpan.Zero),
+            MostRecentDisconnectReason = "Gateway timed out",
+            ManualRecoveryAttempted = true
+        };
+
+    private sealed class InMemoryOutageStore : IDiscordOutageStore
+    {
+        public InMemoryOutageStore(DiscordOutage? outage = null) => CurrentOutage = outage;
+        public DiscordOutage? CurrentOutage { get; private set; }
+
+        public Task<DiscordOutage?> ReadAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(CurrentOutage);
+
+        public Task OpenAsync(DateTimeOffset disconnectedAtUtc, string reason, CancellationToken cancellationToken = default)
+        {
+            CurrentOutage ??= new DiscordOutage
+            {
+                DisconnectedAtUtc = disconnectedAtUtc,
+                MostRecentDisconnectReason = reason
+            };
+            return Task.CompletedTask;
+        }
+
+        public Task MarkManualRecoveryAttemptedAsync(DateTimeOffset disconnectedAtUtc, string reason, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task MarkProcessRestartRequestedAsync(DateTimeOffset disconnectedAtUtc, string reason, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task ClearAsync(CancellationToken cancellationToken = default)
+        {
+            CurrentOutage = null;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingDelivery : IOwnerAlertDelivery
+    {
+        private readonly bool _alwaysFail;
+        public RecordingDelivery(bool alwaysFail = false) => _alwaysFail = alwaysFail;
+        public List<string> Messages { get; } = new();
+        public int AttemptCount { get; private set; }
+
+        public Task DeliverAsync(string alert, CancellationToken cancellationToken)
+        {
+            AttemptCount++;
+            if (_alwaysFail)
+            {
+                throw new InvalidOperationException("Discord REST unavailable");
+            }
+
+            Messages.Add(alert);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/BeanBot.Tests/Services/DiscordOutageStoreTests.cs
+++ b/BeanBot.Tests/Services/DiscordOutageStoreTests.cs
@@ -1,0 +1,117 @@
+using BeanBot.Services;
+
+using Xunit;
+
+namespace BeanBot.Tests.Services;
+
+public sealed class DiscordOutageStoreTests : IDisposable
+{
+    private readonly string _temporaryDirectory = Path.Combine(
+        Path.GetTempPath(),
+        $"beanbot-outage-tests-{Guid.NewGuid():N}");
+
+    public DiscordOutageStoreTests() => Directory.CreateDirectory(_temporaryDirectory);
+
+    [Fact]
+    public async Task OpenAsync_PersistsOutageStartAndReason()
+    {
+        using var store = new DiscordOutageStore(_temporaryDirectory);
+        var disconnectedAtUtc = new DateTimeOffset(2026, 8, 12, 7, 42, 15, TimeSpan.Zero);
+
+        await store.OpenAsync(disconnectedAtUtc, "Gateway timed out");
+        var outage = await store.ReadAsync();
+
+        Assert.NotNull(outage);
+        Assert.Equal(disconnectedAtUtc, outage.DisconnectedAtUtc);
+        Assert.Equal("Gateway timed out", outage.MostRecentDisconnectReason);
+    }
+
+    [Fact]
+    public async Task RepeatedOpenAsync_PreservesOriginalOutageStart()
+    {
+        using var store = new DiscordOutageStore(_temporaryDirectory);
+        var originalDisconnect = new DateTimeOffset(2026, 8, 12, 7, 42, 15, TimeSpan.Zero);
+
+        await store.OpenAsync(originalDisconnect, "First disconnect");
+        await store.OpenAsync(originalDisconnect.AddMinutes(3), "Later disconnect");
+        var outage = await store.ReadAsync();
+
+        Assert.Equal(originalDisconnect, outage!.DisconnectedAtUtc);
+        Assert.Equal("Later disconnect", outage.MostRecentDisconnectReason);
+    }
+
+    [Fact]
+    public async Task MarkManualRecoveryAttemptedAsync_OpensAndUpdatesOutage()
+    {
+        using var store = new DiscordOutageStore(_temporaryDirectory);
+        var disconnectedAtUtc = new DateTimeOffset(2026, 8, 12, 7, 42, 15, TimeSpan.Zero);
+
+        await store.OpenAsync(disconnectedAtUtc, "Initial disconnect");
+        await store.MarkManualRecoveryAttemptedAsync(disconnectedAtUtc.AddMinutes(5), "DNS failure");
+        var outage = await store.ReadAsync();
+
+        Assert.True(outage!.ManualRecoveryAttempted);
+        Assert.False(outage.ProcessRestartRequested);
+        Assert.Equal(disconnectedAtUtc, outage.DisconnectedAtUtc);
+        Assert.Equal("DNS failure", outage.MostRecentDisconnectReason);
+    }
+
+    [Fact]
+    public async Task MarkProcessRestartRequestedAsync_UpdatesExistingOutage()
+    {
+        using var store = new DiscordOutageStore(_temporaryDirectory);
+        await store.MarkManualRecoveryAttemptedAsync(DateTimeOffset.UtcNow, "Initial reason");
+
+        await store.MarkProcessRestartRequestedAsync(DateTimeOffset.UtcNow, "Ready timeout");
+        var outage = await store.ReadAsync();
+
+        Assert.True(outage!.ProcessRestartRequested);
+        Assert.Equal("Ready timeout", outage.MostRecentDisconnectReason);
+    }
+
+    [Fact]
+    public async Task ClearAsync_RemovesPersistedOutage()
+    {
+        using var store = new DiscordOutageStore(_temporaryDirectory);
+        await store.OpenAsync(DateTimeOffset.UtcNow, "Disconnect");
+
+        await store.ClearAsync();
+
+        Assert.Null(await store.ReadAsync());
+        Assert.False(File.Exists(Path.Combine(_temporaryDirectory, DiscordOutageStore.OutageFileName)));
+    }
+
+    [Fact]
+    public async Task ReadAsync_QuarantinesMalformedJsonWithoutThrowing()
+    {
+        var outagePath = Path.Combine(_temporaryDirectory, DiscordOutageStore.OutageFileName);
+        await File.WriteAllTextAsync(outagePath, "{ definitely not valid JSON");
+        using var store = new DiscordOutageStore(_temporaryDirectory);
+
+        var outage = await store.ReadAsync();
+
+        Assert.Null(outage);
+        Assert.False(File.Exists(outagePath));
+        Assert.Single(Directory.GetFiles(_temporaryDirectory, "*.corrupt-*"));
+    }
+
+    [Fact]
+    public async Task WriteAsync_LeavesCompleteFinalFileAndNoTemporaryFile()
+    {
+        using var store = new DiscordOutageStore(_temporaryDirectory);
+
+        await store.OpenAsync(DateTimeOffset.UtcNow, "Disconnect");
+
+        Assert.True(File.Exists(Path.Combine(_temporaryDirectory, DiscordOutageStore.OutageFileName)));
+        Assert.Empty(Directory.GetFiles(_temporaryDirectory, "*.tmp"));
+        Assert.NotNull(await store.ReadAsync());
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_temporaryDirectory))
+        {
+            Directory.Delete(_temporaryDirectory, recursive: true);
+        }
+    }
+}

--- a/BeanBot/Program.cs
+++ b/BeanBot/Program.cs
@@ -13,6 +13,7 @@ using MongoDB.Driver;
 using Serilog;
 
 using System;
+using System.IO;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,6 +25,8 @@ namespace BeanBot
         private DiscordSocketClient _discordClient;
         private DiscordConnectionHealth _discordConnectionHealth;
         private DiscordGatewayRecoveryService _discordGatewayRecovery;
+        private DiscordOutageStore _discordOutageStore;
+        private DiscordOutageRecoveryNotifier _discordOutageRecoveryNotifier;
         private CommandService _commandService;
         private CommandHandler _commandHandler;
         private NewMemberHandler _newMemberHandler;
@@ -139,6 +142,8 @@ namespace BeanBot
 
                 await _ownerErrorNotifier.FlushAsync(TimeSpan.FromSeconds(3));
                 _discordClient.Dispose();
+                _discordOutageRecoveryNotifier?.Dispose();
+                _discordOutageStore?.Dispose();
                 AppDomain.CurrentDomain.UnhandledException -= HandleUnhandledException;
                 TaskScheduler.UnobservedTaskException -= HandleUnobservedTaskException;
             }
@@ -156,8 +161,14 @@ namespace BeanBot
             DirectorySetup.MakeSureAllDirectoriesExist();
             _discordConnectionHealth = new DiscordConnectionHealth();
             CreateNewDiscordSocketClientWithConfigurations();
-            _ownerErrorNotifier = new DiscordOwnerErrorNotifier(_discordClient);
+            var ownerAlertDelivery = new DiscordOwnerAlertDelivery(_discordClient);
+            _ownerErrorNotifier = new DiscordOwnerErrorNotifier(ownerAlertDelivery);
             LogHandler.CreateLoggerConfiguration(_ownerErrorNotifier);
+            _discordOutageStore = new DiscordOutageStore(
+                Path.GetFullPath(DirectorySetup.botBaseDirectory));
+            _discordOutageRecoveryNotifier = new DiscordOutageRecoveryNotifier(
+                _discordOutageStore,
+                ownerAlertDelivery);
             _options = BeanBotOptionsLoader.LoadFromEnvironment();
             var recoveryOptions = DiscordGatewayRecoveryOptions.Default;
             _discordGatewayRecovery = new DiscordGatewayRecoveryService(
@@ -166,6 +177,7 @@ namespace BeanBot
                     _discordClient,
                     _options.BotToken,
                     recoveryOptions.LifecycleOperationTimeout),
+                _discordOutageStore,
                 recoveryOptions);
 
             Log.Information("Configuring MongoDB client");
@@ -248,7 +260,7 @@ namespace BeanBot
             _discordClient.Disconnected += OnDiscordDisconnectedAsync;
         }
 
-        private Task OnDiscordReadyAsync()
+        private async Task OnDiscordReadyAsync()
         {
             _discordConnectionHealth.MarkReady();
             _discordGatewayRecovery.NotifyReady();
@@ -256,7 +268,17 @@ namespace BeanBot
                 "BeanBot Discord gateway reached Ready. LoginState={LoginState}, ConnectionState={ConnectionState}",
                 _discordClient.LoginState,
                 _discordClient.ConnectionState);
-            return Task.CompletedTask;
+            try
+            {
+                await _discordOutageRecoveryNotifier.NotifyIfOutageRecoveredAsync(DateTimeOffset.UtcNow);
+            }
+            catch (Exception exception)
+            {
+                // Ready must remain a successful gateway event even if local persistence is unavailable.
+                Log.Error(
+                    exception,
+                    "Discord reached Ready, but the persisted outage recovery notification could not be processed");
+            }
         }
 
         private Task OnDiscordDisconnectedAsync(Exception exception)

--- a/BeanBot/Services/DiscordGatewayRecoveryService.cs
+++ b/BeanBot/Services/DiscordGatewayRecoveryService.cs
@@ -117,6 +117,7 @@ namespace BeanBot.Services
         private readonly object _syncRoot = new();
         private readonly Func<DiscordHealthSnapshot> _createHealthSnapshot;
         private readonly IDiscordGatewayLifecycle _lifecycle;
+        private readonly IDiscordOutageStore _outageStore;
         private readonly DiscordGatewayRecoveryOptions _options;
         private readonly IRecoveryDelay _delay;
         private readonly Action<int> _exitProcess;
@@ -128,12 +129,14 @@ namespace BeanBot.Services
         public DiscordGatewayRecoveryService(
             Func<DiscordHealthSnapshot> createHealthSnapshot,
             IDiscordGatewayLifecycle lifecycle,
+            IDiscordOutageStore outageStore,
             DiscordGatewayRecoveryOptions options = null,
             IRecoveryDelay delay = null,
             Action<int> exitProcess = null)
         {
             _createHealthSnapshot = createHealthSnapshot ?? throw new ArgumentNullException(nameof(createHealthSnapshot));
             _lifecycle = lifecycle ?? throw new ArgumentNullException(nameof(lifecycle));
+            _outageStore = outageStore ?? throw new ArgumentNullException(nameof(outageStore));
             _options = options ?? DiscordGatewayRecoveryOptions.Default;
             _delay = delay ?? new TaskRecoveryDelay();
             _exitProcess = exitProcess ?? Environment.Exit;
@@ -215,6 +218,8 @@ namespace BeanBot.Services
                     snapshot.ConnectionState,
                     snapshot.MostRecentDisconnectReason);
 
+                await PersistManualRecoveryAttemptAsync(unhealthySince, snapshot);
+
                 try
                 {
                     await _lifecycle.ReconnectAsync(_shutdown.Token);
@@ -277,6 +282,13 @@ namespace BeanBot.Services
 
                 Log.Fatal(
                     "Discord gateway recovery was exhausted; exiting with code 1 so Docker can restart BeanBot");
+                await PersistRestartRequestAsync(unhealthySince, snapshot);
+
+                if (_shutdown.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 _exitProcess(1);
             }
             catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
@@ -289,8 +301,67 @@ namespace BeanBot.Services
                 {
                     Log.Fatal(
                         "Exiting with code 1 because the Discord gateway recovery monitor cannot continue safely");
+                    var snapshot = _createHealthSnapshot();
+                    await PersistRestartRequestAsync(
+                        snapshot.UnhealthySinceAtUtc ?? unhealthySince,
+                        snapshot);
+
+                    if (_shutdown.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
                     _exitProcess(1);
                 }
+            }
+        }
+
+        private async Task PersistManualRecoveryAttemptAsync(
+            DateTimeOffset unhealthySince,
+            DiscordHealthSnapshot snapshot)
+        {
+            try
+            {
+                await _outageStore.MarkManualRecoveryAttemptedAsync(
+                    unhealthySince,
+                    snapshot.MostRecentDisconnectReason,
+                    _shutdown.Token);
+            }
+            catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception exception)
+            {
+                // Recovery must still proceed if the durable incident record cannot be written.
+                Log.Error(
+                    exception,
+                    "Could not persist the meaningful Discord outage before manual recovery. DisconnectedAtUtc={DisconnectedAtUtc}",
+                    unhealthySince);
+            }
+        }
+
+        private async Task PersistRestartRequestAsync(
+            DateTimeOffset unhealthySince,
+            DiscordHealthSnapshot snapshot)
+        {
+            try
+            {
+                await _outageStore.MarkProcessRestartRequestedAsync(
+                    unhealthySince,
+                    snapshot.MostRecentDisconnectReason,
+                    _shutdown.Token);
+            }
+            catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception exception)
+            {
+                // The process must still exit so Docker can restore service even if persistence is unavailable.
+                Log.Error(
+                    exception,
+                    "Could not persist the Discord outage restart request before process exit");
             }
         }
 

--- a/BeanBot/Services/DiscordOutageRecoveryNotifier.cs
+++ b/BeanBot/Services/DiscordOutageRecoveryNotifier.cs
@@ -1,0 +1,162 @@
+using BeanBot.Util;
+
+using Serilog;
+
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BeanBot.Services
+{
+    internal sealed class DiscordOutageRecoveryNotifier : IDisposable
+    {
+        internal const int MaximumDeliveryAttempts = 3;
+        private const int MaximumDiscordMessageLength = 1900;
+        private static readonly TimeSpan DefaultDeliveryTimeout = TimeSpan.FromSeconds(30);
+        private readonly IDiscordOutageStore _outageStore;
+        private readonly IOwnerAlertDelivery _ownerAlertDelivery;
+        private readonly Func<int, TimeSpan> _retryDelay;
+        private readonly TimeSpan _deliveryTimeout;
+        private readonly SemaphoreSlim _notificationAccess = new(1, 1);
+
+        public DiscordOutageRecoveryNotifier(
+            IDiscordOutageStore outageStore,
+            IOwnerAlertDelivery ownerAlertDelivery,
+            Func<int, TimeSpan> retryDelay = null,
+            TimeSpan? deliveryTimeout = null)
+        {
+            _outageStore = outageStore ?? throw new ArgumentNullException(nameof(outageStore));
+            _ownerAlertDelivery = ownerAlertDelivery ?? throw new ArgumentNullException(nameof(ownerAlertDelivery));
+            _retryDelay = retryDelay ?? (attempt => TimeSpan.FromSeconds(attempt));
+            _deliveryTimeout = deliveryTimeout ?? DefaultDeliveryTimeout;
+        }
+
+        public async Task NotifyIfOutageRecoveredAsync(
+            DateTimeOffset recoveredAtUtc,
+            CancellationToken cancellationToken = default)
+        {
+            await _notificationAccess.WaitAsync(cancellationToken);
+            try
+            {
+                var outage = await _outageStore.ReadAsync(cancellationToken);
+                if (outage is null)
+                {
+                    return;
+                }
+
+                Log.Information(
+                    "Attempting Discord outage recovery notification. DisconnectedAtUtc={DisconnectedAtUtc}, ProcessRestartRequested={ProcessRestartRequested}",
+                    outage.DisconnectedAtUtc,
+                    outage.ProcessRestartRequested);
+
+                var recoveryMessage = FormatRecoveryMessage(outage, recoveredAtUtc);
+                if (!await DeliverWithRetryAsync(recoveryMessage, cancellationToken))
+                {
+                    Log.Error(
+                        "Discord outage recovery notification failed after {DeliveryAttempts} attempts; persisted outage retained. DisconnectedAtUtc={DisconnectedAtUtc}",
+                        MaximumDeliveryAttempts,
+                        outage.DisconnectedAtUtc);
+                    return;
+                }
+
+                Log.Information(
+                    "Discord outage recovery notification delivered. DisconnectedAtUtc={DisconnectedAtUtc}",
+                    outage.DisconnectedAtUtc);
+                await _outageStore.ClearAsync(cancellationToken);
+            }
+            finally
+            {
+                _notificationAccess.Release();
+            }
+        }
+
+        internal static string FormatRecoveryMessage(
+            DiscordOutage outage,
+            DateTimeOffset recoveredAtUtc)
+        {
+            var downtime = recoveredAtUtc.ToUniversalTime() - outage.DisconnectedAtUtc.ToUniversalTime();
+            if (downtime < TimeSpan.Zero)
+            {
+                downtime = TimeSpan.Zero;
+            }
+
+            var message = new StringBuilder()
+                .AppendLine("BeanBot recovered from a Discord outage.")
+                .AppendLine()
+                .AppendLine($"Disconnected: {outage.DisconnectedAtUtc.UtcDateTime:yyyy-MM-dd HH:mm:ss} UTC")
+                .AppendLine($"Approximate downtime: {FormatDuration(downtime)}")
+                .AppendLine($"Reason: {outage.MostRecentDisconnectReason}")
+                .AppendLine($"Manual recovery attempted: {FormatBoolean(outage.ManualRecoveryAttempted)}")
+                .Append($"Container restart requested: {FormatBoolean(outage.ProcessRestartRequested)}");
+
+            if (outage.ProcessRestartRequested)
+            {
+                message.AppendLine().Append("This outage persisted across a requested process/container restart.");
+            }
+
+            var recoveryMessage = message.ToString();
+            return recoveryMessage.Length <= MaximumDiscordMessageLength
+                ? recoveryMessage
+                : recoveryMessage.Substring(0, MaximumDiscordMessageLength - 15) + "\n...(truncated)";
+        }
+
+        private async Task<bool> DeliverWithRetryAsync(
+            string recoveryMessage,
+            CancellationToken cancellationToken)
+        {
+            for (var attempt = 1; attempt <= MaximumDeliveryAttempts; attempt++)
+            {
+                try
+                {
+                    await _ownerAlertDelivery
+                        .DeliverAsync(recoveryMessage, cancellationToken)
+                        .WaitAsync(_deliveryTimeout, cancellationToken);
+                    return true;
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception exception)
+                {
+                    Log.Warning(
+                        exception,
+                        "Discord outage recovery notification delivery attempt failed. DeliveryAttempt={DeliveryAttempt}, MaximumDeliveryAttempts={MaximumDeliveryAttempts}",
+                        attempt,
+                        MaximumDeliveryAttempts);
+
+                    if (attempt < MaximumDeliveryAttempts)
+                    {
+                        await Task.Delay(_retryDelay(attempt), cancellationToken);
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static string FormatDuration(TimeSpan duration)
+        {
+            var parts = new StringBuilder();
+            if (duration.Days > 0)
+            {
+                parts.Append($"{duration.Days}d ");
+            }
+            if (duration.Hours > 0 || duration.Days > 0)
+            {
+                parts.Append($"{duration.Hours}h ");
+            }
+            if (duration.Minutes > 0 || duration.Hours > 0 || duration.Days > 0)
+            {
+                parts.Append($"{duration.Minutes}m ");
+            }
+            parts.Append($"{duration.Seconds}s");
+            return parts.ToString();
+        }
+
+        private static string FormatBoolean(bool value) => value ? "yes" : "no";
+
+        public void Dispose() => _notificationAccess.Dispose();
+    }
+}

--- a/BeanBot/Services/DiscordOutageStore.cs
+++ b/BeanBot/Services/DiscordOutageStore.cs
@@ -1,0 +1,270 @@
+using Serilog;
+
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BeanBot.Services
+{
+    internal sealed class DiscordOutage
+    {
+        public DateTimeOffset DisconnectedAtUtc { get; set; }
+        public string MostRecentDisconnectReason { get; set; }
+        public bool ManualRecoveryAttempted { get; set; }
+        public bool ProcessRestartRequested { get; set; }
+    }
+
+    internal interface IDiscordOutageStore
+    {
+        Task<DiscordOutage> ReadAsync(CancellationToken cancellationToken = default);
+        Task OpenAsync(
+            DateTimeOffset disconnectedAtUtc,
+            string mostRecentDisconnectReason,
+            CancellationToken cancellationToken = default);
+        Task MarkManualRecoveryAttemptedAsync(
+            DateTimeOffset disconnectedAtUtc,
+            string mostRecentDisconnectReason,
+            CancellationToken cancellationToken = default);
+        Task MarkProcessRestartRequestedAsync(
+            DateTimeOffset disconnectedAtUtc,
+            string mostRecentDisconnectReason,
+            CancellationToken cancellationToken = default);
+        Task ClearAsync(CancellationToken cancellationToken = default);
+    }
+
+    internal sealed class DiscordOutageStore : IDiscordOutageStore, IDisposable
+    {
+        internal const string OutageFileName = "discord-outage.json";
+        private readonly string _outageFilePath;
+        private readonly SemaphoreSlim _fileAccess = new(1, 1);
+
+        public DiscordOutageStore(string persistentDataDirectory)
+        {
+            if (string.IsNullOrWhiteSpace(persistentDataDirectory))
+            {
+                throw new ArgumentException("A persistent data directory is required.", nameof(persistentDataDirectory));
+            }
+
+            Directory.CreateDirectory(persistentDataDirectory);
+            _outageFilePath = Path.Combine(persistentDataDirectory, OutageFileName);
+        }
+
+        public async Task<DiscordOutage> ReadAsync(CancellationToken cancellationToken = default)
+        {
+            await _fileAccess.WaitAsync(cancellationToken);
+            try
+            {
+                return await ReadWithoutLockAsync(cancellationToken);
+            }
+            finally
+            {
+                _fileAccess.Release();
+            }
+        }
+
+        public async Task OpenAsync(
+            DateTimeOffset disconnectedAtUtc,
+            string mostRecentDisconnectReason,
+            CancellationToken cancellationToken = default)
+        {
+            await UpdateAsync(
+                existingOutage =>
+                {
+                    var outage = existingOutage ?? CreateOutage(disconnectedAtUtc, mostRecentDisconnectReason);
+                    outage.MostRecentDisconnectReason = NormalizeReason(mostRecentDisconnectReason);
+                    return outage;
+                },
+                cancellationToken);
+        }
+
+        public async Task MarkManualRecoveryAttemptedAsync(
+            DateTimeOffset disconnectedAtUtc,
+            string mostRecentDisconnectReason,
+            CancellationToken cancellationToken = default)
+        {
+            await UpdateAsync(
+                existingOutage =>
+                {
+                    var outage = existingOutage ?? CreateOutage(disconnectedAtUtc, mostRecentDisconnectReason);
+                    outage.MostRecentDisconnectReason = NormalizeReason(mostRecentDisconnectReason);
+                    outage.ManualRecoveryAttempted = true;
+                    return outage;
+                },
+                cancellationToken);
+
+            Log.Information(
+                "Discord outage manual recovery attempt persisted. DisconnectedAtUtc={DisconnectedAtUtc}",
+                disconnectedAtUtc);
+        }
+
+        public async Task MarkProcessRestartRequestedAsync(
+            DateTimeOffset disconnectedAtUtc,
+            string mostRecentDisconnectReason,
+            CancellationToken cancellationToken = default)
+        {
+            await UpdateAsync(
+                existingOutage =>
+                {
+                    var outage = existingOutage ?? CreateOutage(disconnectedAtUtc, mostRecentDisconnectReason);
+                    outage.MostRecentDisconnectReason = NormalizeReason(mostRecentDisconnectReason);
+                    outage.ProcessRestartRequested = true;
+                    return outage;
+                },
+                cancellationToken);
+
+            Log.Information("Discord outage process restart request persisted");
+        }
+
+        public async Task ClearAsync(CancellationToken cancellationToken = default)
+        {
+            await _fileAccess.WaitAsync(cancellationToken);
+            try
+            {
+                if (File.Exists(_outageFilePath))
+                {
+                    File.Delete(_outageFilePath);
+                    Log.Information("Persisted Discord outage cleared");
+                }
+            }
+            finally
+            {
+                _fileAccess.Release();
+            }
+        }
+
+        private async Task UpdateAsync(
+            Func<DiscordOutage, DiscordOutage> updateOutage,
+            CancellationToken cancellationToken)
+        {
+            await _fileAccess.WaitAsync(cancellationToken);
+            try
+            {
+                var existingOutage = await ReadWithoutLockAsync(cancellationToken);
+                var updatedOutage = updateOutage(existingOutage);
+                if (updatedOutage is not null)
+                {
+                    await WriteAtomicallyAsync(updatedOutage, cancellationToken);
+                }
+            }
+            finally
+            {
+                _fileAccess.Release();
+            }
+        }
+
+        private async Task<DiscordOutage> ReadWithoutLockAsync(CancellationToken cancellationToken)
+        {
+            if (!File.Exists(_outageFilePath))
+            {
+                return null;
+            }
+
+            try
+            {
+                await using var outageFile = new FileStream(
+                    _outageFilePath,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.Read,
+                    4096,
+                    FileOptions.Asynchronous);
+                var outage = await JsonSerializer.DeserializeAsync<DiscordOutage>(
+                    outageFile,
+                    cancellationToken: cancellationToken);
+                if (outage is null || outage.DisconnectedAtUtc == default)
+                {
+                    throw new JsonException("The persisted Discord outage is missing required data.");
+                }
+
+                Log.Information(
+                    "Persisted Discord outage loaded. DisconnectedAtUtc={DisconnectedAtUtc}, ManualRecoveryAttempted={ManualRecoveryAttempted}, ProcessRestartRequested={ProcessRestartRequested}",
+                    outage.DisconnectedAtUtc,
+                    outage.ManualRecoveryAttempted,
+                    outage.ProcessRestartRequested);
+                return outage;
+            }
+            catch (JsonException exception)
+            {
+                QuarantineCorruptOutageFile(exception);
+                return null;
+            }
+        }
+
+        private async Task WriteAtomicallyAsync(
+            DiscordOutage outage,
+            CancellationToken cancellationToken)
+        {
+            var temporaryFilePath = $"{_outageFilePath}.{Guid.NewGuid():N}.tmp";
+            try
+            {
+                await using (var temporaryFile = new FileStream(
+                    temporaryFilePath,
+                    FileMode.CreateNew,
+                    FileAccess.Write,
+                    FileShare.None,
+                    4096,
+                    FileOptions.Asynchronous | FileOptions.WriteThrough))
+                {
+                    await JsonSerializer.SerializeAsync(
+                        temporaryFile,
+                        outage,
+                        cancellationToken: cancellationToken);
+                    await temporaryFile.FlushAsync(cancellationToken);
+                    temporaryFile.Flush(flushToDisk: true);
+                }
+
+                File.Move(temporaryFilePath, _outageFilePath, overwrite: true);
+                Log.Information(
+                    "Meaningful Discord outage persisted. DisconnectedAtUtc={DisconnectedAtUtc}, ManualRecoveryAttempted={ManualRecoveryAttempted}, ProcessRestartRequested={ProcessRestartRequested}",
+                    outage.DisconnectedAtUtc,
+                    outage.ManualRecoveryAttempted,
+                    outage.ProcessRestartRequested);
+            }
+            finally
+            {
+                if (File.Exists(temporaryFilePath))
+                {
+                    File.Delete(temporaryFilePath);
+                }
+            }
+        }
+
+        private void QuarantineCorruptOutageFile(JsonException exception)
+        {
+            var quarantinePath = $"{_outageFilePath}.corrupt-{DateTimeOffset.UtcNow:yyyyMMddHHmmssfff}";
+            try
+            {
+                File.Move(_outageFilePath, quarantinePath);
+                Log.Error(
+                    exception,
+                    "Corrupted Discord outage state encountered and quarantined. QuarantinePath={QuarantinePath}",
+                    quarantinePath);
+            }
+            catch (Exception quarantineException)
+            {
+                Log.Error(
+                    quarantineException,
+                    "Corrupted Discord outage state encountered but could not be quarantined. OutageFilePath={OutageFilePath}",
+                    _outageFilePath);
+            }
+        }
+
+        private static DiscordOutage CreateOutage(
+            DateTimeOffset disconnectedAtUtc,
+            string mostRecentDisconnectReason)
+            => new()
+            {
+                DisconnectedAtUtc = disconnectedAtUtc.ToUniversalTime(),
+                MostRecentDisconnectReason = NormalizeReason(mostRecentDisconnectReason)
+            };
+
+        private static string NormalizeReason(string disconnectReason)
+            => string.IsNullOrWhiteSpace(disconnectReason)
+                ? "Discord gateway disconnected."
+                : disconnectReason;
+
+        public void Dispose() => _fileAccess.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary

- persist meaningful Discord Gateway outages in the host-mounted `BeanBotFiles` directory using atomic JSON writes
- mark manual recovery attempts and requested process restarts before recovery escalation exits the process
- notify the configured bot owner after the Gateway reaches `Ready`, with bounded delivery retries and clear-on-success semantics
- quarantine malformed outage records and add structured incident lifecycle logging
- add deterministic coverage for outage storage, recovery integration, cross-process notification details, failed delivery retention, and duplicate `Ready` events

## Why

The Discord recovery service can intentionally exit after exhausting reconnect attempts, after which Docker restarts BeanBot. Previously, incident state only lived in process memory, so the restarted process could not tell the owner that a meaningful outage occurred or how recovery happened.

This change stores only the current open incident in the existing persistent data mount and waits for a real Gateway `Ready` event before sending the recovery DM. Short natural reconnects remain log-only.

## Validation

- `dotnet build BeanBot.sln -c Release` — succeeded with 0 warnings and 0 errors
- `dotnet test BeanBot.sln -c Release` — 242 passed, 0 failed, 0 skipped
