### PR TITLE
Fix bounded Discord startup recovery

### DIFF
--- a/BeanBot.Tests/Services/DiscordStartupServiceTests.cs
+++ b/BeanBot.Tests/Services/DiscordStartupServiceTests.cs
@@ -202,6 +202,60 @@ public class DiscordStartupServiceTests
         Assert.Equal(1, lifecycle.PresenceCount);
     }
 
+    [Fact]
+    public async Task PresenceTimeout_WithUnfinishedOperation_IsTerminal()
+    {
+        var presence = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var lifecycle = new DiscordStartupLifecycle(
+            () => Task.CompletedTask,
+            () => Task.CompletedTask,
+            () => presence.Task,
+            TimeSpan.FromMilliseconds(20));
+        var service = new DiscordStartupService(
+            lifecycle,
+            DiscordStartupOptions.Default,
+            new RecordingDelay());
+
+        await Assert.ThrowsAsync<TimeoutException>(
+            () => service.StartAsync(CancellationToken.None));
+        Assert.True(lifecycle.HasUnfinishedOperation);
+
+        presence.TrySetResult(true);
+        await WaitForNoUnfinishedOperationAsync(lifecycle);
+    }
+
+    [Fact]
+    public async Task CancellationDuringPresence_PropagatesAndTracksUnfinishedOperation()
+    {
+        var presenceStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var presence = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var lifecycle = new DiscordStartupLifecycle(
+            () => Task.CompletedTask,
+            () => Task.CompletedTask,
+            () =>
+            {
+                presenceStarted.TrySetResult(true);
+                return presence.Task;
+            },
+            TimeSpan.FromMinutes(1));
+        var service = new DiscordStartupService(
+            lifecycle,
+            DiscordStartupOptions.Default,
+            new RecordingDelay());
+        using var cancellation = new CancellationTokenSource();
+
+        var startup = service.StartAsync(cancellation.Token);
+        await presenceStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => startup.WaitAsync(TimeSpan.FromSeconds(2)));
+        Assert.True(lifecycle.HasUnfinishedOperation);
+
+        presence.TrySetResult(true);
+        await WaitForNoUnfinishedOperationAsync(lifecycle);
+    }
+
     private static Discord.Net.HttpException CreateHttpException(HttpStatusCode statusCode)
         => new(statusCode, null, null, "Test Discord failure", null);
 

--- a/BeanBot.Tests/Services/DiscordStartupServiceTests.cs
+++ b/BeanBot.Tests/Services/DiscordStartupServiceTests.cs
@@ -1,0 +1,281 @@
+using BeanBot.Services;
+
+using System.Net;
+
+using Xunit;
+
+namespace BeanBot.Tests.Services;
+
+public class DiscordStartupServiceTests
+{
+    [Fact]
+    public async Task SuccessfulStartup_LogsInAndStartsOnceWithoutDelay()
+    {
+        var lifecycle = new FakeStartupLifecycle();
+        var delay = new RecordingDelay();
+        var service = new DiscordStartupService(lifecycle, DiscordStartupOptions.Default, delay);
+
+        await service.StartAsync(CancellationToken.None);
+
+        Assert.Equal(1, lifecycle.LoginCount);
+        Assert.Equal(1, lifecycle.StartCount);
+        Assert.Equal(1, lifecycle.PresenceCount);
+        Assert.Empty(delay.RequestedDelays);
+    }
+
+    [Fact]
+    public async Task TransientLoginFailure_DelaysAndRetries()
+    {
+        var lifecycle = new FakeStartupLifecycle(
+            CreateHttpException(HttpStatusCode.ServiceUnavailable),
+            null);
+        var delay = new RecordingDelay();
+        var service = new DiscordStartupService(lifecycle, DiscordStartupOptions.Default, delay);
+
+        await service.StartAsync(CancellationToken.None);
+
+        Assert.Equal(2, lifecycle.LoginCount);
+        Assert.Equal(1, lifecycle.StartCount);
+        Assert.Equal(new[] { TimeSpan.FromSeconds(5) }, delay.RequestedDelays);
+    }
+
+    [Fact]
+    public async Task CancellationBeforeStartup_DoesNotAttemptLogin()
+    {
+        var lifecycle = new FakeStartupLifecycle();
+        var service = new DiscordStartupService(lifecycle, DiscordStartupOptions.Default, new RecordingDelay());
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => service.StartAsync(cancellation.Token));
+
+        Assert.Equal(0, lifecycle.LoginCount);
+        Assert.Equal(0, lifecycle.StartCount);
+    }
+
+    [Fact]
+    public async Task CancellationDuringRetryDelay_PreventsAnotherAttempt()
+    {
+        var lifecycle = new FakeStartupLifecycle(
+            CreateHttpException(HttpStatusCode.ServiceUnavailable));
+        var delay = new BlockingDelay();
+        var service = new DiscordStartupService(lifecycle, DiscordStartupOptions.Default, delay);
+        using var cancellation = new CancellationTokenSource();
+
+        var startup = service.StartAsync(cancellation.Token);
+        await delay.Requested.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => startup);
+        Assert.Equal(1, lifecycle.LoginCount);
+        Assert.Equal(0, lifecycle.StartCount);
+    }
+
+    [Fact]
+    public async Task UnauthorizedLoginFailure_FailsWithoutRetry()
+    {
+        var unauthorized = CreateHttpException(HttpStatusCode.Unauthorized);
+        var lifecycle = new FakeStartupLifecycle(unauthorized);
+        var delay = new RecordingDelay();
+        var service = new DiscordStartupService(lifecycle, DiscordStartupOptions.Default, delay);
+
+        var thrown = await Assert.ThrowsAsync<Discord.Net.HttpException>(
+            () => service.StartAsync(CancellationToken.None));
+
+        Assert.Same(unauthorized, thrown);
+        Assert.Equal(1, lifecycle.LoginCount);
+        Assert.Equal(0, lifecycle.StartCount);
+        Assert.Empty(delay.RequestedDelays);
+    }
+
+    [Fact]
+    public async Task TransientLoginFailures_ExhaustConfiguredAttempts()
+    {
+        var finalFailure = CreateHttpException(HttpStatusCode.BadGateway);
+        var lifecycle = new FakeStartupLifecycle(
+            CreateHttpException(HttpStatusCode.ServiceUnavailable),
+            CreateHttpException(HttpStatusCode.TooManyRequests),
+            finalFailure);
+        var delay = new RecordingDelay();
+        var service = new DiscordStartupService(lifecycle, DiscordStartupOptions.Default, delay);
+
+        var thrown = await Assert.ThrowsAsync<Discord.Net.HttpException>(
+            () => service.StartAsync(CancellationToken.None));
+
+        Assert.Same(finalFailure, thrown);
+        Assert.Equal(3, lifecycle.LoginCount);
+        Assert.Equal(0, lifecycle.StartCount);
+        Assert.Equal(
+            new[] { TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(15) },
+            delay.RequestedDelays);
+    }
+
+    [Fact]
+    public async Task LoginTimeout_IsTerminalAndDoesNotRetry()
+    {
+        var timeout = new TimeoutException("Test timeout");
+        var lifecycle = new FakeStartupLifecycle(timeout);
+        var delay = new RecordingDelay();
+        var service = new DiscordStartupService(lifecycle, DiscordStartupOptions.Default, delay);
+
+        var thrown = await Assert.ThrowsAsync<TimeoutException>(
+            () => service.StartAsync(CancellationToken.None));
+
+        Assert.Same(timeout, thrown);
+        Assert.Equal(1, lifecycle.LoginCount);
+        Assert.Equal(0, lifecycle.StartCount);
+        Assert.Empty(delay.RequestedDelays);
+    }
+
+    [Fact]
+    public async Task InFlightLoginCancellation_ReturnsPromptlyAndBlocksCompetingLifecycleOperations()
+    {
+        var login = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var startCount = 0;
+        var lifecycle = new DiscordStartupLifecycle(
+            () => login.Task,
+            () =>
+            {
+                startCount++;
+                return Task.CompletedTask;
+            },
+            () => Task.CompletedTask,
+            TimeSpan.FromMinutes(1));
+        var service = new DiscordStartupService(
+            lifecycle,
+            DiscordStartupOptions.Default,
+            new RecordingDelay());
+        using var cancellation = new CancellationTokenSource();
+
+        var startup = service.StartAsync(cancellation.Token);
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => startup.WaitAsync(TimeSpan.FromSeconds(2)));
+        Assert.True(lifecycle.HasUnfinishedOperation);
+        Assert.Equal(0, startCount);
+
+        login.TrySetResult(true);
+        await WaitForNoUnfinishedOperationAsync(lifecycle);
+    }
+
+    [Fact]
+    public async Task ProductionLifecycleTimeout_TracksOperationAndObservesLateFailure()
+    {
+        var login = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var lateFailure = new TaskCompletionSource<(Exception Exception, string Operation)>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var lifecycle = new DiscordStartupLifecycle(
+            () => login.Task,
+            () => Task.CompletedTask,
+            () => Task.CompletedTask,
+            TimeSpan.FromMilliseconds(20),
+            (exception, operation) => lateFailure.TrySetResult((exception, operation)));
+
+        await Assert.ThrowsAsync<TimeoutException>(
+            () => lifecycle.LoginAsync(CancellationToken.None));
+        Assert.True(lifecycle.HasUnfinishedOperation);
+
+        var expectedFailure = new InvalidOperationException("Late test failure");
+        login.TrySetException(expectedFailure);
+        var observed = await lateFailure.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.Equal("login", observed.Operation);
+        Assert.Same(expectedFailure, observed.Exception.InnerException);
+        await WaitForNoUnfinishedOperationAsync(lifecycle);
+    }
+
+    [Fact]
+    public async Task PresenceFailure_DoesNotFailConnectedStartup()
+    {
+        var lifecycle = new FakeStartupLifecycle
+        {
+            PresenceFailure = new InvalidOperationException("Test presence failure")
+        };
+        var service = new DiscordStartupService(lifecycle, DiscordStartupOptions.Default, new RecordingDelay());
+
+        await service.StartAsync(CancellationToken.None);
+
+        Assert.Equal(1, lifecycle.LoginCount);
+        Assert.Equal(1, lifecycle.StartCount);
+        Assert.Equal(1, lifecycle.PresenceCount);
+    }
+
+    private static Discord.Net.HttpException CreateHttpException(HttpStatusCode statusCode)
+        => new(statusCode, null, null, "Test Discord failure", null);
+
+    private static async Task WaitForNoUnfinishedOperationAsync(DiscordStartupLifecycle lifecycle)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (lifecycle.HasUnfinishedOperation && DateTime.UtcNow < deadline)
+        {
+            await Task.Yield();
+        }
+
+        Assert.False(lifecycle.HasUnfinishedOperation);
+    }
+
+    private sealed class FakeStartupLifecycle : IDiscordStartupLifecycle
+    {
+        private readonly Queue<Exception?> _loginFailures;
+
+        public FakeStartupLifecycle(params Exception?[] loginFailures)
+        {
+            _loginFailures = new Queue<Exception?>(loginFailures);
+        }
+
+        public int LoginCount { get; private set; }
+        public int StartCount { get; private set; }
+        public int PresenceCount { get; private set; }
+        public Exception? PresenceFailure { get; set; }
+
+        public Task LoginAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            LoginCount++;
+            var failure = _loginFailures.Count > 0 ? _loginFailures.Dequeue() : null;
+            return failure is null ? Task.CompletedTask : Task.FromException(failure);
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            StartCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task SetPresenceAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            PresenceCount++;
+            return PresenceFailure is null
+                ? Task.CompletedTask
+                : Task.FromException(PresenceFailure);
+        }
+    }
+
+    private sealed class RecordingDelay : IDiscordStartupDelay
+    {
+        public List<TimeSpan> RequestedDelays { get; } = new();
+
+        public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            RequestedDelays.Add(delay);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class BlockingDelay : IDiscordStartupDelay
+    {
+        public TaskCompletionSource<bool> Requested { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+        {
+            Requested.TrySetResult(true);
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        }
+    }
+}

--- a/BeanBot/Program.cs
+++ b/BeanBot/Program.cs
@@ -14,7 +14,6 @@ using Serilog;
 
 using System;
 using System.IO;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -37,52 +36,11 @@ namespace BeanBot
         private BeanBotOptions _options;
         private ServiceProvider _services;
         private DiscordOwnerErrorNotifier _ownerErrorNotifier;
+        private DiscordStartupLifecycle _discordStartupLifecycle;
 
         static void Main(string[] args)
         {
             var program = new Program();
-            try
-            {
-                program.StartAsync().GetAwaiter().GetResult();
-            }
-            catch (Exception exception)
-            {
-                Log.Fatal(exception, "BeanBot terminated because of an unhandled exception");
-                Environment.ExitCode = 1;
-            }
-            finally
-            {
-                program.DisposeOwnerErrorNotifierAsync().GetAwaiter().GetResult();
-                Log.CloseAndFlush();
-            }
-        }
-
-        public async Task StartAsync()
-        {
-            var database = InitializeApplication();
-            AppDomain.CurrentDomain.UnhandledException += HandleUnhandledException;
-            TaskScheduler.UnobservedTaskException += HandleUnobservedTaskException;
-            InitializeDiscordLifecycleTracking();
-            CreateCommandServiceWithOptions();
-            _services = CreateServiceProvider(database);
-            _healthCheckServer = HealthCheckServer.Create(_options.HealthCheck, _discordClient, _discordConnectionHealth);
-            _healthCheckServer?.Start();
-
-            await LogIntoDiscord();
-            _discordGatewayRecovery.StartMonitoring();
-            await InstantiateCommandServices();
-            _discordClient.Log += LogHandler.LogMessages;
-            _autoPunPoster = new PunHandler(_discordClient, _options);
-            _autoPunPoster.Start();
-            _editMessageHandler = new EditMessageHandler(_discordClient);
-            _editMessageHandler.InitializeEventListener();
-            _newMemberHandler = new NewMemberHandler(_discordClient);
-            _newMemberHandler.InitializeNewMembers();
-            _reactHandler = new ReactHandler(
-                _discordClient,
-                _services.GetRequiredService<RoleReactService>());
-            _reactHandler.InitializeReactDependentServices();
-
             using var cts = new CancellationTokenSource();
             ConsoleCancelEventHandler cancelKeyPressHandler = (_, eventArgs) =>
             {
@@ -94,16 +52,63 @@ namespace BeanBot
             AppDomain.CurrentDomain.ProcessExit += processExitHandler;
             try
             {
-                await Task.Delay(Timeout.Infinite, cts.Token);
+                program.StartAsync(cts.Token).GetAwaiter().GetResult();
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cts.IsCancellationRequested)
             {
-                Log.Warning("Shutting Down");
+                Log.Warning("Shutting down");
+            }
+            catch (Exception exception)
+            {
+                Log.Fatal(exception, "BeanBot terminated because of an unhandled exception");
+                Environment.ExitCode = 1;
             }
             finally
             {
                 Console.CancelKeyPress -= cancelKeyPressHandler;
                 AppDomain.CurrentDomain.ProcessExit -= processExitHandler;
+                program.DisposeOwnerErrorNotifierAsync().GetAwaiter().GetResult();
+                Log.CloseAndFlush();
+            }
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken = default)
+        {
+            var database = InitializeApplication();
+            AppDomain.CurrentDomain.UnhandledException += HandleUnhandledException;
+            TaskScheduler.UnobservedTaskException += HandleUnobservedTaskException;
+            InitializeDiscordLifecycleTracking();
+            CreateCommandServiceWithOptions();
+            _services = CreateServiceProvider(database);
+            _healthCheckServer = HealthCheckServer.Create(_options.HealthCheck, _discordClient, _discordConnectionHealth);
+            try
+            {
+                _healthCheckServer?.Start();
+                var startupOptions = DiscordStartupOptions.Default;
+                _discordStartupLifecycle = new DiscordStartupLifecycle(
+                    _discordClient,
+                    _options.BotToken,
+                    startupOptions.LifecycleOperationTimeout);
+                var startupService = new DiscordStartupService(_discordStartupLifecycle, startupOptions);
+                await startupService.StartAsync(cancellationToken);
+                _discordGatewayRecovery.StartMonitoring();
+                await InstantiateCommandServices();
+                _discordClient.Log += LogHandler.LogMessages;
+                _autoPunPoster = new PunHandler(_discordClient, _options);
+                _autoPunPoster.Start();
+                _editMessageHandler = new EditMessageHandler(_discordClient);
+                _editMessageHandler.InitializeEventListener();
+                _newMemberHandler = new NewMemberHandler(_discordClient);
+                _newMemberHandler.InitializeNewMembers();
+                _reactHandler = new ReactHandler(
+                    _discordClient,
+                    _services.GetRequiredService<RoleReactService>());
+                _reactHandler.InitializeReactDependentServices();
+
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+            }
+            finally
+            {
                 _reactHandler?.Dispose();
                 _newMemberHandler?.Dispose();
                 _editMessageHandler?.Dispose();
@@ -130,22 +135,78 @@ namespace BeanBot
                 }
 
                 await _ownerErrorNotifier.FlushAsync(TimeSpan.FromSeconds(3));
-                try
-                {
-                    await _discordClient.StopAsync();
-                    await _discordClient.LogoutAsync();
-                }
-                catch (Exception e)
-                {
-                    Log.Error(e, "Error shutting down: ");
-                }
+                await StopDiscordAsync();
 
                 await _ownerErrorNotifier.FlushAsync(TimeSpan.FromSeconds(3));
-                _discordClient.Dispose();
+                if (_discordStartupLifecycle?.HasUnfinishedOperation != true)
+                {
+                    _discordClient.Dispose();
+                }
+                else
+                {
+                    Log.Warning(
+                        "Skipping Discord client disposal because a startup lifecycle operation is still running; process exit will reclaim it");
+                }
                 _discordOutageRecoveryNotifier?.Dispose();
                 _discordOutageStore?.Dispose();
                 AppDomain.CurrentDomain.UnhandledException -= HandleUnhandledException;
                 TaskScheduler.UnobservedTaskException -= HandleUnobservedTaskException;
+            }
+        }
+
+        private async Task StopDiscordAsync()
+        {
+            if (_discordStartupLifecycle?.HasUnfinishedOperation == true)
+            {
+                Log.Warning(
+                    "Skipping Discord stop/logout because a startup lifecycle operation is still running; process exit will reclaim it");
+                return;
+            }
+
+            var operationTimeout = DiscordGatewayRecoveryOptions.Default.LifecycleOperationTimeout;
+            if (!await RunBoundedShutdownOperationAsync(
+                _discordClient.StopAsync(),
+                "stop",
+                operationTimeout))
+            {
+                return;
+            }
+
+            await RunBoundedShutdownOperationAsync(
+                _discordClient.LogoutAsync(),
+                "logout",
+                operationTimeout);
+        }
+
+        private static async Task<bool> RunBoundedShutdownOperationAsync(
+            Task operation,
+            string operationName,
+            TimeSpan timeout)
+        {
+            try
+            {
+                await operation.WaitAsync(timeout);
+                return true;
+            }
+            catch (Exception exception)
+            {
+                if (!operation.IsCompleted)
+                {
+                    _ = operation.ContinueWith(
+                        completedTask => Log.Error(
+                            completedTask.Exception,
+                            "Discord {Operation} operation failed after its shutdown wait ended",
+                            operationName),
+                        CancellationToken.None,
+                        TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                        TaskScheduler.Default);
+                }
+
+                Log.Error(
+                    exception,
+                    "Discord {Operation} operation did not complete during bounded shutdown",
+                    operationName);
+                return false;
             }
         }
 
@@ -216,32 +277,6 @@ namespace BeanBot
                 LogLevel = LogSeverity.Verbose,
                 CaseSensitiveCommands = false,
             });
-        }
-
-        private async Task LogIntoDiscord()
-        {
-            bool loggedIn = false;
-            while (loggedIn == false)
-            {
-                try
-                {
-                    await _discordClient.LoginAsync(TokenType.Bot, _options.BotToken);
-                    await _discordClient.StartAsync();
-                    await _discordClient.SetGameAsync("My purpose is to bully Hatate and succ the world dry", null, ActivityType.Playing);
-                    loggedIn = true;
-                }
-                catch (Discord.Net.HttpException e)
-                {
-                    if (e.HttpCode == HttpStatusCode.Unauthorized)
-                    {
-                        Log.Fatal(e, "Discord rejected the configured bot token. Update BEANBOT_BOT_TOKEN and restart the process.");
-                        throw;
-                    }
-
-                    Log.Error(e, "Discord login failed; retrying in 30 seconds");
-                    await Task.Delay(TimeSpan.FromSeconds(30));
-                }
-            }
         }
 
         private void CreateNewDiscordSocketClientWithConfigurations()

--- a/BeanBot/Services/DiscordStartupService.cs
+++ b/BeanBot/Services/DiscordStartupService.cs
@@ -1,0 +1,294 @@
+using Discord;
+using Discord.WebSocket;
+
+using Serilog;
+
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BeanBot.Services
+{
+    internal sealed class DiscordStartupOptions
+    {
+        public static DiscordStartupOptions Default { get; } = new(
+            3,
+            TimeSpan.FromSeconds(30),
+            attempt => attempt == 1
+                ? TimeSpan.FromSeconds(5)
+                : TimeSpan.FromSeconds(15));
+
+        public DiscordStartupOptions(
+            int maximumAttempts,
+            TimeSpan lifecycleOperationTimeout,
+            Func<int, TimeSpan> retryDelay)
+        {
+            if (maximumAttempts <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maximumAttempts));
+            }
+
+            if (lifecycleOperationTimeout <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(lifecycleOperationTimeout));
+            }
+
+            MaximumAttempts = maximumAttempts;
+            LifecycleOperationTimeout = lifecycleOperationTimeout;
+            RetryDelay = retryDelay ?? throw new ArgumentNullException(nameof(retryDelay));
+        }
+
+        public int MaximumAttempts { get; }
+        public TimeSpan LifecycleOperationTimeout { get; }
+        public Func<int, TimeSpan> RetryDelay { get; }
+    }
+
+    internal interface IDiscordStartupLifecycle
+    {
+        Task LoginAsync(CancellationToken cancellationToken);
+        Task StartAsync(CancellationToken cancellationToken);
+        Task SetPresenceAsync(CancellationToken cancellationToken);
+    }
+
+    internal interface IDiscordStartupDelay
+    {
+        Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken);
+    }
+
+    internal sealed class DiscordStartupDelay : IDiscordStartupDelay
+    {
+        public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+            => Task.Delay(delay, cancellationToken);
+    }
+
+    internal sealed class DiscordStartupLifecycle : IDiscordStartupLifecycle
+    {
+        private const string GameStatus = "My purpose is to bully Hatate and succ the world dry";
+        private readonly object _syncRoot = new();
+        private readonly Func<Task> _login;
+        private readonly Func<Task> _start;
+        private readonly Func<Task> _setPresence;
+        private readonly TimeSpan _operationTimeout;
+        private readonly Action<Exception, string> _lateFailureObserver;
+        private Task _unfinishedOperation;
+
+        public DiscordStartupLifecycle(
+            DiscordSocketClient client,
+            string botToken,
+            TimeSpan operationTimeout)
+        {
+            ArgumentNullException.ThrowIfNull(client);
+            ArgumentNullException.ThrowIfNull(botToken);
+            _login = () => client.LoginAsync(TokenType.Bot, botToken);
+            _start = client.StartAsync;
+            _setPresence = () => client.SetGameAsync(GameStatus, null, ActivityType.Playing);
+            _operationTimeout = operationTimeout;
+            _lateFailureObserver = LogLateFailure;
+        }
+
+        internal DiscordStartupLifecycle(
+            Func<Task> login,
+            Func<Task> start,
+            Func<Task> setPresence,
+            TimeSpan operationTimeout,
+            Action<Exception, string> lateFailureObserver = null)
+        {
+            _login = login ?? throw new ArgumentNullException(nameof(login));
+            _start = start ?? throw new ArgumentNullException(nameof(start));
+            _setPresence = setPresence ?? throw new ArgumentNullException(nameof(setPresence));
+            _operationTimeout = operationTimeout;
+            _lateFailureObserver = lateFailureObserver ?? LogLateFailure;
+        }
+
+        internal bool HasUnfinishedOperation
+        {
+            get
+            {
+                lock (_syncRoot)
+                {
+                    return _unfinishedOperation?.IsCompleted == false;
+                }
+            }
+        }
+
+        public Task LoginAsync(CancellationToken cancellationToken)
+            => RunBoundedAsync(
+                _login,
+                "login",
+                cancellationToken);
+
+        public Task StartAsync(CancellationToken cancellationToken)
+            => RunBoundedAsync(
+                _start,
+                "start",
+                cancellationToken);
+
+        public Task SetPresenceAsync(CancellationToken cancellationToken)
+            => RunBoundedAsync(
+                _setPresence,
+                "presence",
+                cancellationToken);
+
+        private async Task RunBoundedAsync(
+            Func<Task> beginOperation,
+            string operationName,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var operation = beginOperation();
+            try
+            {
+                // Discord.Net does not accept cancellation tokens for these operations,
+                // so BeanBot bounds its own wait and records an abandoned operation. The
+                // caller can then avoid racing teardown against the same client.
+                await operation.WaitAsync(_operationTimeout, cancellationToken);
+            }
+            catch
+            {
+                if (!operation.IsCompleted)
+                {
+                    TrackUnfinishedOperation(operation, operationName);
+                }
+
+                throw;
+            }
+        }
+
+        private void TrackUnfinishedOperation(Task operation, string operationName)
+        {
+            lock (_syncRoot)
+            {
+                _unfinishedOperation = operation;
+            }
+
+            _ = operation.ContinueWith(
+                completedTask =>
+                {
+                    if (completedTask.IsFaulted)
+                    {
+                        _lateFailureObserver(completedTask.Exception, operationName);
+                    }
+
+                    lock (_syncRoot)
+                    {
+                        if (ReferenceEquals(_unfinishedOperation, completedTask))
+                        {
+                            _unfinishedOperation = null;
+                        }
+                    }
+                },
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
+
+        private static void LogLateFailure(Exception exception, string operationName)
+            => Log.Error(
+                exception,
+                "Discord {Operation} operation failed after its startup wait ended",
+                operationName);
+    }
+
+    internal sealed class DiscordStartupService
+    {
+        private readonly IDiscordStartupLifecycle _lifecycle;
+        private readonly DiscordStartupOptions _options;
+        private readonly IDiscordStartupDelay _delay;
+
+        public DiscordStartupService(
+            IDiscordStartupLifecycle lifecycle,
+            DiscordStartupOptions options = null,
+            IDiscordStartupDelay delay = null)
+        {
+            _lifecycle = lifecycle ?? throw new ArgumentNullException(nameof(lifecycle));
+            _options = options ?? DiscordStartupOptions.Default;
+            _delay = delay ?? new DiscordStartupDelay();
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            await LoginWithRetryAsync(cancellationToken);
+            await _lifecycle.StartAsync(cancellationToken);
+
+            try
+            {
+                await _lifecycle.SetPresenceAsync(cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                // Presence is cosmetic and must not restart an otherwise valid gateway lifecycle.
+                Log.Warning(exception, "Discord started, but the initial presence could not be set");
+            }
+        }
+
+        private async Task LoginWithRetryAsync(CancellationToken cancellationToken)
+        {
+            for (var attempt = 1; attempt <= _options.MaximumAttempts; attempt++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Log.Information(
+                    "Attempting Discord login. Attempt={Attempt}, MaximumAttempts={MaximumAttempts}",
+                    attempt,
+                    _options.MaximumAttempts);
+
+                try
+                {
+                    await _lifecycle.LoginAsync(cancellationToken);
+                    Log.Information(
+                        "Discord login succeeded. Attempt={Attempt}, MaximumAttempts={MaximumAttempts}",
+                        attempt,
+                        _options.MaximumAttempts);
+                    return;
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Discord.Net.HttpException exception) when (exception.HttpCode == HttpStatusCode.Unauthorized)
+                {
+                    Log.Fatal(
+                        exception,
+                        "Discord rejected the configured bot token. Update BEANBOT_BOT_TOKEN and restart the process. Attempt={Attempt}, MaximumAttempts={MaximumAttempts}",
+                        attempt,
+                        _options.MaximumAttempts);
+                    throw;
+                }
+                catch (Discord.Net.HttpException exception)
+                {
+                    if (attempt == _options.MaximumAttempts)
+                    {
+                        Log.Fatal(
+                            exception,
+                            "Discord login failed after all startup attempts. Attempt={Attempt}, MaximumAttempts={MaximumAttempts}",
+                            attempt,
+                            _options.MaximumAttempts);
+                        throw;
+                    }
+
+                    var retryDelay = _options.RetryDelay(attempt);
+                    Log.Warning(
+                        exception,
+                        "Discord login attempt failed; delaying before retry. Attempt={Attempt}, MaximumAttempts={MaximumAttempts}, RetryDelay={RetryDelay}",
+                        attempt,
+                        _options.MaximumAttempts,
+                        retryDelay);
+                    await _delay.DelayAsync(retryDelay, cancellationToken);
+                }
+                catch (Exception exception)
+                {
+                    Log.Fatal(
+                        exception,
+                        "Discord startup failed with a non-retryable login error. Attempt={Attempt}, MaximumAttempts={MaximumAttempts}",
+                        attempt,
+                        _options.MaximumAttempts);
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/BeanBot/Services/DiscordStartupService.cs
+++ b/BeanBot/Services/DiscordStartupService.cs
@@ -219,9 +219,16 @@ namespace BeanBot.Services
             {
                 throw;
             }
+            catch (TimeoutException)
+            {
+                // A timed-out presence task may still own the Discord client. Propagate
+                // so startup teardown can avoid racing it with runtime lifecycle work.
+                throw;
+            }
             catch (Exception exception)
             {
-                // Presence is cosmetic and must not restart an otherwise valid gateway lifecycle.
+                // A completed presence failure is cosmetic and must not fail an
+                // otherwise valid gateway lifecycle.
                 Log.Warning(exception, "Discord started, but the initial presence could not be set");
             }
         }

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ docker run -d `
 
 The container uses the .NET 10 runtime image because this is a console application, not an ASP.NET app.
 
+BeanBot makes three bounded attempts to log in to Discord during startup. Permanent token failures fail immediately; exhausted transient failures exit with a non-zero status so the configured Docker restart policy can start a fresh process. Runtime gateway disconnects continue to use BeanBot's separate natural-recovery, manual-reconnect, and process-restart sequence.
+
 ## Note
 
 This bot is slowly being replaced by a new implementation in Python. The .NET version will remain available for the foreseeable future, but no new features will be added to it. The Python version is still in early development and may not have all the same features yet. It will be transitioned one module at a time. The .NET version will continue to receive critical bug fixes and security updates as needed, but new features and improvements will be focused on the Python version going forward.


### PR DESCRIPTION
## Summary

- replace the unbounded Discord startup login loop with three bounded attempts and cancellation-aware backoff
- register process cancellation before startup and make partial-startup Discord teardown bounded and race-safe
- keep runtime gateway recovery unchanged while documenting the separate startup and runtime recovery paths

## Root cause

BeanBot registered its shutdown cancellation handlers only after Discord login succeeded, while non-unauthorized login failures retried forever with a fixed delay. A persistent startup outage could therefore ignore normal shutdown and never exit for Docker to restart it.

## Product impact

Unauthorized tokens now fail immediately. Transient Discord login failures retry after 5 and 15 seconds, then propagate a terminal startup failure and exit code 1 for supervisor recovery. Cancellation during startup ends normally, and an unfinished Discord.Net operation cannot race stop, logout, or client disposal. Existing post-start gateway recovery remains unchanged.

Closes #86.

## Validation

- focused Discord startup tests: 10 passed
- `./scripts/verify.sh fast`
- `./scripts/verify.sh full`: 287 tests passed, zero build warnings/errors, no known vulnerable packages, Docker image built successfully
- independent Verifier: PASS
- independent Reviewer: CLEAN
