### PR TITLE
Upgrade BeanBot to .NET 10 and Discord.Net 3.20.1

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Shared build and test verification
         run: ./scripts/verify.sh build-test

--- a/.github/workflows/dotnetaction.yml
+++ b/.github/workflows/dotnetaction.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Full repository verification
         run: ./scripts/verify.sh full

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 - Keep code human-readable and human-reviewable. Prefer self-documenting method and variable names.
 - Do not weaken tests, assertions, validation, authentication, rate limiting, or failure handling to obtain green output.
 - Never commit or log `.env` contents, Discord tokens, MongoDB credentials, bearer tokens, channel IDs, connection strings, sensitive Discord payloads, or other deployment secrets. Secrets belong in environment variables.
-- Preserve compatibility with the existing self-hosted .NET 8 Docker deployment. Runtime files belong under the existing persistent `BeanBotFiles` data directory.
+- Preserve compatibility with the existing self-hosted .NET 10 Docker deployment. Runtime files belong under the existing persistent `BeanBotFiles` data directory.
 - Critical bug fixes and security maintenance remain allowed. Do not add unrelated bot features, begin the Python migration, or perform the planned .NET/Discord.Net upgrade as part of another task.
 - Do not merge a pull request or enable auto-merge unless the user explicitly instructs it.
 

--- a/BeanBot.Tests/BeanBot.Tests.csproj
+++ b/BeanBot.Tests/BeanBot.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/BeanBot.Tests/DiscordSocketConfigurationTests.cs
+++ b/BeanBot.Tests/DiscordSocketConfigurationTests.cs
@@ -1,0 +1,28 @@
+using Discord;
+
+using Xunit;
+
+namespace BeanBot.Tests;
+
+public class DiscordSocketConfigurationTests
+{
+    [Fact]
+    public void Configuration_RequestsOnlyRequiredGatewayIntents()
+    {
+        var configuration = Program.CreateDiscordSocketConfig();
+        var expected = GatewayIntents.Guilds
+            | GatewayIntents.GuildMembers
+            | GatewayIntents.GuildEmojis
+            | GatewayIntents.GuildMessages
+            | GatewayIntents.DirectMessages
+            | GatewayIntents.GuildMessageReactions
+            | GatewayIntents.DirectMessageReactions
+            | GatewayIntents.MessageContent;
+
+        Assert.Equal(expected, configuration.GatewayIntents);
+        Assert.False(configuration.GatewayIntents.HasFlag(GatewayIntents.GuildPresences));
+        Assert.Equal(50, configuration.MessageCacheSize);
+        Assert.False(configuration.AlwaysDownloadUsers);
+        Assert.False(configuration.IncludeRawPayloadOnGatewayErrors);
+    }
+}

--- a/BeanBot.Tests/Modules/AdministrativeModuleTests.cs
+++ b/BeanBot.Tests/Modules/AdministrativeModuleTests.cs
@@ -1,0 +1,113 @@
+using BeanBot.Modules;
+using Xunit;
+
+namespace BeanBot.Tests.Modules;
+
+public class AdministrativeModuleTests
+{
+    private static readonly AdministrativeModule.RoleCandidate LeagueRole = new(1, "League");
+    private static readonly AdministrativeModule.RoleCandidate OtherRole = new(2, "Other");
+
+    [Fact]
+    public void ResolveRole_WithExplicitMention_ResolvesMentionedRole()
+    {
+        var result = Resolve("<@&1>", [LeagueRole], [LeagueRole.Id]);
+
+        AssertResolved(result, LeagueRole.Id);
+    }
+
+    [Fact]
+    public void ResolveRole_WithPlainTextName_ResolvesMatchingRole()
+    {
+        var result = Resolve("League", [LeagueRole]);
+
+        AssertResolved(result, LeagueRole.Id);
+    }
+
+    [Fact]
+    public void ResolveRole_WithDifferentNameCasing_ResolvesMatchingRole()
+    {
+        var result = Resolve("league", [LeagueRole]);
+
+        AssertResolved(result, LeagueRole.Id);
+    }
+
+    [Fact]
+    public void ResolveRole_WithMentionAndOtherRoleName_PrefersMentionedRole()
+    {
+        var result = Resolve("Please use Other instead", [LeagueRole, OtherRole], [LeagueRole.Id]);
+
+        AssertResolved(result, LeagueRole.Id);
+    }
+
+    [Fact]
+    public void ResolveRole_WithUnknownName_ReturnsNotFound()
+    {
+        var result = Resolve("Unknown", [LeagueRole]);
+
+        Assert.Equal(AdministrativeModule.RoleResolutionStatus.NotFound, result.Status);
+        Assert.Null(result.RoleId);
+    }
+
+    [Fact]
+    public void ResolveRole_WithMultipleDistinctMentions_ReturnsMultipleMentions()
+    {
+        var result = Resolve("League", [LeagueRole, OtherRole], [LeagueRole.Id, OtherRole.Id]);
+
+        Assert.Equal(AdministrativeModule.RoleResolutionStatus.MultipleMentions, result.Status);
+        Assert.Null(result.RoleId);
+    }
+
+    [Fact]
+    public void ResolveRole_WithRepeatedMentionOfSameRole_ResolvesThatRole()
+    {
+        var result = Resolve("unrelated text", [LeagueRole], [LeagueRole.Id, LeagueRole.Id]);
+
+        AssertResolved(result, LeagueRole.Id);
+    }
+
+    [Fact]
+    public void ResolveRole_WithMentionMissingFromGuild_DoesNotFallBackToName()
+    {
+        var result = Resolve("League", [LeagueRole], [99]);
+
+        Assert.Equal(AdministrativeModule.RoleResolutionStatus.NotFound, result.Status);
+        Assert.Null(result.RoleId);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ResolveRole_WithBlankName_ReturnsNotFound(string roleName)
+    {
+        var result = Resolve(roleName, [LeagueRole]);
+
+        Assert.Equal(AdministrativeModule.RoleResolutionStatus.NotFound, result.Status);
+        Assert.Null(result.RoleId);
+    }
+
+    [Fact]
+    public void ResolveRole_WithDuplicateCaseInsensitiveNames_ReturnsAmbiguousName()
+    {
+        var duplicateLeagueRole = new AdministrativeModule.RoleCandidate(3, "LEAGUE");
+
+        var result = Resolve("league", [LeagueRole, duplicateLeagueRole]);
+
+        Assert.Equal(AdministrativeModule.RoleResolutionStatus.AmbiguousName, result.Status);
+        Assert.Null(result.RoleId);
+    }
+
+    private static AdministrativeModule.RoleResolution Resolve(
+        string roleName,
+        IEnumerable<AdministrativeModule.RoleCandidate> availableRoles,
+        IEnumerable<ulong>? mentionedRoleIds = null)
+    {
+        return AdministrativeModule.ResolveRole(roleName, mentionedRoleIds ?? [], availableRoles);
+    }
+
+    private static void AssertResolved(AdministrativeModule.RoleResolution result, ulong expectedRoleId)
+    {
+        Assert.Equal(AdministrativeModule.RoleResolutionStatus.Resolved, result.Status);
+        Assert.Equal(expectedRoleId, result.RoleId);
+    }
+}

--- a/BeanBot.Tests/Services/DiscordMessageWaiterTests.cs
+++ b/BeanBot.Tests/Services/DiscordMessageWaiterTests.cs
@@ -1,0 +1,99 @@
+using BeanBot.Services;
+
+using Xunit;
+
+namespace BeanBot.Tests.Services;
+
+public class DiscordMessageWaiterTests
+{
+    [Fact]
+    public async Task MatchingMessage_CompletesWait()
+    {
+        using var waiter = new BoundedMessageWaiter<string>(2);
+        var wait = waiter.WaitAsync(10, 20, TimeSpan.FromSeconds(1));
+
+        Assert.True(waiter.TryPublish(10, 20, isBot: false, "matched"));
+
+        Assert.Equal("matched", await wait);
+        Assert.Equal(0, waiter.PendingCount);
+    }
+
+    [Theory]
+    [InlineData(11UL, 20UL, false)]
+    [InlineData(10UL, 21UL, false)]
+    [InlineData(10UL, 20UL, true)]
+    public async Task UnrelatedOrBotMessage_DoesNotCompleteWait(
+        ulong userId,
+        ulong channelId,
+        bool isBot)
+    {
+        using var waiter = new BoundedMessageWaiter<string>(2);
+        var wait = waiter.WaitAsync(10, 20, TimeSpan.FromMilliseconds(50));
+
+        Assert.False(waiter.TryPublish(userId, channelId, isBot, "ignored"));
+
+        Assert.Null(await wait);
+    }
+
+    [Fact]
+    public async Task Timeout_ReturnsNullAndReleasesSlot()
+    {
+        using var waiter = new BoundedMessageWaiter<string>(1);
+
+        Assert.Null(await waiter.WaitAsync(10, 20, TimeSpan.FromMilliseconds(20)));
+        Assert.Equal(0, waiter.PendingCount);
+        Assert.Null(await waiter.WaitAsync(11, 21, TimeSpan.FromMilliseconds(20)));
+    }
+
+    [Fact]
+    public async Task Cancellation_PropagatesAndReleasesSlot()
+    {
+        using var waiter = new BoundedMessageWaiter<string>(1);
+        using var cancellation = new CancellationTokenSource();
+        var wait = waiter.WaitAsync(10, 20, TimeSpan.FromMinutes(1), cancellation.Token);
+
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => wait);
+        Assert.Equal(0, waiter.PendingCount);
+    }
+
+    [Fact]
+    public async Task DuplicateUserAndChannelWait_IsRejected()
+    {
+        using var waiter = new BoundedMessageWaiter<string>(2);
+        var first = waiter.WaitAsync(10, 20, TimeSpan.FromSeconds(1));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => waiter.WaitAsync(10, 20, TimeSpan.FromSeconds(1)));
+
+        Assert.True(waiter.TryPublish(10, 20, isBot: false, "done"));
+        Assert.Equal("done", await first);
+    }
+
+    [Fact]
+    public async Task Capacity_IsBounded()
+    {
+        using var waiter = new BoundedMessageWaiter<string>(1);
+        var first = waiter.WaitAsync(10, 20, TimeSpan.FromSeconds(1));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => waiter.WaitAsync(11, 21, TimeSpan.FromSeconds(1)));
+
+        Assert.True(waiter.TryPublish(10, 20, isBot: false, "done"));
+        Assert.Equal("done", await first);
+    }
+
+    [Fact]
+    public async Task Dispose_FailsPendingWaitAndRejectsNewWaits()
+    {
+        var waiter = new BoundedMessageWaiter<string>(1);
+        var pending = waiter.WaitAsync(10, 20, TimeSpan.FromMinutes(1));
+
+        waiter.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => pending);
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => waiter.WaitAsync(11, 21, TimeSpan.FromSeconds(1)));
+    }
+}

--- a/BeanBot.Tests/Services/DiscordPaginatorServiceTests.cs
+++ b/BeanBot.Tests/Services/DiscordPaginatorServiceTests.cs
@@ -1,0 +1,239 @@
+using BeanBot.Services;
+
+using Discord;
+
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace BeanBot.Tests.Services;
+
+public class DiscordPaginatorServiceTests
+{
+    [Fact]
+    public void Cursor_NavigatesWithinBounds()
+    {
+        var cursor = new PaginationCursor(3);
+
+        Assert.False(cursor.Move(PaginationAction.Previous));
+        Assert.True(cursor.Move(PaginationAction.Next));
+        Assert.Equal(1, cursor.PageIndex);
+        Assert.True(cursor.Move(PaginationAction.Last));
+        Assert.Equal(2, cursor.PageIndex);
+        Assert.False(cursor.Move(PaginationAction.Next));
+        Assert.True(cursor.Move(PaginationAction.First));
+        Assert.Equal(0, cursor.PageIndex);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Cursor_RejectsInvalidPageCount(int pageCount)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new PaginationCursor(pageCount));
+    }
+
+    [Fact]
+    public void Cursor_NonNavigationActions_DoNotMove()
+    {
+        var cursor = new PaginationCursor(2);
+
+        Assert.False(cursor.Move(PaginationAction.None));
+        Assert.False(cursor.Move(PaginationAction.Stop));
+        Assert.Equal(0, cursor.PageIndex);
+    }
+
+    [Fact]
+    public async Task SessionLifetime_StopCancelsAndObservesExpirationBeforeReleasingSlot()
+    {
+        using var lifetime = new PaginatorSessionLifetime(CancellationToken.None);
+        using var availableSlots = new SemaphoreSlim(0, 1);
+        lifetime.ExpirationTask = WaitForCancellationAsync(lifetime.ExpirationCancellation);
+
+        Assert.True(lifetime.TryBeginCompletion());
+        lifetime.CancelExpiration();
+        await lifetime.ExpirationTask;
+        Assert.False(availableSlots.Wait(0));
+
+        lifetime.ReleaseSlot(availableSlots);
+        Assert.True(availableSlots.Wait(0));
+    }
+
+    [Fact]
+    public async Task SessionLifetime_ShutdownCancelsExpiration()
+    {
+        using var shutdown = new CancellationTokenSource();
+        using var lifetime = new PaginatorSessionLifetime(shutdown.Token);
+        lifetime.ExpirationTask = WaitForCancellationAsync(lifetime.ExpirationCancellation);
+
+        shutdown.Cancel();
+
+        await lifetime.ExpirationTask;
+        Assert.True(lifetime.ExpirationCancellation.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task SessionLifetime_ExpirationRetainsSlotUntilCleanupCompletes()
+    {
+        using var lifetime = new PaginatorSessionLifetime(CancellationToken.None);
+        using var availableSlots = new SemaphoreSlim(0, 1);
+        var cleanupStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowCleanupToComplete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Assert.True(lifetime.TryBeginCompletion());
+        lifetime.ExpirationTask = CompleteCleanupAsync();
+        await cleanupStarted.Task;
+        Assert.False(availableSlots.Wait(0));
+
+        allowCleanupToComplete.SetResult();
+        await lifetime.ExpirationTask;
+        Assert.True(availableSlots.Wait(0));
+
+        async Task CompleteCleanupAsync()
+        {
+            cleanupStarted.SetResult();
+            await allowCleanupToComplete.Task;
+            lifetime.ReleaseSlot(availableSlots);
+        }
+    }
+
+    [Fact]
+    public async Task SessionLifetime_DisposalWaitsForInFlightCleanupSignal()
+    {
+        using var lifetime = new PaginatorSessionLifetime(CancellationToken.None);
+        var cleanupStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowCleanupToComplete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Assert.True(lifetime.TryBeginCompletion());
+        var cleanup = CompleteCleanupAsync();
+        await cleanupStarted.Task;
+        var disposalWait = lifetime.CompletionTask;
+        Assert.False(disposalWait.IsCompleted);
+
+        allowCleanupToComplete.SetResult();
+        await cleanup;
+        await disposalWait;
+
+        async Task CompleteCleanupAsync()
+        {
+            cleanupStarted.SetResult();
+            await allowCleanupToComplete.Task;
+            lifetime.MarkCompletionFinished();
+        }
+    }
+
+    [Fact]
+    public async Task SessionLifetime_LosingStopWaitsForWinningCleanup()
+    {
+        using var lifetime = new PaginatorSessionLifetime(CancellationToken.None);
+        Assert.True(lifetime.TryBeginCompletion());
+
+        var losingStop = WaitAsLosingStopAsync();
+        Assert.False(losingStop.IsCompleted);
+
+        lifetime.MarkCompletionFinished();
+        await losingStop;
+
+        async Task WaitAsLosingStopAsync()
+        {
+            if (!lifetime.TryBeginCompletion())
+            {
+                await lifetime.CompletionTask;
+            }
+        }
+    }
+
+    [Fact]
+    public async Task SessionLifetime_LosingStopReleasesAccessBeforeWaitingForCleanup()
+    {
+        using var lifetime = new PaginatorSessionLifetime(CancellationToken.None);
+        using var access = new SemaphoreSlim(1, 1);
+        Assert.True(lifetime.TryBeginCompletion());
+        await access.WaitAsync();
+
+        var losingStop = WaitAsLosingStopAsync();
+        await access.WaitAsync().WaitAsync(TimeSpan.FromSeconds(1));
+        lifetime.MarkCompletionFinished();
+        access.Release();
+
+        await losingStop.WaitAsync(TimeSpan.FromSeconds(1));
+
+        async Task WaitAsLosingStopAsync()
+        {
+            access.Release();
+            if (!lifetime.TryBeginCompletion())
+            {
+                await lifetime.CompletionTask;
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ReactionRemoval_UsesUserIdForRepeatedControlsWithoutCachedUser()
+    {
+        var message = DispatchProxy.Create<IUserMessage, ReactionRemovalMessageProxy>();
+        var recorder = (ReactionRemovalMessageProxy)message;
+        var control = new Emoji("▶");
+
+        await DiscordPaginatorService.TryRemoveUserReactionAsync(message, control, 42);
+        await DiscordPaginatorService.TryRemoveUserReactionAsync(message, control, 42);
+
+        Assert.Equal(new ulong[] { 42, 42 }, recorder.RemovedUserIds);
+        Assert.All(recorder.RemovedEmotes, emote => Assert.Equal(control, emote));
+    }
+
+    [Fact]
+    public async Task SessionLifetime_RepeatedStopAndSlotReuse_RemainsBounded()
+    {
+        using var availableSlots = new SemaphoreSlim(1, 1);
+
+        for (var iteration = 0; iteration < 256; iteration++)
+        {
+            Assert.True(availableSlots.Wait(0));
+            using var lifetime = new PaginatorSessionLifetime(CancellationToken.None);
+            lifetime.ExpirationTask = WaitForCancellationAsync(lifetime.ExpirationCancellation);
+
+            Assert.True(lifetime.TryBeginCompletion());
+            Assert.False(lifetime.TryBeginCompletion());
+            lifetime.CancelExpiration();
+            await lifetime.ExpirationTask;
+            lifetime.ReleaseSlot(availableSlots);
+            lifetime.ReleaseSlot(availableSlots);
+        }
+
+        Assert.Equal(1, availableSlots.CurrentCount);
+    }
+
+    private static async Task WaitForCancellationAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+    }
+
+    public class ReactionRemovalMessageProxy : DispatchProxy
+    {
+        public List<ulong> RemovedUserIds { get; } = new();
+        public List<IEmote> RemovedEmotes { get; } = new();
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod?.Name == nameof(IMessage.RemoveReactionAsync)
+                && args is [IEmote emote, ulong userId, ..])
+            {
+                RemovedEmotes.Add(emote);
+                RemovedUserIds.Add(userId);
+                return Task.CompletedTask;
+            }
+
+            throw new NotSupportedException(targetMethod?.Name);
+        }
+    }
+}

--- a/BeanBot.Tests/Services/DiscordPaginatorServiceTests.cs
+++ b/BeanBot.Tests/Services/DiscordPaginatorServiceTests.cs
@@ -1,8 +1,10 @@
 using BeanBot.Services;
 
 using Discord;
+using Discord.WebSocket;
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -183,6 +185,37 @@ public class DiscordPaginatorServiceTests
 
         Assert.Equal(new ulong[] { 42, 42 }, recorder.RemovedUserIds);
         Assert.All(recorder.RemovedEmotes, emote => Assert.Equal(control, emote));
+    }
+
+    [Fact]
+    public void ShutdownWait_ReturnsWithinConfiguredBound()
+    {
+        var incompleteShutdown = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var stopwatch = Stopwatch.StartNew();
+
+        var completed = DiscordPaginatorService.WaitForShutdown(
+            incompleteShutdown.Task,
+            TimeSpan.FromMilliseconds(25));
+
+        stopwatch.Stop();
+        Assert.False(completed);
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public void Dispose_DisposesOwnedSlotSemaphore()
+    {
+        using var client = new DiscordSocketClient();
+        var paginator = new DiscordPaginatorService(client);
+        var slotsField = typeof(DiscordPaginatorService).GetField(
+            "_availableSlots",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        var slots = Assert.IsType<SemaphoreSlim>(slotsField?.GetValue(paginator));
+
+        paginator.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => slots.Wait(0));
     }
 
     [Fact]

--- a/BeanBot/BeanBot.csproj
+++ b/BeanBot/BeanBot.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,14 +19,13 @@
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="15.0.5" />
-    <PackageReference Include="Discord.Addons.Interactive" Version="2.0.0" />
-    <PackageReference Include="Discord.Net.Commands" Version="2.2.0" />
-    <PackageReference Include="Discord.Net.Core" Version="2.2.0" />
-    <PackageReference Include="Discord.Net.Rest" Version="2.2.0" />
-    <PackageReference Include="Discord.Net.Webhook" Version="2.2.0" />
-    <PackageReference Include="Discord.Net.WebSocket" Version="2.2.0" />
+    <PackageReference Include="Discord.Net.Commands" Version="3.20.1" />
+    <PackageReference Include="Discord.Net.Core" Version="3.20.1" />
+    <PackageReference Include="Discord.Net.Rest" Version="3.20.1" />
+    <PackageReference Include="Discord.Net.Webhook" Version="3.20.1" />
+    <PackageReference Include="Discord.Net.WebSocket" Version="3.20.1" />
     <PackageReference Include="LQ.MemeApiDotNetWrapper" Version="1.5.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
     <PackageReference Include="MongoDB.Bson" Version="2.30.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.30.0" />
     <PackageReference Include="MongoDB.Driver.Core" Version="2.30.0" />

--- a/BeanBot/EventHandlers/CommandHandler.cs
+++ b/BeanBot/EventHandlers/CommandHandler.cs
@@ -1,4 +1,5 @@
-﻿using BeanBot.Util;
+﻿using BeanBot.Services;
+using BeanBot.Util;
 
 using Discord.Commands;
 using Discord.WebSocket;
@@ -18,6 +19,7 @@ namespace BeanBot.EventHandlers
         private readonly CommandService _commandService;
         private readonly IServiceProvider _services;
         private readonly FortuneAnswerQueue _fortuneAnswers;
+        private readonly DiscordMessageWaiter _messageWaiter;
         private bool _initialized;
 
         public CommandHandler(
@@ -30,6 +32,7 @@ namespace BeanBot.EventHandlers
             _commandService = commandService ?? throw new ArgumentNullException(nameof(commandService));
             _services = services ?? throw new ArgumentNullException(nameof(services));
             _fortuneAnswers = _services.GetRequiredService<FortuneAnswerQueue>();
+            _messageWaiter = _services.GetRequiredService<DiscordMessageWaiter>();
         }
 
         public async Task InitializeCommandsAsync()
@@ -60,6 +63,7 @@ namespace BeanBot.EventHandlers
 
         internal async Task HandleCommandAsync(SocketMessage messageEvent)
         {
+            _messageWaiter.TryPublish(messageEvent);
             var discordMessage = messageEvent as SocketUserMessage;
             if (MessageIsSystemMessage(discordMessage))
             {

--- a/BeanBot/EventHandlers/NewMemberHandler.cs
+++ b/BeanBot/EventHandlers/NewMemberHandler.cs
@@ -38,7 +38,7 @@ namespace BeanBot.EventHandlers
 
             try
             {
-                var userDmChannel = await user.GetOrCreateDMChannelAsync();
+                var userDmChannel = await user.CreateDMChannelAsync();
                 await userDmChannel.SendMessageAsync("Please read the rules in the Eli's Charter channel. If you agree to these rules and are over the age of 17, please DM one of the moderators with the blue role \"Student Council\" (i.e discount Hatate/Makoto Kikuchi#2351) for full access to the server! (I promise it's worth it)");
                 Log.Debug("Sent the welcome message to {UserId}", user.Id);
             }

--- a/BeanBot/Modules/AdministrativeModule.cs
+++ b/BeanBot/Modules/AdministrativeModule.cs
@@ -15,6 +15,18 @@ namespace BeanBot.Modules
     [Name("Administrative Commands")]
     public class AdministrativeModule : ModuleBase<SocketCommandContext>
     {
+        internal enum RoleResolutionStatus
+        {
+            Resolved,
+            NotFound,
+            MultipleMentions,
+            AmbiguousName
+        }
+
+        internal readonly record struct RoleCandidate(ulong Id, string Name);
+
+        internal readonly record struct RoleResolution(RoleResolutionStatus Status, ulong? RoleId);
+
         private const int MaximumRolesPerGroup = 25;
         private static readonly TimeSpan InteractionTimeout = TimeSpan.FromSeconds(60);
         private readonly RoleReactService _roleReactService;
@@ -160,15 +172,73 @@ namespace BeanBot.Modules
             }
 
             messages.Add(response);
-            var role = Context.Guild.Roles.FirstOrDefault(candidate =>
-                string.Equals(response.Content.Trim(), candidate.Name.Trim(), StringComparison.OrdinalIgnoreCase));
-            if (role == null)
+            var availableRoles = Context.Guild.Roles.ToList();
+            var roleResolution = ResolveRole(
+                response.Content,
+                response.MentionedRoleIds,
+                availableRoles.Select(role => new RoleCandidate(role.Id, role.Name)));
+
+            if (roleResolution.Status == RoleResolutionStatus.MultipleMentions)
+            {
+                messages.Add(await ReplyAsync("Please mention only one role. Please start again."));
+                return null;
+            }
+
+            if (roleResolution.Status == RoleResolutionStatus.AmbiguousName)
+            {
+                messages.Add(await ReplyAsync("Multiple roles have that name. Please mention the role you want and start again."));
+                return null;
+            }
+
+            if (roleResolution.Status == RoleResolutionStatus.NotFound)
             {
                 messages.Add(await ReplyAsync($"The role {response.Content} does not exist. Please start again."));
                 return null;
             }
 
-            return role;
+            return availableRoles.Single(role => role.Id == roleResolution.RoleId);
+        }
+
+        internal static RoleResolution ResolveRole(
+            string roleName,
+            IEnumerable<ulong> mentionedRoleIds,
+            IEnumerable<RoleCandidate> availableRoles)
+        {
+            var roleCandidates = availableRoles.ToList();
+            var distinctMentionedRoleIds = mentionedRoleIds.Distinct().Take(2).ToList();
+            if (distinctMentionedRoleIds.Count > 1)
+            {
+                return new RoleResolution(RoleResolutionStatus.MultipleMentions, null);
+            }
+
+            if (distinctMentionedRoleIds.Count == 1)
+            {
+                var mentionedRoleId = distinctMentionedRoleIds[0];
+                return roleCandidates.Any(candidate => candidate.Id == mentionedRoleId)
+                    ? new RoleResolution(RoleResolutionStatus.Resolved, mentionedRoleId)
+                    : new RoleResolution(RoleResolutionStatus.NotFound, null);
+            }
+
+            if (string.IsNullOrWhiteSpace(roleName))
+            {
+                return new RoleResolution(RoleResolutionStatus.NotFound, null);
+            }
+
+            var normalizedRoleName = roleName.Trim();
+            var matchingRoles = roleCandidates
+                .Where(candidate => string.Equals(
+                    normalizedRoleName,
+                    candidate.Name.Trim(),
+                    StringComparison.OrdinalIgnoreCase))
+                .Take(2)
+                .ToList();
+
+            return matchingRoles.Count switch
+            {
+                1 => new RoleResolution(RoleResolutionStatus.Resolved, matchingRoles[0].Id),
+                > 1 => new RoleResolution(RoleResolutionStatus.AmbiguousName, null),
+                _ => new RoleResolution(RoleResolutionStatus.NotFound, null)
+            };
         }
 
         private async Task<Emote> GetEmoteAsync(List<IMessage> messages, SocketMessage response)

--- a/BeanBot/Modules/AdministrativeModule.cs
+++ b/BeanBot/Modules/AdministrativeModule.cs
@@ -2,7 +2,6 @@ using BeanBot.Attributes;
 using BeanBot.Entities;
 using BeanBot.Services;
 using Discord;
-using Discord.Addons.Interactive;
 using Discord.Commands;
 using Discord.WebSocket;
 using Serilog;
@@ -14,19 +13,22 @@ using System.Threading.Tasks;
 namespace BeanBot.Modules
 {
     [Name("Administrative Commands")]
-    public class AdministrativeModule : InteractiveBase
+    public class AdministrativeModule : ModuleBase<SocketCommandContext>
     {
         private const int MaximumRolesPerGroup = 25;
         private static readonly TimeSpan InteractionTimeout = TimeSpan.FromSeconds(60);
         private readonly RoleReactService _roleReactService;
         private readonly DiscordMessageCleanupService _messageCleanupService;
+        private readonly DiscordMessageWaiter _messageWaiter;
 
         public AdministrativeModule(
             RoleReactService roleReactService,
-            DiscordMessageCleanupService messageCleanupService)
+            DiscordMessageCleanupService messageCleanupService,
+            DiscordMessageWaiter messageWaiter)
         {
             _roleReactService = roleReactService ?? throw new ArgumentNullException(nameof(roleReactService));
             _messageCleanupService = messageCleanupService ?? throw new ArgumentNullException(nameof(messageCleanupService));
+            _messageWaiter = messageWaiter ?? throw new ArgumentNullException(nameof(messageWaiter));
         }
 
         [Command("role setting", RunMode = RunMode.Async)]
@@ -45,7 +47,7 @@ namespace BeanBot.Modules
             {
                 var roleEmotePairs = new List<RoleEmotePair>();
                 messagesInInteraction.Add(await ReplyAsync($"How many roles do you wish to configure? (1-{MaximumRolesPerGroup})"));
-                var amountMessage = await NextMessageAsync(timeout: InteractionTimeout);
+                var amountMessage = await _messageWaiter.WaitForNextMessageAsync(Context, InteractionTimeout);
                 var roleCountResult = await GetRoleCountAsync(messagesInInteraction, amountMessage);
                 if (!roleCountResult.Success)
                 {
@@ -55,7 +57,7 @@ namespace BeanBot.Modules
                 for (var index = 0; index < roleCountResult.RoleCount; index++)
                 {
                     messagesInInteraction.Add(await ReplyAsync("Which role would you like to set up?"));
-                    var roleMessage = await NextMessageAsync(timeout: InteractionTimeout);
+                    var roleMessage = await _messageWaiter.WaitForNextMessageAsync(Context, InteractionTimeout);
                     var role = await GetRoleAsync(messagesInInteraction, roleMessage);
                     if (role == null)
                     {
@@ -63,7 +65,7 @@ namespace BeanBot.Modules
                     }
 
                     messagesInInteraction.Add(await ReplyAsync($"Which emote would you like to set up with the role {role.Name}?"));
-                    var emoteMessage = await NextMessageAsync(timeout: InteractionTimeout);
+                    var emoteMessage = await _messageWaiter.WaitForNextMessageAsync(Context, InteractionTimeout);
                     var emote = await GetEmoteAsync(messagesInInteraction, emoteMessage);
                     if (emote == null)
                     {
@@ -80,7 +82,7 @@ namespace BeanBot.Modules
                 }
 
                 messagesInInteraction.Add(await ReplyAsync("Please label this group of roles (i.e. Games, Position, NSFW, etc)."));
-                var labelMessage = await NextMessageAsync(timeout: InteractionTimeout);
+                var labelMessage = await _messageWaiter.WaitForNextMessageAsync(Context, InteractionTimeout);
                 if (labelMessage == null)
                 {
                     messagesInInteraction.Add(await ReplyAsync("Time has expired, please try again."));

--- a/BeanBot/Modules/MemeModule.cs
+++ b/BeanBot/Modules/MemeModule.cs
@@ -1,10 +1,11 @@
 ﻿using BeanBot.Entities;
 using BeanBot.Configuration;
+using BeanBot.Services;
 using BeanBot.Util;
 using CsvHelper;
 using Discord;
-using Discord.Addons.Interactive;
 using Discord.Commands;
+using Discord.WebSocket;
 using MemeApiDotNetWrapper;
 using Serilog;
 using System;
@@ -18,17 +19,22 @@ using System.Threading.Tasks;
 namespace BeanBot.Modules
 {
     [Name("Meme Commands")]
-    public class MemeModule : InteractiveBase
+    public class MemeModule : ModuleBase<SocketCommandContext>
     {
         private static readonly HttpClient HttpClient = new HttpClient();
         private readonly MemeMachine _memeMachine = new MemeMachine();
         private readonly BeanBotOptions _options;
         private readonly FortuneAnswerQueue _fortuneAnswers;
+        private readonly DiscordPaginatorService _paginator;
 
-        public MemeModule(BeanBotOptions options, FortuneAnswerQueue fortuneAnswers)
+        public MemeModule(
+            BeanBotOptions options,
+            FortuneAnswerQueue fortuneAnswers,
+            DiscordPaginatorService paginator)
         {
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _fortuneAnswers = fortuneAnswers ?? throw new ArgumentNullException(nameof(fortuneAnswers));
+            _paginator = paginator ?? throw new ArgumentNullException(nameof(paginator));
         }
 
         private static readonly string[] EightBallResponses = new string[8]
@@ -370,7 +376,7 @@ namespace BeanBot.Modules
         private async Task ReplyWithOchoOcho()
         {
             var pages = new[] { "One plus one, equals two.", "Two plus two, equals four.", "Four plus four, equals eight.", "Doblehin ang eight.", "Tayo'y mag ocho ocho, ocho ocho, mag ocho ocho pa" };
-            await PagedReplyAsync(pages);
+            await _paginator.SendAsync(Context, pages);
         }
     }
 }

--- a/BeanBot/Program.cs
+++ b/BeanBot/Program.cs
@@ -201,7 +201,8 @@ namespace BeanBot
                 .AddSingleton(_commandService)
                 .AddSingleton(database)
                 .AddSingleton<FortuneAnswerQueue>()
-                .AddSingleton(new Discord.Addons.Interactive.InteractiveService(_discordClient))
+                .AddSingleton<DiscordMessageWaiter>()
+                .AddSingleton<DiscordPaginatorService>()
                 .AddSingleton<RoleReactRepository>()
                 .AddSingleton<RoleReactService>()
                 .AddSingleton<DiscordMessageCleanupService>()
@@ -245,13 +246,25 @@ namespace BeanBot
 
         private void CreateNewDiscordSocketClientWithConfigurations()
         {
-            _discordClient = new DiscordSocketClient(new DiscordSocketConfig
+            _discordClient = new DiscordSocketClient(CreateDiscordSocketConfig());
+        }
+
+        internal static DiscordSocketConfig CreateDiscordSocketConfig()
+        {
+            return new DiscordSocketConfig
             {
                 LogLevel = LogSeverity.Verbose,
                 MessageCacheSize = 50,
-                ExclusiveBulkDelete = true,
-                AlwaysDownloadUsers = false
-            });
+                AlwaysDownloadUsers = false,
+                GatewayIntents = GatewayIntents.Guilds
+                    | GatewayIntents.GuildMembers
+                    | GatewayIntents.GuildEmojis
+                    | GatewayIntents.GuildMessages
+                    | GatewayIntents.DirectMessages
+                    | GatewayIntents.GuildMessageReactions
+                    | GatewayIntents.DirectMessageReactions
+                    | GatewayIntents.MessageContent
+            };
         }
 
         private void InitializeDiscordLifecycleTracking()

--- a/BeanBot/Services/DiscordMessageWaiter.cs
+++ b/BeanBot/Services/DiscordMessageWaiter.cs
@@ -1,0 +1,175 @@
+using Discord.Commands;
+using Discord.WebSocket;
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BeanBot.Services
+{
+    public sealed class DiscordMessageWaiter : IDisposable
+    {
+        internal const int MaximumPendingWaits = 64;
+        private readonly BoundedMessageWaiter<SocketMessage> _waiter = new(MaximumPendingWaits);
+
+        public Task<SocketMessage> WaitForNextMessageAsync(
+            SocketCommandContext context,
+            TimeSpan timeout,
+            CancellationToken cancellationToken = default)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            return _waiter.WaitAsync(
+                context.User.Id,
+                context.Channel.Id,
+                timeout,
+                cancellationToken);
+        }
+
+        public bool TryPublish(SocketMessage message)
+        {
+            if (message == null)
+            {
+                return false;
+            }
+
+            return _waiter.TryPublish(
+                message.Author.Id,
+                message.Channel.Id,
+                message.Author.IsBot,
+                message);
+        }
+
+        public void Dispose() => _waiter.Dispose();
+    }
+
+    internal sealed class BoundedMessageWaiter<TMessage> : IDisposable
+    {
+        private readonly ConcurrentDictionary<MessageWaitKey, PendingWait> _pending = new();
+        private readonly SemaphoreSlim _availableSlots;
+        private readonly object _syncRoot = new();
+        private int _disposed;
+
+        public BoundedMessageWaiter(int maximumPendingWaits)
+        {
+            if (maximumPendingWaits <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maximumPendingWaits));
+            }
+
+            _availableSlots = new SemaphoreSlim(maximumPendingWaits, maximumPendingWaits);
+        }
+
+        internal int PendingCount => _pending.Count;
+
+        public async Task<TMessage> WaitAsync(
+            ulong userId,
+            ulong channelId,
+            TimeSpan timeout,
+            CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+            if (timeout <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(timeout));
+            }
+
+            if (!_availableSlots.Wait(0))
+            {
+                throw new InvalidOperationException("Too many Discord message waits are already active.");
+            }
+
+            var key = new MessageWaitKey(userId, channelId);
+            var pending = new PendingWait();
+            lock (_syncRoot)
+            {
+                if (Volatile.Read(ref _disposed) != 0)
+                {
+                    _availableSlots.Release();
+                    throw new ObjectDisposedException(nameof(BoundedMessageWaiter<TMessage>));
+                }
+
+                if (!_pending.TryAdd(key, pending))
+                {
+                    _availableSlots.Release();
+                    throw new InvalidOperationException("A Discord message wait is already active for this user and channel.");
+                }
+            }
+
+            try
+            {
+                try
+                {
+                    return await pending.Completion.Task.WaitAsync(timeout, cancellationToken);
+                }
+                catch (TimeoutException)
+                {
+                    return default;
+                }
+            }
+            finally
+            {
+                RemovePendingWait(key, pending);
+                _availableSlots.Release();
+            }
+        }
+
+        public bool TryPublish(
+            ulong userId,
+            ulong channelId,
+            bool isBot,
+            TMessage message)
+        {
+            if (isBot || Volatile.Read(ref _disposed) != 0)
+            {
+                return false;
+            }
+
+            return _pending.TryGetValue(new MessageWaitKey(userId, channelId), out var pending)
+                && pending.Completion.TrySetResult(message);
+        }
+
+        public void Dispose()
+        {
+            lock (_syncRoot)
+            {
+                if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                {
+                    return;
+                }
+
+                foreach (var pending in _pending.Values)
+                {
+                    pending.Completion.TrySetException(new ObjectDisposedException(nameof(BoundedMessageWaiter<TMessage>)));
+                }
+            }
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (Volatile.Read(ref _disposed) != 0)
+            {
+                throw new ObjectDisposedException(nameof(BoundedMessageWaiter<TMessage>));
+            }
+        }
+
+        private void RemovePendingWait(MessageWaitKey key, PendingWait pending)
+        {
+            var pair = new KeyValuePair<MessageWaitKey, PendingWait>(key, pending);
+            ((ICollection<KeyValuePair<MessageWaitKey, PendingWait>>)_pending).Remove(pair);
+        }
+
+        private readonly record struct MessageWaitKey(ulong UserId, ulong ChannelId);
+
+        private sealed class PendingWait
+        {
+            public TaskCompletionSource<TMessage> Completion { get; } = new(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+    }
+}

--- a/BeanBot/Services/DiscordPaginatorService.cs
+++ b/BeanBot/Services/DiscordPaginatorService.cs
@@ -17,6 +17,7 @@ namespace BeanBot.Services
     {
         internal const int MaximumActivePaginators = 64;
         internal static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(5);
+        internal static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(5);
         private static readonly Emoji FirstPage = new("⏮");
         private static readonly Emoji PreviousPage = new("◀");
         private static readonly Emoji NextPage = new("▶");
@@ -68,9 +69,13 @@ namespace BeanBot.Services
                 throw new ArgumentOutOfRangeException(nameof(timeout));
             }
 
-            if (!_availableSlots.Wait(0))
+            lock (_syncRoot)
             {
-                throw new InvalidOperationException("Too many Discord paginators are already active.");
+                ThrowIfDisposed();
+                if (!_availableSlots.Wait(0))
+                {
+                    throw new InvalidOperationException("Too many Discord paginators are already active.");
+                }
             }
 
             IUserMessage message = null;
@@ -80,7 +85,9 @@ namespace BeanBot.Services
             try
             {
                 var cursor = new PaginationCursor(pageList.Count);
-                message = await context.Channel.SendMessageAsync(embed: BuildEmbed(pageList, cursor));
+                message = await context.Channel.SendMessageAsync(
+                    embed: BuildEmbed(pageList, cursor),
+                    options: CreateRequestOptions(_shutdown.Token));
                 session = new PaginationSession(message, context.User.Id, pageList, cursor, _shutdown.Token);
                 await session.Access.WaitAsync();
                 sessionAccessHeld = true;
@@ -97,7 +104,7 @@ namespace BeanBot.Services
 
                 foreach (var control in Controls)
                 {
-                    await message.AddReactionAsync(control);
+                    await message.AddReactionAsync(control, CreateRequestOptions(_shutdown.Token));
                 }
 
                 if (!_sessions.TryGetValue(message.Id, out var currentSession)
@@ -113,7 +120,7 @@ namespace BeanBot.Services
             {
                 if (!sessionRegistered)
                 {
-                    _availableSlots.Release();
+                    ReleaseAvailableSlot();
                 }
                 else
                 {
@@ -177,13 +184,15 @@ namespace BeanBot.Services
                         if (session.Cursor.Move(action))
                         {
                             await session.Message.ModifyAsync(
-                                properties => properties.Embed = BuildEmbed(session.Pages, session.Cursor));
+                                properties => properties.Embed = BuildEmbed(session.Pages, session.Cursor),
+                                options: CreateRequestOptions(_shutdown.Token));
                         }
 
                         await TryRemoveUserReactionAsync(
                             session.Message,
                             reaction.Emote,
-                            reaction.UserId);
+                            reaction.UserId,
+                            _shutdown.Token);
                     }
                 }
                 finally
@@ -243,7 +252,10 @@ namespace BeanBot.Services
 
                     try
                     {
-                        await session.Message.RemoveReactionAsync(control, currentUser);
+                        await session.Message.RemoveReactionAsync(
+                            control,
+                            currentUser,
+                            CreateRequestOptions(expirationCancellation));
                     }
                     catch (Exception exception)
                     {
@@ -291,7 +303,7 @@ namespace BeanBot.Services
                 await session.ExpirationTask;
                 if (deleteMessage && !_shutdown.IsCancellationRequested)
                 {
-                    await session.Message.DeleteAsync();
+                    await session.Message.DeleteAsync(CreateRequestOptions(_shutdown.Token));
                 }
             }
             finally
@@ -303,11 +315,15 @@ namespace BeanBot.Services
         internal static async Task TryRemoveUserReactionAsync(
             IUserMessage message,
             IEmote emote,
-            ulong userId)
+            ulong userId,
+            CancellationToken cancellationToken = default)
         {
             try
             {
-                await message.RemoveReactionAsync(emote, userId);
+                await message.RemoveReactionAsync(
+                    emote,
+                    userId,
+                    CreateRequestOptions(cancellationToken));
             }
             catch (Exception exception)
             {
@@ -327,7 +343,7 @@ namespace BeanBot.Services
             try
             {
                 RemoveSession(messageId, session);
-                session.ReleaseSlot(_availableSlots);
+                ReleaseAvailableSlot(session);
                 session.Dispose();
             }
             finally
@@ -335,6 +351,27 @@ namespace BeanBot.Services
                 session.MarkCompletionFinished();
             }
         }
+
+        private void ReleaseAvailableSlot(PaginationSession session = null)
+        {
+            lock (_syncRoot)
+            {
+                if (Volatile.Read(ref _disposed) == 0)
+                {
+                    if (session == null)
+                    {
+                        _availableSlots.Release();
+                    }
+                    else
+                    {
+                        session.ReleaseSlot(_availableSlots);
+                    }
+                }
+            }
+        }
+
+        private static RequestOptions CreateRequestOptions(CancellationToken cancellationToken)
+            => new() { CancelToken = cancellationToken };
 
         private static PaginationAction GetAction(IEmote emote)
         {
@@ -354,8 +391,7 @@ namespace BeanBot.Services
 
         public void Dispose()
         {
-            List<Task> inFlightCompletions;
-            List<KeyValuePair<ulong, PaginationSession>> ownedSessions;
+            List<Task> shutdownTasks;
             lock (_syncRoot)
             {
                 if (Interlocked.Exchange(ref _disposed, 1) != 0)
@@ -365,37 +401,79 @@ namespace BeanBot.Services
 
                 _discordClient.ReactionAdded -= HandleReactionAsync;
                 _shutdown.Cancel();
-                inFlightCompletions = new List<Task>(_sessions.Count);
-                ownedSessions = new List<KeyValuePair<ulong, PaginationSession>>(_sessions.Count);
+                shutdownTasks = new List<Task>(_sessions.Count);
                 foreach (var session in _sessions)
                 {
                     session.Value.CancelExpiration();
                     if (session.Value.TryBeginCompletion())
                     {
-                        ownedSessions.Add(session);
+                        shutdownTasks.Add(CompleteOwnedSessionAsync(session.Key, session.Value));
                     }
                     else
                     {
-                        inFlightCompletions.Add(session.Value.CompletionTask);
+                        shutdownTasks.Add(session.Value.CompletionTask);
                     }
                 }
+
+                _availableSlots.Dispose();
             }
 
-            foreach (var session in ownedSessions)
+            var shutdown = Task.WhenAll(shutdownTasks);
+            try
             {
-                session.Value.ExpirationTask.GetAwaiter().GetResult();
-                session.Value.Access.Wait();
-                try
+                if (WaitForShutdown(shutdown, ShutdownTimeout))
                 {
-                    CompleteSession(session.Key, session.Value);
+                    _shutdown.Dispose();
+                    return;
                 }
-                finally
-                {
-                    session.Value.Access.Release();
-                }
+
+                Log.Warning(
+                    "Discord paginator shutdown exceeded {Timeout}; cleanup will finish in the background",
+                    ShutdownTimeout);
             }
-            Task.WhenAll(inFlightCompletions).GetAwaiter().GetResult();
-            _shutdown.Dispose();
+            catch (Exception exception)
+            {
+                Log.Warning(exception, "Discord paginator shutdown encountered a cleanup failure");
+                _shutdown.Dispose();
+                return;
+            }
+
+            _ = ObserveDeferredShutdownAsync(shutdown);
+        }
+
+        internal static bool WaitForShutdown(Task shutdown, TimeSpan timeout)
+            => shutdown.Wait(timeout);
+
+        private async Task CompleteOwnedSessionAsync(
+            ulong messageId,
+            PaginationSession session)
+        {
+            await session.ExpirationTask;
+            await session.Access.WaitAsync();
+            try
+            {
+                CompleteSession(messageId, session);
+            }
+            finally
+            {
+                session.Access.Release();
+            }
+        }
+
+        private async Task ObserveDeferredShutdownAsync(Task shutdown)
+        {
+            try
+            {
+                await shutdown;
+            }
+            catch (Exception exception)
+            {
+                Log.Warning(exception, "Deferred Discord paginator cleanup failed");
+            }
+            finally
+            {
+                _shutdown.Dispose();
+            }
         }
 
         private void ThrowIfDisposed()

--- a/BeanBot/Services/DiscordPaginatorService.cs
+++ b/BeanBot/Services/DiscordPaginatorService.cs
@@ -1,0 +1,540 @@
+using Discord;
+using Discord.Commands;
+using Discord.WebSocket;
+
+using Serilog;
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BeanBot.Services
+{
+    public sealed class DiscordPaginatorService : IDisposable
+    {
+        internal const int MaximumActivePaginators = 64;
+        internal static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(5);
+        private static readonly Emoji FirstPage = new("⏮");
+        private static readonly Emoji PreviousPage = new("◀");
+        private static readonly Emoji NextPage = new("▶");
+        private static readonly Emoji LastPage = new("⏭");
+        private static readonly Emoji Stop = new("⏹");
+        private static readonly IReadOnlyCollection<IEmote> Controls = new IEmote[]
+        {
+            FirstPage,
+            PreviousPage,
+            NextPage,
+            LastPage,
+            Stop
+        };
+
+        private readonly DiscordSocketClient _discordClient;
+        private readonly ConcurrentDictionary<ulong, PaginationSession> _sessions = new();
+        private readonly SemaphoreSlim _availableSlots = new(MaximumActivePaginators, MaximumActivePaginators);
+        private readonly CancellationTokenSource _shutdown = new();
+        private readonly object _syncRoot = new();
+        private int _disposed;
+
+        public DiscordPaginatorService(DiscordSocketClient discordClient)
+        {
+            _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
+            _discordClient.ReactionAdded += HandleReactionAsync;
+        }
+
+        public async Task<IUserMessage> SendAsync(
+            SocketCommandContext context,
+            IReadOnlyCollection<string> pages,
+            TimeSpan? timeout = null)
+        {
+            ThrowIfDisposed();
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var pageList = pages?.Where(page => page != null).ToList()
+                ?? throw new ArgumentNullException(nameof(pages));
+            if (pageList.Count == 0)
+            {
+                throw new ArgumentException("At least one pagination page is required.", nameof(pages));
+            }
+
+            var paginationTimeout = timeout ?? DefaultTimeout;
+            if (paginationTimeout <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(timeout));
+            }
+
+            if (!_availableSlots.Wait(0))
+            {
+                throw new InvalidOperationException("Too many Discord paginators are already active.");
+            }
+
+            IUserMessage message = null;
+            PaginationSession session = null;
+            var sessionRegistered = false;
+            var sessionAccessHeld = false;
+            try
+            {
+                var cursor = new PaginationCursor(pageList.Count);
+                message = await context.Channel.SendMessageAsync(embed: BuildEmbed(pageList, cursor));
+                session = new PaginationSession(message, context.User.Id, pageList, cursor, _shutdown.Token);
+                await session.Access.WaitAsync();
+                sessionAccessHeld = true;
+                lock (_syncRoot)
+                {
+                    ThrowIfDisposed();
+                    if (!_sessions.TryAdd(message.Id, session))
+                    {
+                        throw new InvalidOperationException("The Discord paginator message is already registered.");
+                    }
+                    sessionRegistered = true;
+                    session.ExpirationTask = ExpireAsync(message.Id, session, paginationTimeout);
+                }
+
+                foreach (var control in Controls)
+                {
+                    await message.AddReactionAsync(control);
+                }
+
+                if (!_sessions.TryGetValue(message.Id, out var currentSession)
+                    || !ReferenceEquals(currentSession, session)
+                    || session.CompletionStarted)
+                {
+                    throw new ObjectDisposedException(nameof(DiscordPaginatorService));
+                }
+
+                return message;
+            }
+            catch
+            {
+                if (!sessionRegistered)
+                {
+                    _availableSlots.Release();
+                }
+                else
+                {
+                    if (sessionAccessHeld)
+                    {
+                        session.Access.Release();
+                        sessionAccessHeld = false;
+                    }
+                    await StopSessionAsync(message.Id, session, deleteMessage: false);
+                }
+
+                throw;
+            }
+            finally
+            {
+                if (sessionAccessHeld)
+                {
+                    session.Access.Release();
+                }
+            }
+        }
+
+        private async Task HandleReactionAsync(
+            Cacheable<IUserMessage, ulong> message,
+            Cacheable<IMessageChannel, ulong> channel,
+            SocketReaction reaction)
+        {
+            if (Volatile.Read(ref _disposed) != 0
+                || reaction.UserId == _discordClient.CurrentUser?.Id
+                || !_sessions.TryGetValue(message.Id, out var session)
+                || reaction.UserId != session.UserId)
+            {
+                return;
+            }
+
+            var action = GetAction(reaction.Emote);
+            if (action == PaginationAction.None)
+            {
+                return;
+            }
+
+            try
+            {
+                var stopRequested = false;
+                await session.Access.WaitAsync(_shutdown.Token);
+                try
+                {
+                    if (!_sessions.TryGetValue(message.Id, out var currentSession)
+                        || !ReferenceEquals(currentSession, session)
+                        || session.CompletionStarted)
+                    {
+                        return;
+                    }
+
+                    if (action == PaginationAction.Stop)
+                    {
+                        stopRequested = true;
+                    }
+                    else
+                    {
+                        if (session.Cursor.Move(action))
+                        {
+                            await session.Message.ModifyAsync(
+                                properties => properties.Embed = BuildEmbed(session.Pages, session.Cursor));
+                        }
+
+                        await TryRemoveUserReactionAsync(
+                            session.Message,
+                            reaction.Emote,
+                            reaction.UserId);
+                    }
+                }
+                finally
+                {
+                    session.Access.Release();
+                }
+
+                if (stopRequested)
+                {
+                    await StopSessionAsync(message.Id, session, deleteMessage: true);
+                }
+            }
+            catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
+            {
+            }
+            catch (Exception exception)
+            {
+                Log.Warning(
+                    exception,
+                    "Could not process Discord paginator reaction for message {MessageId}",
+                    message.Id);
+            }
+        }
+
+        private async Task ExpireAsync(
+            ulong messageId,
+            PaginationSession session,
+            TimeSpan timeout)
+        {
+            var ownsCompletion = false;
+            var ownsAccess = false;
+            var expirationCancellation = session.ExpirationCancellation;
+            try
+            {
+                await Task.Delay(timeout, expirationCancellation);
+                if (!session.TryBeginCompletion())
+                {
+                    return;
+                }
+
+                ownsCompletion = true;
+                await session.Access.WaitAsync();
+                ownsAccess = true;
+
+                var currentUser = _discordClient.CurrentUser;
+                if (currentUser == null)
+                {
+                    return;
+                }
+
+                foreach (var control in Controls)
+                {
+                    if (_shutdown.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
+                    try
+                    {
+                        await session.Message.RemoveReactionAsync(control, currentUser);
+                    }
+                    catch (Exception exception)
+                    {
+                        Log.Debug(
+                            exception,
+                            "Could not remove expired paginator control from message {MessageId}",
+                            messageId);
+                    }
+                }
+            }
+            catch (OperationCanceledException) when (expirationCancellation.IsCancellationRequested)
+            {
+            }
+            catch (Exception exception)
+            {
+                Log.Warning(exception, "Discord paginator expiration failed for message {MessageId}", messageId);
+            }
+            finally
+            {
+                if (ownsCompletion)
+                {
+                    if (ownsAccess)
+                    {
+                        session.Access.Release();
+                    }
+                    CompleteSession(messageId, session);
+                }
+            }
+        }
+
+        private async Task StopSessionAsync(
+            ulong messageId,
+            PaginationSession session,
+            bool deleteMessage)
+        {
+            if (!session.TryBeginCompletion())
+            {
+                await session.CompletionTask;
+                return;
+            }
+
+            session.CancelExpiration();
+            try
+            {
+                await session.ExpirationTask;
+                if (deleteMessage && !_shutdown.IsCancellationRequested)
+                {
+                    await session.Message.DeleteAsync();
+                }
+            }
+            finally
+            {
+                CompleteSession(messageId, session);
+            }
+        }
+
+        internal static async Task TryRemoveUserReactionAsync(
+            IUserMessage message,
+            IEmote emote,
+            ulong userId)
+        {
+            try
+            {
+                await message.RemoveReactionAsync(emote, userId);
+            }
+            catch (Exception exception)
+            {
+                Log.Debug(
+                    exception,
+                    "Could not remove paginator reaction from user {UserId}",
+                    userId);
+            }
+        }
+
+        private bool RemoveSession(ulong messageId, PaginationSession session)
+            => ((ICollection<KeyValuePair<ulong, PaginationSession>>)_sessions)
+                .Remove(new KeyValuePair<ulong, PaginationSession>(messageId, session));
+
+        private void CompleteSession(ulong messageId, PaginationSession session)
+        {
+            try
+            {
+                RemoveSession(messageId, session);
+                session.ReleaseSlot(_availableSlots);
+                session.Dispose();
+            }
+            finally
+            {
+                session.MarkCompletionFinished();
+            }
+        }
+
+        private static PaginationAction GetAction(IEmote emote)
+        {
+            if (emote.Equals(FirstPage)) return PaginationAction.First;
+            if (emote.Equals(PreviousPage)) return PaginationAction.Previous;
+            if (emote.Equals(NextPage)) return PaginationAction.Next;
+            if (emote.Equals(LastPage)) return PaginationAction.Last;
+            if (emote.Equals(Stop)) return PaginationAction.Stop;
+            return PaginationAction.None;
+        }
+
+        private static Embed BuildEmbed(IReadOnlyList<string> pages, PaginationCursor cursor)
+            => new EmbedBuilder()
+                .WithDescription(pages[cursor.PageIndex])
+                .WithFooter($"Page {cursor.PageIndex + 1}/{cursor.PageCount}")
+                .Build();
+
+        public void Dispose()
+        {
+            List<Task> inFlightCompletions;
+            List<KeyValuePair<ulong, PaginationSession>> ownedSessions;
+            lock (_syncRoot)
+            {
+                if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                {
+                    return;
+                }
+
+                _discordClient.ReactionAdded -= HandleReactionAsync;
+                _shutdown.Cancel();
+                inFlightCompletions = new List<Task>(_sessions.Count);
+                ownedSessions = new List<KeyValuePair<ulong, PaginationSession>>(_sessions.Count);
+                foreach (var session in _sessions)
+                {
+                    session.Value.CancelExpiration();
+                    if (session.Value.TryBeginCompletion())
+                    {
+                        ownedSessions.Add(session);
+                    }
+                    else
+                    {
+                        inFlightCompletions.Add(session.Value.CompletionTask);
+                    }
+                }
+            }
+
+            foreach (var session in ownedSessions)
+            {
+                session.Value.ExpirationTask.GetAwaiter().GetResult();
+                session.Value.Access.Wait();
+                try
+                {
+                    CompleteSession(session.Key, session.Value);
+                }
+                finally
+                {
+                    session.Value.Access.Release();
+                }
+            }
+            Task.WhenAll(inFlightCompletions).GetAwaiter().GetResult();
+            _shutdown.Dispose();
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (Volatile.Read(ref _disposed) != 0)
+            {
+                throw new ObjectDisposedException(nameof(DiscordPaginatorService));
+            }
+        }
+
+        private sealed class PaginationSession
+        {
+            public PaginationSession(
+                IUserMessage message,
+                ulong userId,
+                IReadOnlyList<string> pages,
+                PaginationCursor cursor,
+                CancellationToken shutdownCancellation)
+            {
+                Message = message;
+                UserId = userId;
+                Pages = pages;
+                Cursor = cursor;
+                Lifetime = new PaginatorSessionLifetime(shutdownCancellation);
+            }
+
+            public IUserMessage Message { get; }
+            public ulong UserId { get; }
+            public IReadOnlyList<string> Pages { get; }
+            public PaginationCursor Cursor { get; }
+            public SemaphoreSlim Access { get; } = new(1, 1);
+            public PaginatorSessionLifetime Lifetime { get; }
+            public Task ExpirationTask
+            {
+                get => Lifetime.ExpirationTask;
+                set => Lifetime.ExpirationTask = value;
+            }
+            public CancellationToken ExpirationCancellation => Lifetime.ExpirationCancellation;
+            public bool CompletionStarted => Lifetime.CompletionStarted;
+            public Task CompletionTask => Lifetime.CompletionTask;
+
+            public bool TryBeginCompletion()
+                => Lifetime.TryBeginCompletion();
+
+            public void CancelExpiration() => Lifetime.CancelExpiration();
+
+            public void ReleaseSlot(SemaphoreSlim availableSlots)
+                => Lifetime.ReleaseSlot(availableSlots);
+
+            public void MarkCompletionFinished() => Lifetime.MarkCompletionFinished();
+
+            public void Dispose()
+            {
+                Lifetime.Dispose();
+            }
+        }
+    }
+
+    internal sealed class PaginatorSessionLifetime : IDisposable
+    {
+        private readonly CancellationTokenSource _expiration;
+        private readonly TaskCompletionSource _completion = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _completionStarted;
+        private int _slotReleased;
+
+        public PaginatorSessionLifetime(CancellationToken shutdownCancellation)
+        {
+            _expiration = CancellationTokenSource.CreateLinkedTokenSource(shutdownCancellation);
+        }
+
+        public Task ExpirationTask { get; set; } = Task.CompletedTask;
+        public CancellationToken ExpirationCancellation => _expiration.Token;
+        public bool CompletionStarted => Volatile.Read(ref _completionStarted) != 0;
+        public Task CompletionTask => _completion.Task;
+
+        public bool TryBeginCompletion()
+            => Interlocked.CompareExchange(ref _completionStarted, 1, 0) == 0;
+
+        public void CancelExpiration() => _expiration.Cancel();
+
+        public void MarkCompletionFinished() => _completion.TrySetResult();
+
+        public void ReleaseSlot(SemaphoreSlim availableSlots)
+        {
+            if (Interlocked.Exchange(ref _slotReleased, 1) == 0)
+            {
+                availableSlots.Release();
+            }
+        }
+
+        public void Dispose() => _expiration.Dispose();
+    }
+
+    internal enum PaginationAction
+    {
+        None,
+        First,
+        Previous,
+        Next,
+        Last,
+        Stop
+    }
+
+    internal sealed class PaginationCursor
+    {
+        public PaginationCursor(int pageCount)
+        {
+            if (pageCount <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(pageCount));
+            }
+
+            PageCount = pageCount;
+        }
+
+        public int PageCount { get; }
+        public int PageIndex { get; private set; }
+
+        public bool Move(PaginationAction action)
+        {
+            var previousPage = PageIndex;
+            switch (action)
+            {
+                case PaginationAction.First:
+                    PageIndex = 0;
+                    break;
+                case PaginationAction.Previous when PageIndex > 0:
+                    PageIndex--;
+                    break;
+                case PaginationAction.Next when PageIndex < PageCount - 1:
+                    PageIndex++;
+                    break;
+                case PaginationAction.Last:
+                    PageIndex = PageCount - 1;
+                    break;
+            }
+
+            return previousPage != PageIndex;
+        }
+    }
+}

--- a/BeanBot/Services/RoleReactService.cs
+++ b/BeanBot/Services/RoleReactService.cs
@@ -40,14 +40,20 @@ namespace BeanBot.Services
         {
             try
             {
+                var currentUser = _client?.CurrentUser;
+                if (currentUser == null)
+                {
+                    return;
+                }
+
                 var resolvedChannel = await channel.GetOrDownloadAsync();
-                if (_client?.CurrentUser == null || resolvedChannel is not SocketTextChannel textChannel)
+                if (resolvedChannel is not SocketTextChannel textChannel)
                 {
                     return;
                 }
 
                 var cachedMessage = await message.GetOrDownloadAsync();
-                if (cachedMessage.Author.Id != _client.CurrentUser.Id || reaction.UserId == _client.CurrentUser.Id)
+                if (cachedMessage.Author.Id != currentUser.Id || reaction.UserId == currentUser.Id)
                 {
                     return;
                 }

--- a/BeanBot/Services/RoleReactService.cs
+++ b/BeanBot/Services/RoleReactService.cs
@@ -26,21 +26,22 @@ namespace BeanBot.Services
             _client = client;
         }
 
-        public Task HandleReact(Cacheable<IUserMessage, ulong> message, ISocketMessageChannel channel, SocketReaction reaction)
+        public Task HandleReact(Cacheable<IUserMessage, ulong> message, Cacheable<IMessageChannel, ulong> channel, SocketReaction reaction)
             => HandleReactionAsync(message, channel, reaction, addRole: true);
 
-        public Task HandleRemoveReact(Cacheable<IUserMessage, ulong> message, ISocketMessageChannel channel, SocketReaction reaction)
+        public Task HandleRemoveReact(Cacheable<IUserMessage, ulong> message, Cacheable<IMessageChannel, ulong> channel, SocketReaction reaction)
             => HandleReactionAsync(message, channel, reaction, addRole: false);
 
         private async Task HandleReactionAsync(
             Cacheable<IUserMessage, ulong> message,
-            ISocketMessageChannel channel,
+            Cacheable<IMessageChannel, ulong> channel,
             SocketReaction reaction,
             bool addRole)
         {
             try
             {
-                if (_client?.CurrentUser == null || channel is not SocketTextChannel textChannel)
+                var resolvedChannel = await channel.GetOrDownloadAsync();
+                if (_client?.CurrentUser == null || resolvedChannel is not SocketTextChannel textChannel)
                 {
                     return;
                 }

--- a/BeanBot/Util/DiscordOwnerErrorSink.cs
+++ b/BeanBot/Util/DiscordOwnerErrorSink.cs
@@ -194,7 +194,7 @@ namespace BeanBot.Util
             }
 
             cancellationToken.ThrowIfCancellationRequested();
-            var directMessageChannel = await owner.GetOrCreateDMChannelAsync();
+            var directMessageChannel = await owner.CreateDMChannelAsync();
             cancellationToken.ThrowIfCancellationRequested();
             await directMessageChannel.SendMessageAsync(alert);
         }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 COPY ["BeanBot/BeanBot.csproj", "BeanBot/"]
@@ -8,7 +8,7 @@ COPY . .
 WORKDIR /src/BeanBot
 RUN dotnet publish "BeanBot.csproj" -c Release -o /app/publish --no-restore
 
-FROM mcr.microsoft.com/dotnet/runtime:8.0 AS final
+FROM mcr.microsoft.com/dotnet/runtime:10.0 AS final
 WORKDIR /app
 COPY --from=build /app/publish ./
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Bean Bot
 
-Bean Bot is a .NET 8 Discord bot with MongoDB-backed role reaction storage and a small set of server utilities.
+Bean Bot is a .NET 10 Discord bot with MongoDB-backed role reaction storage and a small set of server utilities.
 
 ## Configuration
 
@@ -18,6 +18,15 @@ BEANBOT_YOSHIMARU_URL=
 ```
 
 For backwards compatibility, the legacy variable names (`botToken`, `mongoConnectionString`, and so on) are still accepted, but the `BEANBOT_*` names are the intended format. Real environment variables take precedence over values from `.env`.
+
+### Discord Gateway Intents
+
+BeanBot explicitly requests only the gateway events used by its commands and event handlers. In the Discord Developer Portal, open the application, select **Bot**, and enable these privileged intents before deployment:
+
+- **Server Members Intent** for new-member welcome messages and current guild-member data.
+- **Message Content Intent** for BeanBot's prefix commands and edited-message handling.
+
+Leave **Presence Intent** disabled; BeanBot does not use presence events. The remaining requested intents are unprivileged and cover guild/channel state, guild emotes, guild and direct messages, and guild/direct-message reactions used by reaction roles and pagination.
 
 Optional health check settings:
 
@@ -40,7 +49,7 @@ If you bind the endpoint to anything other than `127.0.0.1`, set `BEANBOT_HEALTH
 
 ## Local Development
 
-Install the .NET 8 SDK, then restore, build, and run the test suite from the repo root:
+Install the .NET 10 SDK, then restore, build, and run the test suite from the repo root:
 
 ```powershell
 dotnet restore BeanBot.sln
@@ -78,7 +87,7 @@ docker run -d `
   beanbot
 ```
 
-The container uses the .NET 8 runtime image because this is a console application, not an ASP.NET app.
+The container uses the .NET 10 runtime image because this is a console application, not an ASP.NET app.
 
 ## Note
 

--- a/scripts/test-verification.sh
+++ b/scripts/test-verification.sh
@@ -121,7 +121,7 @@ assert_not_contains "|dotnet|test " "$failure_log"
 assert_not_contains "|docker|" "$failure_log"
 
 vulnerable_log="$temporary_directory/vulnerable.log"
-vulnerability_json='{"version":1,"projects":[{"path":"Fixture.csproj","frameworks":[{"framework":"net8.0","topLevelPackages":[{"id":"Example.Package","resolvedVersion":"1.2.3","vulnerabilities":[{"severity":"High","advisoryurl":"https://example.invalid/advisory"}]}]}]}]}'
+vulnerability_json='{"version":1,"projects":[{"path":"Fixture.csproj","frameworks":[{"framework":"net10.0","topLevelPackages":[{"id":"Example.Package","resolvedVersion":"1.2.3","vulnerabilities":[{"severity":"High","advisoryurl":"https://example.invalid/advisory"}]}]}]}]}'
 if PATH="$stub_directory:$PATH" BEANBOT_VERIFY_TEST_LOG="$vulnerable_log" \
   BEANBOT_VERIFY_REAL_PYTHON="$real_python" \
   BEANBOT_VERIFY_TEST_VULNERABILITY_JSON="$vulnerability_json" \

--- a/scripts/validate-workflow.py
+++ b/scripts/validate-workflow.py
@@ -97,7 +97,7 @@ def validate_workflows() -> None:
     release = release_path.read_text(encoding="utf-8")
     required_validation_fragments = (
         "name: .NET Core Master and Deploy Checks",
-        "dotnet-version: 8.0.x",
+        "dotnet-version: 10.0.x",
         "./scripts/verify.sh full",
     )
     required_release_fragments = (


### PR DESCRIPTION
Closes #81.

## What changed

- Retarget BeanBot, tests, Docker, and GitHub Actions to .NET 10.
- Upgrade the direct Discord.Net packages to 3.20.1 and dependency injection to 10.0.10.
- Remove the stale Interactive addon and replace its message-waiting and paginator behavior with bounded, cancellation-aware internal services.
- Migrate Discord.Net 3 API changes and configure the exact gateway intents required by commands, reaction roles, member events, and guild/DM pagination.
- Document required Developer Portal intents and add focused configuration, waiter, paginator, concurrency, and reaction-removal coverage.

## Why

BeanBot was pinned to the old .NET 8 and Discord.Net 2.x stack. The Interactive addon also prevented a consistent Discord.Net 3 upgrade. The internal replacements preserve the existing command behavior while bounding pending work and making shutdown and cleanup observable.

## Validation

- `./scripts/verify.sh fast`
- `./scripts/verify.sh full`
- 264 tests passed with zero skipped
- Release build completed with zero warnings and zero errors
- No known vulnerable direct or transitive NuGet packages
- Real multi-stage .NET 10 Docker image build succeeded
- Fresh independent Verifier: PASS
- Fresh independent Reviewer: CLEAN

## Manual deployment checks

Confirm Server Members and Message Content intents in the Discord Developer Portal, then exercise guild/DM pagination, reaction roles, welcome/owner DMs, recovery behavior, health checks, and container volume permissions in the deployed environment.