### PR TITLE
Adopt .NET Generic Host lifecycle

### DIFF
--- a/BeanBot.Tests/DiscordSocketConfigurationTests.cs
+++ b/BeanBot.Tests/DiscordSocketConfigurationTests.cs
@@ -1,3 +1,5 @@
+using BeanBot.Hosting;
+
 using Discord;
 
 using Xunit;
@@ -9,7 +11,7 @@ public class DiscordSocketConfigurationTests
     [Fact]
     public void Configuration_RequestsOnlyRequiredGatewayIntents()
     {
-        var configuration = Program.CreateDiscordSocketConfig();
+        var configuration = DiscordSocketConfiguration.Create();
         var expected = GatewayIntents.Guilds
             | GatewayIntents.GuildMembers
             | GatewayIntents.GuildEmojis

--- a/BeanBot.Tests/EventHandlers/PunHandlerTests.cs
+++ b/BeanBot.Tests/EventHandlers/PunHandlerTests.cs
@@ -1,0 +1,30 @@
+using BeanBot.Configuration;
+using BeanBot.EventHandlers;
+
+using Discord.WebSocket;
+
+using Xunit;
+
+namespace BeanBot.Tests.EventHandlers;
+
+public class PunHandlerTests
+{
+    [Fact]
+    public async Task DisposeAsync_IsIdempotentAndPreventsStart()
+    {
+        using var client = new DiscordSocketClient();
+        var options = new BeanBotOptions(
+            "token",
+            "mongodb://localhost",
+            1,
+            new Uri("https://example.com/hatoete"),
+            new Uri("https://example.com/yoshimaru"),
+            HealthCheckOptions.Disabled);
+        var handler = new PunHandler(client, options);
+
+        await handler.DisposeAsync();
+        await handler.DisposeAsync();
+
+        Assert.Throws<ObjectDisposedException>(() => handler.Start());
+    }
+}

--- a/BeanBot.Tests/Hosting/BeanBotApplicationTests.cs
+++ b/BeanBot.Tests/Hosting/BeanBotApplicationTests.cs
@@ -1,0 +1,135 @@
+using BeanBot.Hosting;
+
+using Xunit;
+
+namespace BeanBot.Tests.Hosting;
+
+public class BeanBotApplicationTests
+{
+    [Fact]
+    public async Task StartAsync_StartsHealthBeforeDiscordAndInitializesInOrderOnce()
+    {
+        var runtime = new RecordingRuntime();
+        var application = new BeanBotApplication(runtime);
+
+        await application.StartAsync(CancellationToken.None);
+        await application.StartAsync(CancellationToken.None);
+
+        Assert.Equal(
+            new[]
+            {
+                "subscribe-events",
+                "start-health",
+                "start-discord",
+                "start-recovery",
+                "start-commands",
+                "start-event-background"
+            },
+            runtime.Calls);
+    }
+
+    [Fact]
+    public async Task StopAsync_NormalShutdown_CleansUpInOrderOnce()
+    {
+        var runtime = new RecordingRuntime();
+        var application = new BeanBotApplication(runtime);
+
+        await application.StopAsync(CancellationToken.None);
+        await application.StopAsync(CancellationToken.None);
+
+        Assert.Equal(
+            new[]
+            {
+                "stop-event-command",
+                "stop-recovery",
+                "unsubscribe-events",
+                "stop-background",
+                "flush-alerts",
+                "stop-discord",
+                "dispose-discord",
+                "flush-alerts"
+            },
+            runtime.Calls);
+    }
+
+    [Fact]
+    public async Task StopAsync_UnfinishedDiscordStartup_SkipsDiscordShutdownAndDisposal()
+    {
+        var runtime = new RecordingRuntime
+        {
+            HasUnfinishedDiscordStartupOperation = true
+        };
+        var application = new BeanBotApplication(runtime);
+
+        await application.StopAsync(CancellationToken.None);
+
+        Assert.DoesNotContain("stop-discord", runtime.Calls);
+        Assert.DoesNotContain("dispose-discord", runtime.Calls);
+        Assert.Equal(2, runtime.Calls.Count(call => call == "flush-alerts"));
+        Assert.Contains("unsubscribe-events", runtime.Calls);
+    }
+
+    [Theory]
+    [InlineData("start-discord")]
+    [InlineData("start-commands")]
+    public async Task StartupFailure_AllowsCompletePartialStartupCleanup(string failingOperation)
+    {
+        var runtime = new RecordingRuntime { FailingOperation = failingOperation };
+        var application = new BeanBotApplication(runtime);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => application.StartAsync(CancellationToken.None));
+        await application.StopAsync(CancellationToken.None);
+
+        Assert.Contains("stop-event-command", runtime.Calls);
+        Assert.Contains("stop-recovery", runtime.Calls);
+        Assert.Contains("unsubscribe-events", runtime.Calls);
+        Assert.Contains("stop-background", runtime.Calls);
+        Assert.Equal(1, runtime.Calls.Count(call => call == "unsubscribe-events"));
+    }
+
+    private sealed class RecordingRuntime : IBeanBotRuntime
+    {
+        public List<string> Calls { get; } = new();
+        public string? FailingOperation { get; init; }
+        public bool HasUnfinishedDiscordStartupOperation { get; init; }
+
+        public void SubscribeApplicationEvents() => Record("subscribe-events");
+        public void StartHealthServer() => Record("start-health");
+        public Task StartDiscordAsync(CancellationToken cancellationToken)
+            => RecordAsync("start-discord");
+        public void StartGatewayRecovery() => Record("start-recovery");
+        public Task StartCommandServicesAsync() => RecordAsync("start-commands");
+        public void StartEventAndBackgroundServices() => Record("start-event-background");
+        public void StopEventAndCommandServices() => Record("stop-event-command");
+        public Task StopGatewayRecoveryAsync() => RecordAsync("stop-recovery");
+        public void UnsubscribeApplicationEvents() => Record("unsubscribe-events");
+        public Task StopBackgroundServicesAsync() => RecordAsync("stop-background");
+        public Task FlushOwnerAlertsAsync() => RecordAsync("flush-alerts");
+        public Task StopDiscordAsync(CancellationToken cancellationToken)
+            => RecordAsync("stop-discord");
+        public void DisposeDiscordClient() => Record("dispose-discord");
+
+        private void Record(string operation)
+        {
+            Calls.Add(operation);
+            if (FailingOperation == operation)
+            {
+                throw new InvalidOperationException($"{operation} failed");
+            }
+        }
+
+        private Task RecordAsync(string operation)
+        {
+            try
+            {
+                Record(operation);
+                return Task.CompletedTask;
+            }
+            catch (Exception exception)
+            {
+                return Task.FromException(exception);
+            }
+        }
+    }
+}

--- a/BeanBot.Tests/Hosting/BeanBotHostedServiceTests.cs
+++ b/BeanBot.Tests/Hosting/BeanBotHostedServiceTests.cs
@@ -1,0 +1,198 @@
+using BeanBot.Hosting;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+using Xunit;
+
+namespace BeanBot.Tests.Hosting;
+
+public class BeanBotHostedServiceTests
+{
+    [Fact]
+    public async Task Host_StartAndStop_InvokesApplicationLifecycleOnce()
+    {
+        var application = new RecordingApplication();
+        var builder = Host.CreateApplicationBuilder();
+        builder.Logging.ClearProviders();
+        builder.Services.AddSingleton<IBeanBotApplication>(application);
+        builder.Services.AddHostedService<BeanBotHostedService>();
+
+        var host = builder.Build();
+        try
+        {
+            await host.StartAsync();
+            await host.StopAsync();
+        }
+        finally
+        {
+            if (host is IAsyncDisposable asyncDisposableHost)
+            {
+                await asyncDisposableHost.DisposeAsync();
+            }
+            else
+            {
+                host.Dispose();
+            }
+        }
+
+        Assert.Equal(1, application.StartCount);
+        Assert.Equal(1, application.StopCount);
+        Assert.False(application.StartToken.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task StartAsync_ForwardsCancellationToken()
+    {
+        var application = new RecordingApplication { BlockUntilCancelled = true };
+        var hostedService = new BeanBotHostedService(application, new RecordingHostLifetime());
+        using var cancellation = new CancellationTokenSource();
+
+        var startup = hostedService.StartAsync(cancellation.Token);
+        await application.StartEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => startup);
+        Assert.True(application.StartToken.IsCancellationRequested);
+        Assert.Equal(1, application.StopCount);
+    }
+
+    [Fact]
+    public async Task StopAsync_ForwardsCancellationToken()
+    {
+        var application = new RecordingApplication();
+        var hostedService = new BeanBotHostedService(application, new RecordingHostLifetime());
+        using var cancellation = new CancellationTokenSource();
+
+        await hostedService.StopAsync(cancellation.Token);
+
+        Assert.Equal(cancellation.Token, application.StopToken);
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenStartupFails_CleansUpAndPreservesStartupFailure()
+    {
+        var startupFailure = new InvalidOperationException("startup failed");
+        var application = new RecordingApplication { StartFailure = startupFailure };
+        var hostedService = new BeanBotHostedService(application, new RecordingHostLifetime());
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => hostedService.StartAsync(CancellationToken.None));
+
+        Assert.Same(startupFailure, thrown);
+        Assert.Equal(1, application.StopCount);
+        Assert.Equal(CancellationToken.None, application.StopToken);
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenStartupAndCleanupFail_PreservesStartupFailure()
+    {
+        var startupFailure = new InvalidOperationException("startup failed");
+        var application = new RecordingApplication
+        {
+            StartFailure = startupFailure,
+            StopFailure = new InvalidOperationException("cleanup failed")
+        };
+        var hostedService = new BeanBotHostedService(application, new RecordingHostLifetime());
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => hostedService.StartAsync(CancellationToken.None));
+
+        Assert.Same(startupFailure, thrown);
+        Assert.Equal(1, application.StopCount);
+    }
+
+    [Fact]
+    public async Task Host_StopApplicationDuringStartup_CancelsStartupAndCleansUpOnce()
+    {
+        var application = new RecordingApplication { BlockUntilCancelled = true };
+        var builder = Host.CreateApplicationBuilder();
+        builder.Logging.ClearProviders();
+        builder.Services.AddSingleton<IBeanBotApplication>(application);
+        builder.Services.AddHostedService<BeanBotHostedService>();
+        var host = builder.Build();
+
+        try
+        {
+            var startup = host.StartAsync();
+            await application.StartEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            host.Services.GetRequiredService<IHostApplicationLifetime>().StopApplication();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => startup);
+            Assert.True(application.StartToken.IsCancellationRequested);
+        }
+        finally
+        {
+            if (host is IAsyncDisposable asyncDisposableHost)
+            {
+                await asyncDisposableHost.DisposeAsync();
+            }
+            else
+            {
+                host.Dispose();
+            }
+        }
+
+        Assert.Equal(1, application.StopCount);
+    }
+
+    private sealed class RecordingApplication : IBeanBotApplication
+    {
+        public int StartCount { get; private set; }
+        public int StopCount { get; private set; }
+        public CancellationToken StartToken { get; private set; }
+        public CancellationToken StopToken { get; private set; }
+        public Exception? StartFailure { get; init; }
+        public Exception? StopFailure { get; init; }
+        public bool BlockUntilCancelled { get; init; }
+        public TaskCompletionSource StartEntered { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            StartCount++;
+            StartToken = cancellationToken;
+            StartEntered.TrySetResult();
+            if (StartFailure is not null)
+            {
+                throw StartFailure;
+            }
+
+            if (BlockUntilCancelled)
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            }
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            StopCount++;
+            StopToken = cancellationToken;
+            return StopFailure is null
+                ? Task.CompletedTask
+                : Task.FromException(StopFailure);
+        }
+    }
+
+    private sealed class RecordingHostLifetime : IHostApplicationLifetime, IDisposable
+    {
+        private readonly CancellationTokenSource _started = new();
+        private readonly CancellationTokenSource _stopping = new();
+        private readonly CancellationTokenSource _stopped = new();
+
+        public CancellationToken ApplicationStarted => _started.Token;
+        public CancellationToken ApplicationStopping => _stopping.Token;
+        public CancellationToken ApplicationStopped => _stopped.Token;
+
+        public void StopApplication() => _stopping.Cancel();
+
+        public void Dispose()
+        {
+            _started.Dispose();
+            _stopping.Dispose();
+            _stopped.Dispose();
+        }
+    }
+}

--- a/BeanBot.Tests/Hosting/BeanBotServiceRegistrationTests.cs
+++ b/BeanBot.Tests/Hosting/BeanBotServiceRegistrationTests.cs
@@ -1,0 +1,44 @@
+using BeanBot.Configuration;
+using BeanBot.Hosting;
+
+using Discord.WebSocket;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Xunit;
+
+namespace BeanBot.Tests.Hosting;
+
+public class BeanBotServiceRegistrationTests
+{
+    [Fact]
+    public void AddBeanBot_RegistersOneHostedServiceAndHostOwnedDependencies()
+    {
+        var services = new ServiceCollection();
+
+        services.AddBeanBot();
+
+        Assert.Single(services, descriptor => descriptor.ServiceType == typeof(IHostedService));
+        AssertSingleton<BeanBotOptions>(services);
+        AssertSingleton<IBeanBotRuntime>(services);
+        AssertSingleton<IBeanBotApplication>(services);
+        AssertSingleton<BeanBotHostedService>(services);
+
+        var clientDescriptor = Assert.Single(
+            services,
+            descriptor => descriptor.ServiceType == typeof(DiscordSocketClient));
+        Assert.Equal(ServiceLifetime.Singleton, clientDescriptor.Lifetime);
+        Assert.NotNull(clientDescriptor.ImplementationInstance);
+
+        ((DiscordSocketClient)clientDescriptor.ImplementationInstance!).Dispose();
+    }
+
+    private static void AssertSingleton<TService>(IEnumerable<ServiceDescriptor> services)
+    {
+        var descriptor = Assert.Single(
+            services,
+            candidate => candidate.ServiceType == typeof(TService));
+        Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+    }
+}

--- a/BeanBot/BeanBot.csproj
+++ b/BeanBot/BeanBot.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Discord.Net.WebSocket" Version="3.20.1" />
     <PackageReference Include="LQ.MemeApiDotNetWrapper" Version="1.5.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
     <PackageReference Include="MongoDB.Bson" Version="2.30.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.30.0" />
     <PackageReference Include="MongoDB.Driver.Core" Version="2.30.0" />

--- a/BeanBot/EventHandlers/PunHandler.cs
+++ b/BeanBot/EventHandlers/PunHandler.cs
@@ -19,6 +19,7 @@ namespace BeanBot.EventHandlers
         private readonly ulong _generalChannelId;
         private readonly CancellationTokenSource _tokenSource = new();
         private Task _runner;
+        private int _disposed;
 
         private static readonly TimeSpan PostTimeLocal = new TimeSpan(16, 20, 0);
 
@@ -31,6 +32,11 @@ namespace BeanBot.EventHandlers
 
         public void Start()
         {
+            if (Volatile.Read(ref _disposed) != 0)
+            {
+                throw new ObjectDisposedException(nameof(PunHandler));
+            }
+
             if (_runner is not null)
             {
                 throw new InvalidOperationException("The daily pun service has already been started.");
@@ -173,6 +179,11 @@ namespace BeanBot.EventHandlers
 
         public async ValueTask DisposeAsync()
         {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
             try
             {
                 _tokenSource.Cancel();

--- a/BeanBot/Hosting/BeanBotApplication.cs
+++ b/BeanBot/Hosting/BeanBotApplication.cs
@@ -1,0 +1,80 @@
+using Serilog;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BeanBot.Hosting
+{
+    internal interface IBeanBotRuntime
+    {
+        bool HasUnfinishedDiscordStartupOperation { get; }
+        void SubscribeApplicationEvents();
+        void StartHealthServer();
+        Task StartDiscordAsync(CancellationToken cancellationToken);
+        void StartGatewayRecovery();
+        Task StartCommandServicesAsync();
+        void StartEventAndBackgroundServices();
+        void StopEventAndCommandServices();
+        Task StopGatewayRecoveryAsync();
+        void UnsubscribeApplicationEvents();
+        Task StopBackgroundServicesAsync();
+        Task FlushOwnerAlertsAsync();
+        Task StopDiscordAsync(CancellationToken cancellationToken);
+        void DisposeDiscordClient();
+    }
+
+    internal sealed class BeanBotApplication : IBeanBotApplication
+    {
+        private readonly IBeanBotRuntime _runtime;
+        private int _startRequested;
+        private int _stopRequested;
+
+        public BeanBotApplication(IBeanBotRuntime runtime)
+        {
+            _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            if (Interlocked.Exchange(ref _startRequested, 1) != 0)
+            {
+                return;
+            }
+
+            _runtime.SubscribeApplicationEvents();
+            _runtime.StartHealthServer();
+            await _runtime.StartDiscordAsync(cancellationToken);
+            _runtime.StartGatewayRecovery();
+            await _runtime.StartCommandServicesAsync();
+            _runtime.StartEventAndBackgroundServices();
+        }
+
+        public async Task StopAsync(CancellationToken cancellationToken)
+        {
+            if (Interlocked.Exchange(ref _stopRequested, 1) != 0)
+            {
+                return;
+            }
+
+            _runtime.StopEventAndCommandServices();
+            await _runtime.StopGatewayRecoveryAsync();
+            _runtime.UnsubscribeApplicationEvents();
+            await _runtime.StopBackgroundServicesAsync();
+
+            await _runtime.FlushOwnerAlertsAsync();
+            if (_runtime.HasUnfinishedDiscordStartupOperation)
+            {
+                Log.Warning(
+                    "Skipping Discord stop/logout and client disposal because a startup lifecycle operation is still running; process exit will reclaim it");
+            }
+            else
+            {
+                await _runtime.StopDiscordAsync(cancellationToken);
+                _runtime.DisposeDiscordClient();
+            }
+
+            await _runtime.FlushOwnerAlertsAsync();
+        }
+    }
+}

--- a/BeanBot/Hosting/BeanBotHostedService.cs
+++ b/BeanBot/Hosting/BeanBotHostedService.cs
@@ -1,0 +1,59 @@
+using Microsoft.Extensions.Hosting;
+
+using Serilog;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BeanBot.Hosting
+{
+    internal interface IBeanBotApplication
+    {
+        Task StartAsync(CancellationToken cancellationToken);
+        Task StopAsync(CancellationToken cancellationToken);
+    }
+
+    internal sealed class BeanBotHostedService : IHostedService
+    {
+        private readonly IBeanBotApplication _application;
+        private readonly IHostApplicationLifetime _hostLifetime;
+
+        public BeanBotHostedService(
+            IBeanBotApplication application,
+            IHostApplicationLifetime hostLifetime)
+        {
+            _application = application ?? throw new ArgumentNullException(nameof(application));
+            _hostLifetime = hostLifetime ?? throw new ArgumentNullException(nameof(hostLifetime));
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                using var startupCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                    cancellationToken,
+                    _hostLifetime.ApplicationStopping);
+                await _application.StartAsync(startupCancellation.Token);
+            }
+            catch
+            {
+                try
+                {
+                    await _application.StopAsync(CancellationToken.None);
+                }
+                catch (Exception cleanupException)
+                {
+                    Log.Error(
+                        cleanupException,
+                        "BeanBot cleanup failed after application startup did not complete");
+                }
+
+                throw;
+            }
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+            => _application.StopAsync(cancellationToken);
+    }
+}

--- a/BeanBot/Hosting/BeanBotRuntime.cs
+++ b/BeanBot/Hosting/BeanBotRuntime.cs
@@ -1,0 +1,258 @@
+using BeanBot.EventHandlers;
+using BeanBot.Services;
+using BeanBot.Util;
+
+using Discord.WebSocket;
+
+using Serilog;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BeanBot.Hosting
+{
+    internal sealed class BeanBotRuntime : IBeanBotRuntime
+    {
+        private readonly DiscordSocketClient _discordClient;
+        private readonly DiscordConnectionHealth _discordConnectionHealth;
+        private readonly DiscordGatewayRecoveryService _discordGatewayRecovery;
+        private readonly DiscordOutageRecoveryNotifier _discordOutageRecoveryNotifier;
+        private readonly DiscordStartupLifecycle _discordStartupLifecycle;
+        private readonly DiscordStartupService _discordStartupService;
+        private readonly DiscordOwnerErrorNotifier _ownerErrorNotifier;
+        private readonly HealthCheckServer _healthCheckServer;
+        private readonly CommandHandler _commandHandler;
+        private readonly PunHandler _punHandler;
+        private readonly EditMessageHandler _editMessageHandler;
+        private readonly NewMemberHandler _newMemberHandler;
+        private readonly ReactHandler _reactHandler;
+        private readonly DiscordMessageWaiter _messageWaiter;
+        private readonly DiscordPaginatorService _paginatorService;
+
+        public BeanBotRuntime(
+            DiscordSocketClient discordClient,
+            DiscordConnectionHealth discordConnectionHealth,
+            DiscordGatewayRecoveryService discordGatewayRecovery,
+            DiscordOutageRecoveryNotifier discordOutageRecoveryNotifier,
+            DiscordStartupLifecycle discordStartupLifecycle,
+            DiscordStartupService discordStartupService,
+            DiscordOwnerErrorNotifier ownerErrorNotifier,
+            HealthCheckServer healthCheckServer,
+            CommandHandler commandHandler,
+            PunHandler punHandler,
+            EditMessageHandler editMessageHandler,
+            NewMemberHandler newMemberHandler,
+            ReactHandler reactHandler,
+            DiscordMessageWaiter messageWaiter,
+            DiscordPaginatorService paginatorService)
+        {
+            _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
+            _discordConnectionHealth = discordConnectionHealth ?? throw new ArgumentNullException(nameof(discordConnectionHealth));
+            _discordGatewayRecovery = discordGatewayRecovery ?? throw new ArgumentNullException(nameof(discordGatewayRecovery));
+            _discordOutageRecoveryNotifier = discordOutageRecoveryNotifier ?? throw new ArgumentNullException(nameof(discordOutageRecoveryNotifier));
+            _discordStartupLifecycle = discordStartupLifecycle ?? throw new ArgumentNullException(nameof(discordStartupLifecycle));
+            _discordStartupService = discordStartupService ?? throw new ArgumentNullException(nameof(discordStartupService));
+            _ownerErrorNotifier = ownerErrorNotifier ?? throw new ArgumentNullException(nameof(ownerErrorNotifier));
+            _healthCheckServer = healthCheckServer ?? throw new ArgumentNullException(nameof(healthCheckServer));
+            _commandHandler = commandHandler ?? throw new ArgumentNullException(nameof(commandHandler));
+            _punHandler = punHandler ?? throw new ArgumentNullException(nameof(punHandler));
+            _editMessageHandler = editMessageHandler ?? throw new ArgumentNullException(nameof(editMessageHandler));
+            _newMemberHandler = newMemberHandler ?? throw new ArgumentNullException(nameof(newMemberHandler));
+            _reactHandler = reactHandler ?? throw new ArgumentNullException(nameof(reactHandler));
+            _messageWaiter = messageWaiter ?? throw new ArgumentNullException(nameof(messageWaiter));
+            _paginatorService = paginatorService ?? throw new ArgumentNullException(nameof(paginatorService));
+        }
+
+        public bool HasUnfinishedDiscordStartupOperation
+            => _discordStartupLifecycle.HasUnfinishedOperation;
+
+        public void SubscribeApplicationEvents()
+        {
+            AppDomain.CurrentDomain.UnhandledException += HandleUnhandledException;
+            TaskScheduler.UnobservedTaskException += HandleUnobservedTaskException;
+            _discordClient.Ready += OnDiscordReadyAsync;
+            _discordClient.Disconnected += OnDiscordDisconnectedAsync;
+        }
+
+        public void StartHealthServer() => _healthCheckServer.Start();
+
+        public Task StartDiscordAsync(CancellationToken cancellationToken)
+            => _discordStartupService.StartAsync(cancellationToken);
+
+        public void StartGatewayRecovery() => _discordGatewayRecovery.StartMonitoring();
+
+        public async Task StartCommandServicesAsync()
+        {
+            Log.Information("Instantiating Command Services");
+            await _commandHandler.InitializeCommandsAsync();
+        }
+
+        public void StartEventAndBackgroundServices()
+        {
+            _discordClient.Log += LogHandler.LogMessages;
+            _punHandler.Start();
+            _editMessageHandler.InitializeEventListener();
+            _newMemberHandler.InitializeNewMembers();
+            _reactHandler.InitializeReactDependentServices();
+        }
+
+        public void StopEventAndCommandServices()
+        {
+            _reactHandler.Dispose();
+            _newMemberHandler.Dispose();
+            _editMessageHandler.Dispose();
+            _commandHandler.Dispose();
+            _messageWaiter.Dispose();
+            _paginatorService.Dispose();
+            _discordClient.Log -= LogHandler.LogMessages;
+        }
+
+        public Task StopGatewayRecoveryAsync()
+            => _discordGatewayRecovery.DisposeAsync().AsTask();
+
+        public void UnsubscribeApplicationEvents()
+        {
+            _discordClient.Ready -= OnDiscordReadyAsync;
+            _discordClient.Disconnected -= OnDiscordDisconnectedAsync;
+            AppDomain.CurrentDomain.UnhandledException -= HandleUnhandledException;
+            TaskScheduler.UnobservedTaskException -= HandleUnobservedTaskException;
+        }
+
+        public async Task StopBackgroundServicesAsync()
+        {
+            await _punHandler.DisposeAsync();
+            await _healthCheckServer.DisposeAsync();
+        }
+
+        public Task FlushOwnerAlertsAsync()
+            => _ownerErrorNotifier.FlushAsync(TimeSpan.FromSeconds(3));
+
+        public async Task StopDiscordAsync(CancellationToken cancellationToken)
+        {
+            var operationTimeout = DiscordGatewayRecoveryOptions.Default.LifecycleOperationTimeout;
+            if (!await RunBoundedShutdownOperationAsync(
+                _discordClient.StopAsync,
+                "stop",
+                operationTimeout,
+                cancellationToken))
+            {
+                return;
+            }
+
+            await RunBoundedShutdownOperationAsync(
+                _discordClient.LogoutAsync,
+                "logout",
+                operationTimeout,
+                cancellationToken);
+        }
+
+        public void DisposeDiscordClient() => _discordClient.Dispose();
+
+        private static async Task<bool> RunBoundedShutdownOperationAsync(
+            Func<Task> beginOperation,
+            string operationName,
+            TimeSpan timeout,
+            CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                Log.Warning(
+                    "Skipping Discord {Operation} operation because the host shutdown deadline elapsed",
+                    operationName);
+                return false;
+            }
+
+            var operation = beginOperation();
+            try
+            {
+                await operation.WaitAsync(timeout, cancellationToken);
+                return true;
+            }
+            catch (Exception exception)
+            {
+                if (!operation.IsCompleted)
+                {
+                    _ = operation.ContinueWith(
+                        completedTask => Log.Error(
+                            completedTask.Exception,
+                            "Discord {Operation} operation failed after its shutdown wait ended",
+                            operationName),
+                        CancellationToken.None,
+                        TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                        TaskScheduler.Default);
+                }
+
+                Log.Error(
+                    exception,
+                    "Discord {Operation} operation did not complete during bounded shutdown",
+                    operationName);
+                return false;
+            }
+        }
+
+        private async Task OnDiscordReadyAsync()
+        {
+            _discordConnectionHealth.MarkReady();
+            _discordGatewayRecovery.NotifyReady();
+            Log.Information(
+                "BeanBot Discord gateway reached Ready. LoginState={LoginState}, ConnectionState={ConnectionState}",
+                _discordClient.LoginState,
+                _discordClient.ConnectionState);
+            try
+            {
+                await _discordOutageRecoveryNotifier.NotifyIfOutageRecoveredAsync(DateTimeOffset.UtcNow);
+            }
+            catch (Exception exception)
+            {
+                Log.Error(
+                    exception,
+                    "Discord reached Ready, but the persisted outage recovery notification could not be processed");
+            }
+        }
+
+        private Task OnDiscordDisconnectedAsync(Exception exception)
+        {
+            _discordConnectionHealth.MarkDisconnected(exception);
+            var snapshot = _discordConnectionHealth.CreateSnapshot(_discordClient);
+            if (exception is null)
+            {
+                Log.Warning(
+                    "BeanBot disconnected from Discord. LoginState={LoginState}, ConnectionState={ConnectionState}, MostRecentDisconnectReason={MostRecentDisconnectReason}",
+                    snapshot.LoginState,
+                    snapshot.ConnectionState,
+                    snapshot.MostRecentDisconnectReason);
+            }
+            else
+            {
+                Log.Warning(
+                    exception,
+                    "BeanBot disconnected from Discord. LoginState={LoginState}, ConnectionState={ConnectionState}, MostRecentDisconnectReason={MostRecentDisconnectReason}",
+                    snapshot.LoginState,
+                    snapshot.ConnectionState,
+                    snapshot.MostRecentDisconnectReason);
+            }
+
+            _discordGatewayRecovery.StartMonitoring();
+            return Task.CompletedTask;
+        }
+
+        private static void HandleUnhandledException(object sender, UnhandledExceptionEventArgs eventArgs)
+        {
+            if (eventArgs.ExceptionObject is Exception exception)
+            {
+                Log.Fatal(exception, "An unhandled application exception occurred");
+            }
+            else
+            {
+                Log.Fatal("An unhandled non-Exception error occurred: {Error}", eventArgs.ExceptionObject);
+            }
+        }
+
+        private static void HandleUnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs eventArgs)
+        {
+            Log.Error(eventArgs.Exception, "An unobserved task exception occurred");
+            eventArgs.SetObserved();
+        }
+    }
+}

--- a/BeanBot/Hosting/BeanBotServiceCollectionExtensions.cs
+++ b/BeanBot/Hosting/BeanBotServiceCollectionExtensions.cs
@@ -1,0 +1,127 @@
+using BeanBot.Configuration;
+using BeanBot.EventHandlers;
+using BeanBot.Repository;
+using BeanBot.Services;
+using BeanBot.Util;
+
+using Discord;
+using Discord.Commands;
+using Discord.WebSocket;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using MongoDB.Driver;
+
+using System;
+using System.IO;
+
+namespace BeanBot.Hosting
+{
+    internal static class BeanBotServiceCollectionExtensions
+    {
+        internal static IServiceCollection AddBeanBot(this IServiceCollection services)
+        {
+            ArgumentNullException.ThrowIfNull(services);
+
+            // Register the client as an existing singleton so the host container does not
+            // dispose it automatically. BeanBotApplication owns its conditional teardown
+            // because a timed-out Discord.Net startup operation may still be using it.
+            var discordClient = new DiscordSocketClient(DiscordSocketConfiguration.Create());
+            services.AddSingleton(discordClient);
+
+            services.AddSingleton(_ => BeanBotOptionsLoader.LoadFromEnvironment());
+            services.AddSingleton(_ => new CommandService(new CommandServiceConfig
+            {
+                LogLevel = LogSeverity.Verbose,
+                CaseSensitiveCommands = false
+            }));
+
+            services.AddSingleton<MongoClient>(provider =>
+                new MongoClient(provider.GetRequiredService<BeanBotOptions>().MongoConnectionString));
+            services.AddSingleton<IMongoDatabase>(provider =>
+                provider.GetRequiredService<MongoClient>().GetDatabase("BeanBotDB"));
+
+            services.AddSingleton<DiscordConnectionHealth>();
+            services.AddSingleton(DiscordStartupOptions.Default);
+            services.AddSingleton<DiscordStartupLifecycle>(provider =>
+            {
+                var options = provider.GetRequiredService<DiscordStartupOptions>();
+                return new DiscordStartupLifecycle(
+                    provider.GetRequiredService<DiscordSocketClient>(),
+                    provider.GetRequiredService<BeanBotOptions>().BotToken,
+                    options.LifecycleOperationTimeout);
+            });
+            services.AddSingleton<IDiscordStartupLifecycle>(provider =>
+                provider.GetRequiredService<DiscordStartupLifecycle>());
+            services.AddSingleton<IDiscordStartupDelay, DiscordStartupDelay>();
+            services.AddSingleton<DiscordStartupService>();
+
+            services.AddSingleton(DiscordGatewayRecoveryOptions.Default);
+            services.AddSingleton<IDiscordGatewayLifecycle>(provider =>
+            {
+                var options = provider.GetRequiredService<DiscordGatewayRecoveryOptions>();
+                return new DiscordGatewayLifecycle(
+                    provider.GetRequiredService<DiscordSocketClient>(),
+                    provider.GetRequiredService<BeanBotOptions>().BotToken,
+                    options.LifecycleOperationTimeout);
+            });
+            services.AddSingleton<IRecoveryDelay, TaskRecoveryDelay>();
+
+            services.AddSingleton<DiscordOutageStore>(_ => new DiscordOutageStore(
+                Path.GetFullPath(DirectorySetup.botBaseDirectory)));
+            services.AddSingleton<IDiscordOutageStore>(provider =>
+                provider.GetRequiredService<DiscordOutageStore>());
+
+            services.AddSingleton<DiscordOwnerAlertDelivery>();
+            services.AddSingleton<IOwnerAlertDelivery>(provider =>
+                provider.GetRequiredService<DiscordOwnerAlertDelivery>());
+            services.AddSingleton<DiscordOwnerErrorNotifier>(provider =>
+                new DiscordOwnerErrorNotifier(provider.GetRequiredService<IOwnerAlertDelivery>()));
+            services.AddSingleton<IOwnerErrorNotifier>(provider =>
+                provider.GetRequiredService<DiscordOwnerErrorNotifier>());
+            services.AddSingleton<DiscordOutageRecoveryNotifier>();
+
+            services.AddSingleton<DiscordGatewayRecoveryService>(provider =>
+            {
+                var client = provider.GetRequiredService<DiscordSocketClient>();
+                var connectionHealth = provider.GetRequiredService<DiscordConnectionHealth>();
+                return new DiscordGatewayRecoveryService(
+                    () => connectionHealth.CreateSnapshot(client),
+                    provider.GetRequiredService<IDiscordGatewayLifecycle>(),
+                    provider.GetRequiredService<IDiscordOutageStore>(),
+                    provider.GetRequiredService<DiscordGatewayRecoveryOptions>(),
+                    provider.GetRequiredService<IRecoveryDelay>());
+            });
+
+            services.AddSingleton<FortuneAnswerQueue>();
+            services.AddSingleton<DiscordMessageWaiter>();
+            services.AddSingleton<DiscordPaginatorService>();
+            services.AddSingleton<RoleReactRepository>();
+            services.AddSingleton<RoleReactService>();
+            services.AddSingleton<DiscordMessageCleanupService>();
+
+            services.AddSingleton<CommandHandler>();
+            services.AddSingleton<PunHandler>();
+            services.AddSingleton<EditMessageHandler>();
+            services.AddSingleton<NewMemberHandler>();
+            services.AddSingleton<ReactHandler>();
+            services.AddSingleton<HealthCheckServer>(provider => new HealthCheckServer(
+                provider.GetRequiredService<BeanBotOptions>().HealthCheck,
+                provider.GetRequiredService<DiscordSocketClient>(),
+                provider.GetRequiredService<DiscordConnectionHealth>()));
+
+            services.AddSingleton<BeanBotRuntime>();
+            services.AddSingleton<IBeanBotRuntime>(provider =>
+                provider.GetRequiredService<BeanBotRuntime>());
+            services.AddSingleton<BeanBotApplication>();
+            services.AddSingleton<IBeanBotApplication>(provider =>
+                provider.GetRequiredService<BeanBotApplication>());
+            services.AddSingleton<BeanBotHostedService>();
+            services.AddSingleton<IHostedService>(provider =>
+                provider.GetRequiredService<BeanBotHostedService>());
+
+            return services;
+        }
+    }
+}

--- a/BeanBot/Hosting/DiscordSocketConfiguration.cs
+++ b/BeanBot/Hosting/DiscordSocketConfiguration.cs
@@ -1,0 +1,26 @@
+using Discord;
+using Discord.WebSocket;
+
+namespace BeanBot.Hosting
+{
+    internal static class DiscordSocketConfiguration
+    {
+        internal static DiscordSocketConfig Create()
+        {
+            return new DiscordSocketConfig
+            {
+                LogLevel = LogSeverity.Verbose,
+                MessageCacheSize = 50,
+                AlwaysDownloadUsers = false,
+                GatewayIntents = GatewayIntents.Guilds
+                    | GatewayIntents.GuildMembers
+                    | GatewayIntents.GuildEmojis
+                    | GatewayIntents.GuildMessages
+                    | GatewayIntents.DirectMessages
+                    | GatewayIntents.GuildMessageReactions
+                    | GatewayIntents.DirectMessageReactions
+                    | GatewayIntents.MessageContent
+            };
+        }
+    }
+}

--- a/BeanBot/Program.cs
+++ b/BeanBot/Program.cs
@@ -1,377 +1,79 @@
-using BeanBot.Configuration;
-using BeanBot.EventHandlers;
-using BeanBot.Repository;
-using BeanBot.Services;
+using BeanBot.Hosting;
 using BeanBot.Util;
 
-using Discord;
-using Discord.Commands;
-using Discord.WebSocket;
-
 using Microsoft.Extensions.DependencyInjection;
-using MongoDB.Driver;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
 using Serilog;
 
 using System;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace BeanBot
 {
-    class Program
+    internal static class Program
     {
-        private DiscordSocketClient _discordClient;
-        private DiscordConnectionHealth _discordConnectionHealth;
-        private DiscordGatewayRecoveryService _discordGatewayRecovery;
-        private DiscordOutageStore _discordOutageStore;
-        private DiscordOutageRecoveryNotifier _discordOutageRecoveryNotifier;
-        private CommandService _commandService;
-        private CommandHandler _commandHandler;
-        private NewMemberHandler _newMemberHandler;
-        private PunHandler _autoPunPoster;
-        private EditMessageHandler _editMessageHandler;
-        private ReactHandler _reactHandler;
-        private HealthCheckServer _healthCheckServer;
-        private BeanBotOptions _options;
-        private ServiceProvider _services;
-        private DiscordOwnerErrorNotifier _ownerErrorNotifier;
-        private DiscordStartupLifecycle _discordStartupLifecycle;
+        internal static readonly TimeSpan HostShutdownTimeout = TimeSpan.FromMinutes(2);
 
-        static void Main(string[] args)
+        private static async Task<int> Main(string[] args)
         {
-            var program = new Program();
-            using var cts = new CancellationTokenSource();
-            ConsoleCancelEventHandler cancelKeyPressHandler = (_, eventArgs) =>
-            {
-                eventArgs.Cancel = true;
-                cts.Cancel();
-            };
-            EventHandler processExitHandler = (_, __) => cts.Cancel();
-            Console.CancelKeyPress += cancelKeyPressHandler;
-            AppDomain.CurrentDomain.ProcessExit += processExitHandler;
+            IHost host = null;
             try
             {
-                program.StartAsync(cts.Token).GetAwaiter().GetResult();
+                DirectorySetup.MakeSureAllDirectoriesExist();
+
+                var builder = Host.CreateApplicationBuilder(args);
+                builder.Logging.ClearProviders();
+                builder.Services.Configure<HostOptions>(options =>
+                    options.ShutdownTimeout = HostShutdownTimeout);
+                builder.Services.AddBeanBot();
+
+                host = builder.Build();
+                LogHandler.CreateLoggerConfiguration(
+                    host.Services.GetRequiredService<DiscordOwnerErrorNotifier>());
+
+                await host.RunAsync();
+                return 0;
             }
-            catch (OperationCanceledException) when (cts.IsCancellationRequested)
+            catch (OperationCanceledException) when (IsHostStopping(host))
             {
                 Log.Warning("Shutting down");
+                return 0;
             }
             catch (Exception exception)
             {
                 Log.Fatal(exception, "BeanBot terminated because of an unhandled exception");
-                Environment.ExitCode = 1;
+                return 1;
             }
             finally
             {
-                Console.CancelKeyPress -= cancelKeyPressHandler;
-                AppDomain.CurrentDomain.ProcessExit -= processExitHandler;
-                program.DisposeOwnerErrorNotifierAsync().GetAwaiter().GetResult();
-                Log.CloseAndFlush();
-            }
-        }
-
-        public async Task StartAsync(CancellationToken cancellationToken = default)
-        {
-            var database = InitializeApplication();
-            AppDomain.CurrentDomain.UnhandledException += HandleUnhandledException;
-            TaskScheduler.UnobservedTaskException += HandleUnobservedTaskException;
-            InitializeDiscordLifecycleTracking();
-            CreateCommandServiceWithOptions();
-            _services = CreateServiceProvider(database);
-            _healthCheckServer = HealthCheckServer.Create(_options.HealthCheck, _discordClient, _discordConnectionHealth);
-            try
-            {
-                _healthCheckServer?.Start();
-                var startupOptions = DiscordStartupOptions.Default;
-                _discordStartupLifecycle = new DiscordStartupLifecycle(
-                    _discordClient,
-                    _options.BotToken,
-                    startupOptions.LifecycleOperationTimeout);
-                var startupService = new DiscordStartupService(_discordStartupLifecycle, startupOptions);
-                await startupService.StartAsync(cancellationToken);
-                _discordGatewayRecovery.StartMonitoring();
-                await InstantiateCommandServices();
-                _discordClient.Log += LogHandler.LogMessages;
-                _autoPunPoster = new PunHandler(_discordClient, _options);
-                _autoPunPoster.Start();
-                _editMessageHandler = new EditMessageHandler(_discordClient);
-                _editMessageHandler.InitializeEventListener();
-                _newMemberHandler = new NewMemberHandler(_discordClient);
-                _newMemberHandler.InitializeNewMembers();
-                _reactHandler = new ReactHandler(
-                    _discordClient,
-                    _services.GetRequiredService<RoleReactService>());
-                _reactHandler.InitializeReactDependentServices();
-
-                await Task.Delay(Timeout.Infinite, cancellationToken);
-            }
-            finally
-            {
-                _reactHandler?.Dispose();
-                _newMemberHandler?.Dispose();
-                _editMessageHandler?.Dispose();
-                _commandHandler?.Dispose();
-                _services?.Dispose();
-                _discordClient.Log -= LogHandler.LogMessages;
-
-                if (_discordGatewayRecovery is not null)
+                try
                 {
-                    await _discordGatewayRecovery.DisposeAsync();
+                    if (host is not null)
+                    {
+                        if (host is IAsyncDisposable asyncDisposableHost)
+                        {
+                            await asyncDisposableHost.DisposeAsync();
+                        }
+                        else
+                        {
+                            host.Dispose();
+                        }
+                    }
                 }
-
-                _discordClient.Ready -= OnDiscordReadyAsync;
-                _discordClient.Disconnected -= OnDiscordDisconnectedAsync;
-
-                if (_autoPunPoster is not null)
+                finally
                 {
-                    await _autoPunPoster.DisposeAsync();
+                    Log.CloseAndFlush();
                 }
-
-                if (_healthCheckServer is not null)
-                {
-                    await _healthCheckServer.DisposeAsync();
-                }
-
-                await _ownerErrorNotifier.FlushAsync(TimeSpan.FromSeconds(3));
-                await StopDiscordAsync();
-
-                await _ownerErrorNotifier.FlushAsync(TimeSpan.FromSeconds(3));
-                if (_discordStartupLifecycle?.HasUnfinishedOperation != true)
-                {
-                    _discordClient.Dispose();
-                }
-                else
-                {
-                    Log.Warning(
-                        "Skipping Discord client disposal because a startup lifecycle operation is still running; process exit will reclaim it");
-                }
-                _discordOutageRecoveryNotifier?.Dispose();
-                _discordOutageStore?.Dispose();
-                AppDomain.CurrentDomain.UnhandledException -= HandleUnhandledException;
-                TaskScheduler.UnobservedTaskException -= HandleUnobservedTaskException;
             }
         }
 
-        private async Task StopDiscordAsync()
-        {
-            if (_discordStartupLifecycle?.HasUnfinishedOperation == true)
-            {
-                Log.Warning(
-                    "Skipping Discord stop/logout because a startup lifecycle operation is still running; process exit will reclaim it");
-                return;
-            }
-
-            var operationTimeout = DiscordGatewayRecoveryOptions.Default.LifecycleOperationTimeout;
-            if (!await RunBoundedShutdownOperationAsync(
-                _discordClient.StopAsync(),
-                "stop",
-                operationTimeout))
-            {
-                return;
-            }
-
-            await RunBoundedShutdownOperationAsync(
-                _discordClient.LogoutAsync(),
-                "logout",
-                operationTimeout);
-        }
-
-        private static async Task<bool> RunBoundedShutdownOperationAsync(
-            Task operation,
-            string operationName,
-            TimeSpan timeout)
-        {
-            try
-            {
-                await operation.WaitAsync(timeout);
-                return true;
-            }
-            catch (Exception exception)
-            {
-                if (!operation.IsCompleted)
-                {
-                    _ = operation.ContinueWith(
-                        completedTask => Log.Error(
-                            completedTask.Exception,
-                            "Discord {Operation} operation failed after its shutdown wait ended",
-                            operationName),
-                        CancellationToken.None,
-                        TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
-                        TaskScheduler.Default);
-                }
-
-                Log.Error(
-                    exception,
-                    "Discord {Operation} operation did not complete during bounded shutdown",
-                    operationName);
-                return false;
-            }
-        }
-
-        private async Task InstantiateCommandServices()
-        {
-            Log.Information("Instantiating Command Services");
-            _commandHandler = new CommandHandler(_discordClient, _commandService, _services);
-            await _commandHandler.InitializeCommandsAsync();
-        }
-
-        private IMongoDatabase InitializeApplication()
-        {
-            DirectorySetup.MakeSureAllDirectoriesExist();
-            _discordConnectionHealth = new DiscordConnectionHealth();
-            CreateNewDiscordSocketClientWithConfigurations();
-            var ownerAlertDelivery = new DiscordOwnerAlertDelivery(_discordClient);
-            _ownerErrorNotifier = new DiscordOwnerErrorNotifier(ownerAlertDelivery);
-            LogHandler.CreateLoggerConfiguration(_ownerErrorNotifier);
-            _discordOutageStore = new DiscordOutageStore(
-                Path.GetFullPath(DirectorySetup.botBaseDirectory));
-            _discordOutageRecoveryNotifier = new DiscordOutageRecoveryNotifier(
-                _discordOutageStore,
-                ownerAlertDelivery);
-            _options = BeanBotOptionsLoader.LoadFromEnvironment();
-            var recoveryOptions = DiscordGatewayRecoveryOptions.Default;
-            _discordGatewayRecovery = new DiscordGatewayRecoveryService(
-                () => _discordConnectionHealth.CreateSnapshot(_discordClient),
-                new DiscordGatewayLifecycle(
-                    _discordClient,
-                    _options.BotToken,
-                    recoveryOptions.LifecycleOperationTimeout),
-                _discordOutageStore,
-                recoveryOptions);
-
-            Log.Information("Configuring MongoDB client");
-            var mongoClient = new MongoClient(_options.MongoConnectionString);
-            return mongoClient.GetDatabase("BeanBotDB");
-        }
-
-        private async Task DisposeOwnerErrorNotifierAsync()
-        {
-            if (_ownerErrorNotifier is not null)
-            {
-                await _ownerErrorNotifier.DisposeAsync();
-            }
-        }
-
-        private ServiceProvider CreateServiceProvider(IMongoDatabase database)
-        {
-            return new ServiceCollection()
-                .AddSingleton(_options)
-                .AddSingleton(_discordClient)
-                .AddSingleton(_commandService)
-                .AddSingleton(database)
-                .AddSingleton<FortuneAnswerQueue>()
-                .AddSingleton<DiscordMessageWaiter>()
-                .AddSingleton<DiscordPaginatorService>()
-                .AddSingleton<RoleReactRepository>()
-                .AddSingleton<RoleReactService>()
-                .AddSingleton<DiscordMessageCleanupService>()
-                .BuildServiceProvider();
-        }
-
-        private void CreateCommandServiceWithOptions()
-        {
-            _commandService = new CommandService(new CommandServiceConfig
-            {
-                LogLevel = LogSeverity.Verbose,
-                CaseSensitiveCommands = false,
-            });
-        }
-
-        private void CreateNewDiscordSocketClientWithConfigurations()
-        {
-            _discordClient = new DiscordSocketClient(CreateDiscordSocketConfig());
-        }
-
-        internal static DiscordSocketConfig CreateDiscordSocketConfig()
-        {
-            return new DiscordSocketConfig
-            {
-                LogLevel = LogSeverity.Verbose,
-                MessageCacheSize = 50,
-                AlwaysDownloadUsers = false,
-                GatewayIntents = GatewayIntents.Guilds
-                    | GatewayIntents.GuildMembers
-                    | GatewayIntents.GuildEmojis
-                    | GatewayIntents.GuildMessages
-                    | GatewayIntents.DirectMessages
-                    | GatewayIntents.GuildMessageReactions
-                    | GatewayIntents.DirectMessageReactions
-                    | GatewayIntents.MessageContent
-            };
-        }
-
-        private void InitializeDiscordLifecycleTracking()
-        {
-            _discordClient.Ready += OnDiscordReadyAsync;
-            _discordClient.Disconnected += OnDiscordDisconnectedAsync;
-        }
-
-        private async Task OnDiscordReadyAsync()
-        {
-            _discordConnectionHealth.MarkReady();
-            _discordGatewayRecovery.NotifyReady();
-            Log.Information(
-                "BeanBot Discord gateway reached Ready. LoginState={LoginState}, ConnectionState={ConnectionState}",
-                _discordClient.LoginState,
-                _discordClient.ConnectionState);
-            try
-            {
-                await _discordOutageRecoveryNotifier.NotifyIfOutageRecoveredAsync(DateTimeOffset.UtcNow);
-            }
-            catch (Exception exception)
-            {
-                // Ready must remain a successful gateway event even if local persistence is unavailable.
-                Log.Error(
-                    exception,
-                    "Discord reached Ready, but the persisted outage recovery notification could not be processed");
-            }
-        }
-
-        private Task OnDiscordDisconnectedAsync(Exception exception)
-        {
-            _discordConnectionHealth.MarkDisconnected(exception);
-            var snapshot = _discordConnectionHealth.CreateSnapshot(_discordClient);
-            if (exception is null)
-            {
-                Log.Warning(
-                    "BeanBot disconnected from Discord. LoginState={LoginState}, ConnectionState={ConnectionState}, MostRecentDisconnectReason={MostRecentDisconnectReason}",
-                    snapshot.LoginState,
-                    snapshot.ConnectionState,
-                    snapshot.MostRecentDisconnectReason);
-            }
-            else
-            {
-                Log.Warning(
-                    exception,
-                    "BeanBot disconnected from Discord. LoginState={LoginState}, ConnectionState={ConnectionState}, MostRecentDisconnectReason={MostRecentDisconnectReason}",
-                    snapshot.LoginState,
-                    snapshot.ConnectionState,
-                    snapshot.MostRecentDisconnectReason);
-            }
-
-            _discordGatewayRecovery.StartMonitoring();
-
-            return Task.CompletedTask;
-        }
-
-        private static void HandleUnhandledException(object sender, UnhandledExceptionEventArgs eventArgs)
-        {
-            if (eventArgs.ExceptionObject is Exception exception)
-            {
-                Log.Fatal(exception, "An unhandled application exception occurred");
-            }
-            else
-            {
-                Log.Fatal("An unhandled non-Exception error occurred: {Error}", eventArgs.ExceptionObject);
-            }
-        }
-
-        private static void HandleUnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs eventArgs)
-        {
-            Log.Error(eventArgs.Exception, "An unobserved task exception occurred");
-            eventArgs.SetObserved();
-        }
+        private static bool IsHostStopping(IHost host)
+            => host?.Services
+                .GetService<IHostApplicationLifetime>()
+                ?.ApplicationStopping
+                .IsCancellationRequested == true;
     }
 }

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ dotnet run --project BeanBot/BeanBot.csproj
 ```
 
 The bot requires access to the MongoDB instance configured by `BEANBOT_MONGO_CONNECTION_STRING`. If a `.env` file exists in the repo root, `dotnet run` loads it automatically.
+BeanBot runs through the .NET Generic Host, so Ctrl+C and normal process-stop signals trigger the same bounded graceful-shutdown path used in production.
 
 ## Docker
 
@@ -88,6 +89,7 @@ docker run -d `
 ```
 
 The container uses the .NET 10 runtime image because this is a console application, not an ASP.NET app.
+Container stop signals are handled by the Generic Host and flow through BeanBot's bounded Discord and background-service shutdown sequence.
 
 BeanBot makes three bounded attempts to log in to Discord during startup. Permanent token failures fail immediately; exhausted transient failures exit with a non-zero status so the configured Docker restart policy can start a fresh process. Runtime gateway disconnects continue to use BeanBot's separate natural-recovery, manual-reconnect, and process-restart sequence.
 


### PR DESCRIPTION
## Summary

- start BeanBot through `Host.CreateApplicationBuilder`
- centralize application registrations in the host container
- route startup, shutdown, and stop signals through hosted lifecycle services
- preserve bounded Discord startup, recovery/outage behavior, health checks, and Docker runtime compatibility
- add lifecycle, cancellation, ordering, failure-path, and registration tests

## Why

`Program.cs` previously owned dependency construction, process signals, Discord lifecycle orchestration, background services, and shutdown. Moving that coordination into the .NET Generic Host makes cancellation and disposal consistent while keeping BeanBot's specialized services intact.

## Validation

- focused hosting/lifecycle tests: 14 passed
- `./scripts/verify.sh fast`: 302 passed, 0 warnings
- `./scripts/verify.sh full`: 302 passed, vulnerability scan clean, Docker image built
- independent verifier: PASS
- independent reviewer: CLEAN

Closes #85