### PR TITLE
Add Codex multi-agent development loop

### DIFF
--- a/.agents/skills/beanbot-implement/SKILL.md
+++ b/.agents/skills/beanbot-implement/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: beanbot-implement
+description: Implement an approved BeanBot plan as the main-thread sole writer and drive it through focused checks, independent verification, and independent review. Use for BeanBot coding tasks after the user has approved a concrete plan and acceptance criteria.
+---
+
+# Implement an approved BeanBot plan
+
+1. Require the approved plan and acceptance criteria. Read applicable `AGENTS.md` and inspect repository reality before following the plan. Stop if they materially conflict.
+2. Confirm a clean dedicated branch from current `origin/master`. Implement the smallest complete change without unrelated refactoring.
+3. Add meaningful behavioral and failure-path tests. Preserve existing architecture, reliability rules, validation, authentication, and failure handling.
+4. Run the narrowest relevant checks first and repair failures. Then run `./scripts/verify.sh fast` and, before PR completion, `./scripts/verify.sh full` when its dependencies are available.
+5. Give a fresh Verifier the complete original goal, approved plan, acceptance criteria, base branch, and full diff. Correct every actionable finding and request fresh verification.
+6. Request a fresh independent Reviewer only after `Result: PASS`. Correct consequential review findings, rerun verification, and request review again.
+7. Prepare, commit, push, and open or update the PR only when required gates pass. If local infrastructure alone blocks a required gate, use a draft PR for exact-head CI evidence, then return that evidence to a fresh Verifier.
+8. Mark the PR ready only after Verifier PASS, Reviewer CLEAN, and required exact-head CI succeeds. Never merge or enable auto-merge without explicit instruction.
+
+Keep the repair loop bounded: stop after two reasonable attempts at the same materially unchanged failure, or sooner for an environmental failure, unavailable Discord/GitHub/NuGet/Docker infrastructure, conflicting requirements, missing tools or permissions, repository/plan conflict, required test weakening, or unrelated redesign. Report the failing command, evidence, attempts, and safe next action.
+
+The main thread remains the only writer. Do not delegate implementation to another agent.

--- a/.agents/skills/beanbot-implement/agents/openai.yaml
+++ b/.agents/skills/beanbot-implement/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "BeanBot Implementer"
+  short_description: "Implement an approved BeanBot plan safely"
+  default_prompt: "Use $beanbot-implement to implement this approved BeanBot plan and drive it through verification."

--- a/.agents/skills/beanbot-plan/SKILL.md
+++ b/.agents/skills/beanbot-plan/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: beanbot-plan
+description: Create an implementation-ready, read-only plan for a BeanBot change. Use when a BeanBot goal needs current behavior, affected files, reliability constraints, acceptance criteria, and a concrete test plan established before implementation.
+---
+
+# Plan a BeanBot change
+
+1. Read every applicable `AGENTS.md` before analyzing the request.
+2. Inspect the current code, tests, configuration, Docker behavior, CI, and documentation relevant to the goal. Treat the repository as authoritative.
+3. Confirm current behavior and distinguish evidence from assumptions. Identify affected files, compatibility risks, and any unresolved decision that would materially change the implementation.
+4. Produce a bounded, implementation-ready plan with these sections:
+   - Confirmed current behavior
+   - Requested behavior
+   - Relevant files/components
+   - Reliability/security constraints
+   - Implementation plan
+   - Test plan
+   - Acceptance criteria
+   - Risks/assumptions
+5. Stop after returning the plan. If a material decision remains unresolved, state it and request direction.
+
+Do not edit files, commit, push, open a pull request, or begin implementation.

--- a/.agents/skills/beanbot-plan/agents/openai.yaml
+++ b/.agents/skills/beanbot-plan/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "BeanBot Planner"
+  short_description: "Plan bounded BeanBot repository changes"
+  default_prompt: "Use $beanbot-plan to produce an implementation-ready plan for this BeanBot goal."

--- a/.agents/skills/beanbot-review/SKILL.md
+++ b/.agents/skills/beanbot-review/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: beanbot-review
+description: Independently review a fully verified BeanBot diff for consequential correctness, reliability, security, test, and deployment risks. Use only after a fresh Verifier has returned PASS and the reviewer must report findings or CLEAN without editing files.
+---
+
+# Review a verified BeanBot change independently
+
+Require the original goal, approved plan, acceptance criteria, base branch, complete diff, and fresh Verifier PASS evidence.
+
+1. Read applicable `AGENTS.md`, especially `Code Review Rules`.
+2. Inspect the complete diff and relevant surrounding code. Do not trust summaries as evidence.
+3. Prioritize correctness, Discord lifecycle races, persistence semantics, health truthfulness, security, MongoDB/cache consistency, Docker compatibility, and meaningful test gaps. Avoid style-only comments unless they conceal a real defect.
+4. For each finding, provide severity, file/behavior, evidence, impact, and expected correction.
+5. List residual risks and intentionally manual checks. Return `Result: CLEAN` when no consequential finding remains.
+6. Do not edit files, repair findings, commit, push, or open a PR.
+
+Review only after verification passes. A correction invalidates prior verification and review; require fresh verification before reviewing again.

--- a/.agents/skills/beanbot-review/agents/openai.yaml
+++ b/.agents/skills/beanbot-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "BeanBot Reviewer"
+  short_description: "Review a verified BeanBot change independently"
+  default_prompt: "Use $beanbot-review to independently review this verified BeanBot diff for consequential findings."

--- a/.agents/skills/beanbot-verify/SKILL.md
+++ b/.agents/skills/beanbot-verify/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: beanbot-verify
+description: Independently verify a completed BeanBot diff against its approved plan and acceptance criteria. Use after implementation or corrections when a fresh verifier must inspect the diff, run all required gates, detect workspace mutations, and return PASS or FAIL without editing source files.
+---
+
+# Verify a BeanBot change independently
+
+Require the original goal, approved plan, acceptance criteria, base branch, and complete diff. Read applicable `AGENTS.md`; inspect the diff instead of trusting the Implementer's summary.
+
+1. Capture `git status --porcelain=v1 --untracked-files=all` before running commands. Record tracked and non-ignored files.
+2. Map every acceptance criterion to concrete evidence.
+3. Run relevant focused tests, then every applicable deterministic repository gate. Normally run `./scripts/verify.sh fast` and `./scripts/verify.sh full`; a required failed or skipped gate means FAIL.
+4. Confirm local commands match CI, and inspect Docker/configuration implications where applicable.
+5. Check the diff and workspace for secrets, generated junk, weakened tests, and unexpected files.
+6. Capture the same status baseline afterward and confirm it is unchanged. Ignored `bin`, `obj`, test-result, package, or Docker output is allowed.
+7. Do not edit or repair implementation files. Do not commit, push, or open a PR.
+
+Return exactly this structure:
+
+```text
+Result: PASS | FAIL
+
+Acceptance criteria:
+- criterion -> pass/fail with evidence
+
+Commands run:
+- command -> result
+
+Findings:
+- actionable correctness or verification issue
+
+Unverified:
+- unavailable, skipped, CI-only, or manual item with reason
+```
+
+Never report PASS while omitting a required check.

--- a/.agents/skills/beanbot-verify/agents/openai.yaml
+++ b/.agents/skills/beanbot-verify/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "BeanBot Verifier"
+  short_description: "Independently verify a BeanBot change"
+  default_prompt: "Use $beanbot-verify to independently verify this BeanBot diff against its acceptance criteria."

--- a/.codex/agents/beanbot_planner.toml
+++ b/.codex/agents/beanbot_planner.toml
@@ -1,0 +1,9 @@
+name = "beanbot_planner"
+description = "Read-only BeanBot planner that establishes repository reality and returns an implementation-ready plan."
+sandbox_mode = "read-only"
+developer_instructions = """
+Use the beanbot-plan repository skill and read every applicable AGENTS.md.
+Inspect current code, tests, configuration, Docker behavior, CI, and documentation relevant to the goal.
+Return confirmed behavior, requested behavior, relevant files, constraints, a bounded plan, test plan, acceptance criteria, and risks or assumptions.
+Do not edit files, commit, push, open a pull request, or begin implementation. Stop after the plan or a material unresolved decision.
+"""

--- a/.codex/agents/beanbot_reviewer.toml
+++ b/.codex/agents/beanbot_reviewer.toml
@@ -1,0 +1,9 @@
+name = "beanbot_reviewer"
+description = "Read-only independent reviewer for a BeanBot diff that already has fresh verifier PASS evidence."
+sandbox_mode = "read-only"
+developer_instructions = """
+Use the beanbot-review repository skill and read every applicable AGENTS.md, especially Code Review Rules.
+Run only after fresh Verifier PASS. Inspect the complete diff and relevant surrounding code.
+Report consequential findings with severity, location or behavior, evidence, impact, and expected correction, or return Result: CLEAN.
+List residual risks and manual checks. Do not edit, repair, commit, push, or open a pull request.
+"""

--- a/.codex/agents/beanbot_verifier.toml
+++ b/.codex/agents/beanbot_verifier.toml
@@ -1,0 +1,10 @@
+name = "beanbot_verifier"
+description = "Independent BeanBot verifier that may run build tools but must not edit source or repair findings."
+sandbox_mode = "workspace-write"
+developer_instructions = """
+Use the beanbot-verify repository skill and read every applicable AGENTS.md.
+Require the original goal, approved plan, acceptance criteria, base branch, and complete diff. Inspect the diff directly.
+Capture tracked and non-ignored workspace state before and after verification. Run every required focused, fast, and full gate; report FAIL for a required failure or skip.
+Build tools may create ignored output, but do not edit or repair source, configuration, or documentation files. Do not commit, push, or open a pull request.
+Return the skill's required PASS/FAIL evidence format.
+"""

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,10 @@
 .git
 .github
 .agents
+.codex
+docs
+scripts
+AGENTS.md
 .artifacts
 .dotnet
 .dotnet-home

--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -15,20 +15,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
 
-      - name: Restore
-        run: dotnet restore BeanBot.sln
-
-      - name: Build
-        run: dotnet build BeanBot.sln --configuration Release --no-restore
-
-      - name: Test
-        run: dotnet test BeanBot.sln --configuration Release --no-build
+      - name: Shared build and test verification
+        run: ./scripts/verify.sh build-test
 
   release-on-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnetaction.yml
+++ b/.github/workflows/dotnetaction.yml
@@ -22,17 +22,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
 
-      - name: Restore
-        run: dotnet restore BeanBot.sln
-
-      - name: Build
-        run: dotnet build BeanBot.sln --configuration Release --no-restore
-
-      - name: Test
-        run: dotnet test BeanBot.sln --configuration Release --no-build
+      - name: Full repository verification
+        run: ./scripts/verify.sh full

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# BeanBot Development Policy
+
+## Working Rules
+
+- Perform coding work on a dedicated branch created from the latest `origin/master`; never implement directly on `master`.
+- Inspect current behavior, tests, configuration, Docker, CI, and documentation before editing. Implement the smallest complete change and avoid unrelated refactors.
+- Keep code human-readable and human-reviewable. Prefer self-documenting method and variable names.
+- Do not weaken tests, assertions, validation, authentication, rate limiting, or failure handling to obtain green output.
+- Never commit or log `.env` contents, Discord tokens, MongoDB credentials, bearer tokens, channel IDs, connection strings, sensitive Discord payloads, or other deployment secrets. Secrets belong in environment variables.
+- Preserve compatibility with the existing self-hosted .NET 8 Docker deployment. Runtime files belong under the existing persistent `BeanBotFiles` data directory.
+- Critical bug fixes and security maintenance remain allowed. Do not add unrelated bot features, begin the Python migration, or perform the planned .NET/Discord.Net upgrade as part of another task.
+- Do not merge a pull request or enable auto-merge unless the user explicitly instructs it.
+
+## Engineering Invariants
+
+- Register Discord event handlers and subscriptions at most once, and unsubscribe cleanly.
+- Keep shutdown, cancellation, reconnect, retry, timeout, queue, and task-creation behavior bounded. Do not swallow cancellation.
+- Prevent asynchronous failures from becoming unobserved or triggering recursive owner-alert failures.
+- Keep Discord recovery race-safe; never start competing reconnect attempts.
+- Keep persisted outage state atomic, corruption-tolerant, and retained until a recovery notification succeeds.
+- Repeated Discord `Ready` events must not duplicate outage notifications, and failed delivery must not discard the persisted outage.
+- Keep `/healthz` truthful about process and gateway state. Do not weaken health authentication or rate limiting.
+- Preserve safe reaction-role persistence/cache consistency and cleanup behavior.
+
+## Development Loop
+
+- Use Planner → approved plan → Implementer → Verifier → Reviewer for coding changes.
+- The main Codex thread is the sole Implementer and sole source-file writer. Planner, Verifier, and Reviewer report evidence and findings; they do not repair code.
+- The Implementer corrects Verifier or Reviewer findings, reruns focused checks, and requests fresh verification. Review begins only after verification passes.
+- Stop after two reasonable attempts at the same materially unchanged failure, or sooner for unavailable infrastructure, conflicting requirements, missing permissions/tools, architectural conflict, or a fix that would require weakened tests or unrelated redesign. Report the command, evidence, attempts, and safest next action.
+- Never commit ordinary transient plans, verification reports, or review results.
+
+## Code Review Rules
+
+Prioritize consequential findings involving:
+
+- Discord lifecycle races, duplicate subscriptions, or duplicate messages
+- unbounded retries, waits, queues, or task creation; swallowed cancellation
+- false healthy status or weakened health authentication/rate limiting
+- loss, duplication, corruption, or non-atomic writes of persisted outage state
+- recursive error reporting or unobserved asynchronous failures
+- MongoDB consistency or reaction-role cache/persistence drift
+- token, connection-string, bearer-token, channel-ID, or sensitive payload exposure
+- Docker/runtime incompatibility
+- weakened tests or assertions
+- unrelated refactors

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ dotnet build BeanBot.sln --configuration Release --no-restore
 dotnet test BeanBot.sln --configuration Release --no-build
 ```
 
+Repository changes use a Codex-native Planner → Implementer → Verifier → Reviewer loop with one writer and independent verification/review. See [Codex development loop](docs/codex-development-loop.md) for role handoffs and the shared fast/full verification commands.
+
 To start the bot:
 
 ```powershell

--- a/docs/codex-development-loop.md
+++ b/docs/codex-development-loop.md
@@ -1,0 +1,49 @@
+# Codex Development Loop
+
+BeanBot uses repository-scoped Codex skills and custom agents to separate planning, implementation, verification, and review. `AGENTS.md` is the authoritative shared policy; role skills contain only their workflow-specific instructions.
+
+## Flow and ownership
+
+1. Invoke `$beanbot-plan` or the `beanbot_planner` custom agent with the user goal. It inspects the repository read-only and returns current behavior, a bounded plan, tests, acceptance criteria, and risks.
+2. After the user approves the plan, invoke `$beanbot-implement` in the main thread. The main thread is the sole writer and implements the smallest complete change.
+3. Hand the original goal, approved plan, acceptance criteria, base branch, and complete diff to a fresh `beanbot_verifier`. It may create ignored build output but must not edit source files. `Result: FAIL` returns findings to the main thread.
+4. After `Result: PASS`, hand the same context, diff, and verifier evidence to a fresh `beanbot_reviewer`. Findings return to the main thread; every correction requires fresh verification before review runs again. `Result: CLEAN` completes independent review.
+5. Required exact-head GitHub CI must pass before the PR is marked ready. A human decides whether to merge; the workflow never merges or enables auto-merge.
+
+Plans, handoffs, verification evidence, and review results are transient conversation artifacts. Do not commit routine `PLAN.md`, `VERIFICATION.md`, or review-result files.
+
+## Verification interfaces
+
+Run commands from any directory; each script resolves the repository root itself.
+
+```bash
+/path/to/BeanBot-DEPRACATED/scripts/test-verification.sh
+/path/to/BeanBot-DEPRACATED/scripts/verify.sh fast
+/path/to/BeanBot-DEPRACATED/scripts/verify.sh full
+```
+
+`fast` is the normal implementation loop. It tests the verifier's orchestration and failure propagation, validates Codex/CI configuration, restores the solution, builds Release without a second restore, runs Release tests without a second build, and checks committed, staged, and unstaged diffs for whitespace errors.
+
+`full` runs every fast gate once, then checks direct and transitive NuGet dependencies across the complete solution for known vulnerabilities and builds the Docker image. The internal `build-test` mode gives the master-only release workflow the same orchestration self-test, validation, restore, Release build, Release test, and diff gates without duplicating full-only Docker and vulnerability work.
+
+The script keeps the .NET CLI home and NuGet package cache in the repository's ignored `.dotnet-home` and `.dotnet` directories unless the caller explicitly supplies `DOTNET_CLI_HOME` or `NUGET_PACKAGES`.
+
+The gates have these dependencies:
+
+- Configuration, script orchestration, build, test, and diff checks are deterministic local checks once dependencies are restored.
+- Restore and vulnerable-package checks require NuGet/network availability.
+- The Docker gate requires a working Docker daemon and registry/network access when base layers are absent.
+- GitHub evaluates Actions syntax/triggers and supplies exact-head required-check evidence.
+- Real Discord, production MongoDB, deployment health, and post-deployment behavior remain manual. Tests must not connect to them.
+
+Formatting is not a mandatory gate because the repository has no established formatting baseline. No coverage threshold is imposed.
+
+## Repair and infrastructure failures
+
+The main thread applies Verifier and Reviewer corrections and reruns focused checks before requesting fresh verification. Stop after two reasonable attempts at the same materially unchanged failure, or sooner when infrastructure, requirements, permissions, tools, or architecture block safe progress. Report the command, evidence, attempts, and safest next action; never weaken a gate.
+
+If only local infrastructure is unavailable, open a draft PR to obtain exact-head CI evidence, then give that evidence to a fresh Verifier. Failures arriving while an active Codex task is still running can be inspected and repaired. Failures after the task ends require another user/Codex invocation.
+
+## Automation boundaries
+
+Skills and custom-agent files guide active Codex sessions; they do not create a persistent autonomous daemon. Repository rules can guide Codex review, but cannot enable an external GitHub review setting. GitHub Actions performs shared verification and the existing master-only release action. PR creation/readiness and deployment checks are user- or agent-triggered, merging remains human-controlled, and no automatic merge is configured.

--- a/scripts/test-verification.sh
+++ b/scripts/test-verification.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+repository_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
+verify_script="$repository_root/scripts/verify.sh"
+temporary_directory="$(mktemp -d)"
+trap 'rm -rf -- "$temporary_directory"' EXIT
+
+stub_directory="$temporary_directory/bin"
+mkdir -p "$stub_directory"
+stub="$temporary_directory/command-stub"
+
+cat >"$stub" <<'STUB'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+command_name="$(basename -- "$0")"
+echo "$PWD|$command_name|$*" >>"$BEANBOT_VERIFY_TEST_LOG"
+if [[ -n "${BEANBOT_VERIFY_TEST_FAIL:-}" && "$command_name $*" == *"$BEANBOT_VERIFY_TEST_FAIL"* ]]; then
+  exit 17
+fi
+STUB
+chmod +x "$stub"
+for command_name in python3 dotnet git docker; do
+  cp "$stub" "$stub_directory/$command_name"
+done
+
+assert_contains() {
+  local expected="$1"
+  local file="$2"
+  if ! grep -Fq -- "$expected" "$file"; then
+    echo "Expected '$expected' in $file" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local unexpected="$1"
+  local file="$2"
+  if grep -Fq -- "$unexpected" "$file"; then
+    echo "Did not expect '$unexpected' in $file" >&2
+    exit 1
+  fi
+}
+
+assert_count() {
+  local expected_count="$1"
+  local expected="$2"
+  local file="$3"
+  local actual_count
+  actual_count="$(grep -Fc -- "$expected" "$file" || true)"
+  if [[ "$actual_count" -ne "$expected_count" ]]; then
+    echo "Expected '$expected' $expected_count time(s) in $file, found $actual_count" >&2
+    exit 1
+  fi
+}
+
+fast_log="$temporary_directory/fast.log"
+(
+  cd /tmp
+  PATH="$stub_directory:$PATH" BEANBOT_VERIFY_TEST_LOG="$fast_log" \
+    BEANBOT_VERIFY_SKIP_SELF_TEST=1 "$verify_script" fast
+)
+assert_contains "$repository_root|dotnet|restore BeanBot.sln" "$fast_log"
+assert_contains "$repository_root|dotnet|test BeanBot.sln --configuration Release --no-build" "$fast_log"
+assert_not_contains "|dotnet|list " "$fast_log"
+assert_not_contains "|docker|" "$fast_log"
+
+full_log="$temporary_directory/full.log"
+(
+  cd /tmp
+  PATH="$stub_directory:$PATH" BEANBOT_VERIFY_TEST_LOG="$full_log" \
+    BEANBOT_VERIFY_SKIP_SELF_TEST=1 "$verify_script" full
+)
+assert_contains "$repository_root|dotnet|list BeanBot.sln package --vulnerable --include-transitive" "$full_log"
+assert_contains "$repository_root|docker|build --tag beanbot-verification:local ." "$full_log"
+assert_count 1 "|python3|scripts/validate-workflow.py" "$full_log"
+assert_count 1 "|dotnet|restore BeanBot.sln" "$full_log"
+assert_count 1 "|dotnet|build BeanBot.sln --configuration Release --no-restore" "$full_log"
+assert_count 1 "|dotnet|test BeanBot.sln --configuration Release --no-build" "$full_log"
+assert_count 1 "|dotnet|list BeanBot.sln package --vulnerable --include-transitive" "$full_log"
+assert_count 1 "|docker|build --tag beanbot-verification:local ." "$full_log"
+
+invalid_log="$temporary_directory/invalid.log"
+if PATH="$stub_directory:$PATH" BEANBOT_VERIFY_TEST_LOG="$invalid_log" \
+  BEANBOT_VERIFY_SKIP_SELF_TEST=1 "$verify_script" unsupported >"$temporary_directory/invalid.out" 2>&1; then
+  echo "Invalid mode unexpectedly succeeded" >&2
+  exit 1
+fi
+assert_contains "Unknown verification mode: unsupported" "$temporary_directory/invalid.out"
+
+failure_log="$temporary_directory/failure.log"
+if PATH="$stub_directory:$PATH" BEANBOT_VERIFY_TEST_LOG="$failure_log" \
+  BEANBOT_VERIFY_TEST_FAIL="dotnet build BeanBot.sln" BEANBOT_VERIFY_SKIP_SELF_TEST=1 \
+  "$verify_script" full; then
+  echo "Injected child-command failure unexpectedly succeeded" >&2
+  exit 1
+fi
+assert_contains "|dotnet|build BeanBot.sln --configuration Release --no-restore" "$failure_log"
+assert_not_contains "|dotnet|test " "$failure_log"
+assert_not_contains "|docker|" "$failure_log"
+
+echo "Verification orchestration tests passed."

--- a/scripts/validate-workflow.py
+++ b/scripts/validate-workflow.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Validate BeanBot's checked-in Codex and CI workflow infrastructure."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import stat
+import sys
+import tomllib
+
+try:
+    import yaml
+except ImportError:  # GitHub itself parses workflows before a job can start.
+    yaml = None
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
+SKILL_NAMES = ("beanbot-plan", "beanbot-implement", "beanbot-verify", "beanbot-review")
+AGENTS = {
+    "beanbot_planner.toml": ("beanbot_planner", "read-only"),
+    "beanbot_verifier.toml": ("beanbot_verifier", "workspace-write"),
+    "beanbot_reviewer.toml": ("beanbot_reviewer", "read-only"),
+}
+
+
+def fail(message: str) -> None:
+    raise ValueError(message)
+
+
+def validate_yaml(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    if "\t" in text:
+        fail(f"{path.relative_to(REPOSITORY_ROOT)} contains a YAML tab indentation")
+    if yaml is not None:
+        try:
+            yaml.compose(text)
+        except yaml.YAMLError as error:
+            fail(f"{path.relative_to(REPOSITORY_ROOT)} is not valid YAML: {error}")
+
+
+def parse_skill_frontmatter(text: str, path: Path) -> dict[str, str]:
+    if not text.startswith("---\n") or "\n---\n" not in text[4:]:
+        fail(f"{path.relative_to(REPOSITORY_ROOT)} has invalid frontmatter")
+    frontmatter_text, _ = text[4:].split("\n---\n", 1)
+    metadata: dict[str, str] = {}
+    for line in frontmatter_text.splitlines():
+        key, separator, value = line.partition(":")
+        if not separator or not key.strip() or not value.strip():
+            fail(f"{path.relative_to(REPOSITORY_ROOT)} has invalid frontmatter content")
+        metadata[key.strip()] = value.strip()
+    return metadata
+
+
+def validate_skills() -> None:
+    for skill_name in SKILL_NAMES:
+        skill_directory = REPOSITORY_ROOT / ".agents" / "skills" / skill_name
+        skill_path = skill_directory / "SKILL.md"
+        text = skill_path.read_text(encoding="utf-8")
+        metadata = parse_skill_frontmatter(text, skill_path)
+        _, body = text[4:].split("\n---\n", 1)
+        if set(metadata) != {"name", "description"}:
+            fail(f"{skill_path.relative_to(REPOSITORY_ROOT)} must contain only name and description metadata")
+        if metadata["name"] != skill_name or not metadata["description"].strip():
+            fail(f"{skill_path.relative_to(REPOSITORY_ROOT)} metadata does not match its directory")
+        if not body.strip() or "TODO" in text:
+            fail(f"{skill_path.relative_to(REPOSITORY_ROOT)} is incomplete")
+
+        ui_path = skill_directory / "agents" / "openai.yaml"
+        validate_yaml(ui_path)
+        if f"${skill_name}" not in ui_path.read_text(encoding="utf-8"):
+            fail(f"{ui_path.relative_to(REPOSITORY_ROOT)} default_prompt must mention ${skill_name}")
+
+
+def validate_custom_agents() -> None:
+    agent_directory = REPOSITORY_ROOT / ".codex" / "agents"
+    for filename, (expected_name, expected_sandbox) in AGENTS.items():
+        path = agent_directory / filename
+        with path.open("rb") as stream:
+            data = tomllib.load(stream)
+        required = {"name", "description", "developer_instructions"}
+        if not required.issubset(data):
+            fail(f"{path.relative_to(REPOSITORY_ROOT)} is missing required custom-agent fields")
+        if data["name"] != expected_name or data.get("sandbox_mode") != expected_sandbox:
+            fail(f"{path.relative_to(REPOSITORY_ROOT)} has unexpected name or sandbox_mode")
+        if "model" in data or "model_reasoning_effort" in data:
+            fail(f"{path.relative_to(REPOSITORY_ROOT)} must inherit the parent model policy")
+
+
+def validate_workflows() -> None:
+    validation_path = REPOSITORY_ROOT / ".github" / "workflows" / "dotnetaction.yml"
+    release_path = REPOSITORY_ROOT / ".github" / "workflows" / "autorelease.yml"
+    validate_yaml(validation_path)
+    validate_yaml(release_path)
+
+    validation = validation_path.read_text(encoding="utf-8")
+    release = release_path.read_text(encoding="utf-8")
+    required_validation_fragments = (
+        "name: .NET Core Master and Deploy Checks",
+        "dotnet-version: 8.0.x",
+        "./scripts/verify.sh full",
+    )
+    required_release_fragments = (
+        "name: Bean Bot Automated Release/Versioning",
+        "branches:\n      - master",
+        "./scripts/verify.sh build-test",
+        "needs: build",
+    )
+    for fragment in required_validation_fragments:
+        if fragment not in validation:
+            fail(f"dotnetaction.yml is missing required content: {fragment}")
+    for fragment in required_release_fragments:
+        if fragment not in release:
+            fail(f"autorelease.yml is missing required content: {fragment}")
+
+
+def validate_policy_and_scripts() -> None:
+    policy = (REPOSITORY_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    for heading in ("## Working Rules", "## Engineering Invariants", "## Development Loop", "## Code Review Rules"):
+        if heading not in policy:
+            fail(f"AGENTS.md is missing {heading}")
+
+    for relative_path in ("scripts/verify.sh", "scripts/test-verification.sh"):
+        path = REPOSITORY_ROOT / relative_path
+        if not path.stat().st_mode & stat.S_IXUSR:
+            fail(f"{relative_path} must be executable")
+
+    verifier = (REPOSITORY_ROOT / "scripts" / "verify.sh").read_text(encoding="utf-8")
+    if 'run_stage "Test verification orchestration" scripts/test-verification.sh' not in verifier:
+        fail("scripts/verify.sh must run the orchestration self-test")
+    if "dotnet list BeanBot.sln package --vulnerable --include-transitive" not in verifier:
+        fail("full verification must scan all solution package dependencies")
+
+    gitignore = (REPOSITORY_ROOT / ".gitignore").read_text(encoding="utf-8").splitlines()
+    for ignored_directory in (".dotnet/", ".dotnet-home/"):
+        if ignored_directory not in gitignore:
+            fail(f".gitignore must exclude verification cache {ignored_directory}")
+
+
+def main() -> int:
+    os.chdir(REPOSITORY_ROOT)
+    try:
+        validate_skills()
+        validate_custom_agents()
+        validate_workflows()
+        validate_policy_and_scripts()
+    except (KeyError, OSError, TypeError, ValueError, tomllib.TOMLDecodeError) as error:
+        print(f"Workflow validation failed: {error}", file=sys.stderr)
+        return 1
+    print("Workflow infrastructure validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+repository_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "$repository_root"
+
+usage() {
+  echo "Usage: $0 {fast|full|build-test}" >&2
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 2
+fi
+
+mode="$1"
+case "$mode" in
+  fast|full|build-test) ;;
+  *)
+    echo "Unknown verification mode: $mode" >&2
+    usage
+    exit 2
+    ;;
+esac
+
+export DOTNET_CLI_HOME="${DOTNET_CLI_HOME:-$repository_root/.dotnet-home}"
+export NUGET_PACKAGES="${NUGET_PACKAGES:-$repository_root/.dotnet/packages}"
+export DOTNET_CLI_TELEMETRY_OPTOUT="${DOTNET_CLI_TELEMETRY_OPTOUT:-1}"
+export DOTNET_NOLOGO="${DOTNET_NOLOGO:-1}"
+mkdir -p "$DOTNET_CLI_HOME" "$NUGET_PACKAGES"
+
+run_stage() {
+  local stage_name="$1"
+  shift
+  echo "==> $stage_name"
+  "$@"
+}
+
+validate_workflow() {
+  run_stage "Validate workflow infrastructure" python3 scripts/validate-workflow.py
+}
+
+self_test_workflow() {
+  run_stage "Test verification orchestration" scripts/test-verification.sh
+}
+
+build_and_test() {
+  run_stage "Restore .NET dependencies" dotnet restore BeanBot.sln
+  run_stage "Build Release" dotnet build BeanBot.sln --configuration Release --no-restore
+  run_stage "Run Release tests" dotnet test BeanBot.sln --configuration Release --no-build
+}
+
+check_diff() {
+  local base_ref="${BEANBOT_VERIFY_BASE_REF:-}"
+  if [[ -z "$base_ref" ]]; then
+    if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+      base_ref="origin/${GITHUB_BASE_REF}"
+    else
+      base_ref="origin/master"
+    fi
+  fi
+
+  run_stage "Check committed branch diff" git diff --check "$base_ref...HEAD"
+  run_stage "Check staged diff" git diff --cached --check
+  run_stage "Check unstaged diff" git diff --check
+}
+
+if [[ "${BEANBOT_VERIFY_SKIP_SELF_TEST:-0}" != "1" ]]; then
+  self_test_workflow
+fi
+validate_workflow
+build_and_test
+check_diff
+
+if [[ "$mode" == "full" ]]; then
+  run_stage "Check vulnerable NuGet packages" \
+    dotnet list BeanBot.sln package --vulnerable --include-transitive
+  run_stage "Build Docker image" docker build --tag beanbot-verification:local .
+fi
+
+echo "Verification mode '$mode' completed successfully."


### PR DESCRIPTION
## Summary

- centralize BeanBot development, reliability, security, Docker, and review policy in `AGENTS.md`
- add repository-scoped planning, implementation, verification, and review skills plus independent custom agents
- add root-resolving fast/full verification with workflow metadata validation and orchestration self-tests
- reuse the shared verification entry point in validation and master-only release workflows
- document role handoffs, bounded repair behavior, automation boundaries, and the human merge boundary

## Why

BeanBot had reliable product tests and CI but no durable Codex-native development loop separating planning, sole-writer implementation, independent verification, and independent review. This adds that infrastructure without changing runtime bot behavior or upgrading .NET/Discord.Net.

## Validation

- `bash -n scripts/verify.sh scripts/test-verification.sh`
- all four skills passed the supported Codex `quick_validate.py`
- `scripts/test-verification.sh` passed outside the repository root, including invalid-mode and failure-propagation cases
- `./scripts/verify.sh fast` passed: Release build succeeded with zero warnings/errors; 242 tests passed
- `./scripts/verify.sh full` passed: both solution projects reported no vulnerable direct/transitive packages; Docker image built successfully
- independent Verifier found no implementation defect; its only pre-publication failure was the then-missing PR/exact-head CI evidence
- independent Reviewer findings were corrected by making orchestration self-tests required and scanning solution-wide dependencies

## Boundaries

- no runtime BeanBot source or product behavior changed
- no automatic merge is configured
- keep this PR unmerged for human review
