### PR TITLE
Enable nullable analysis in production

### DIFF
--- a/BeanBot.Tests/Configuration/BeanBotOptionsLoaderTests.cs
+++ b/BeanBot.Tests/Configuration/BeanBotOptionsLoaderTests.cs
@@ -22,6 +22,7 @@ public class BeanBotOptionsLoaderTests
         Assert.Equal(8080, options.HealthCheck.Port);
         Assert.Equal(IPAddress.Loopback, options.HealthCheck.BindAddress);
         Assert.Equal(TimeSpan.FromSeconds(12), options.HealthCheck.MinimumPollInterval);
+        Assert.Null(options.HealthCheck.BearerToken);
     }
 
     [Fact]

--- a/BeanBot.Tests/Entities/RoleSettingsTests.cs
+++ b/BeanBot.Tests/Entities/RoleSettingsTests.cs
@@ -1,0 +1,47 @@
+using BeanBot.Entities;
+
+using MongoDB.Bson;
+
+using Newtonsoft.Json.Linq;
+
+using Xunit;
+
+namespace BeanBot.Tests.Entities;
+
+public class RoleSettingsTests
+{
+    [Fact]
+    public void ParameterlessInstance_HasSafeCollectionAndStringDefaults()
+    {
+        var settings = new RoleSettings();
+
+        Assert.Empty(settings.roleEmotePair);
+        Assert.Empty(settings.guildId);
+        Assert.Empty(settings.channelId);
+        Assert.Empty(settings.messageId);
+    }
+
+    [Fact]
+    public void Serialization_PreservesExistingPersistedMemberNames()
+    {
+        var settings = new RoleSettings(
+            new List<RoleEmotePair> { new("role", "emoji") },
+            "guild",
+            "channel",
+            "message");
+
+        var bson = settings.ToBsonDocument();
+        var json = JObject.Parse(settings.ToString());
+
+        Assert.True(bson.Contains("_id"));
+        Assert.True(bson.Contains("roleEmotePair"));
+        Assert.True(bson.Contains("guildId"));
+        Assert.True(bson.Contains("channelId"));
+        Assert.True(bson.Contains("messageId"));
+        Assert.True(bson.Contains("lastAccessed"));
+        Assert.NotNull(json["roleEmotePair"]);
+        Assert.NotNull(json["guildId"]);
+        Assert.NotNull(json["channelId"]);
+        Assert.NotNull(json["messageId"]);
+    }
+}

--- a/BeanBot.Tests/Hosting/BeanBotServiceRegistrationTests.cs
+++ b/BeanBot.Tests/Hosting/BeanBotServiceRegistrationTests.cs
@@ -1,5 +1,6 @@
 using BeanBot.Configuration;
 using BeanBot.Hosting;
+using BeanBot.Services;
 
 using Discord.WebSocket;
 
@@ -24,6 +25,7 @@ public class BeanBotServiceRegistrationTests
         AssertSingleton<IBeanBotRuntime>(services);
         AssertSingleton<IBeanBotApplication>(services);
         AssertSingleton<BeanBotHostedService>(services);
+        AssertSingleton<RoleReactService>(services);
 
         var clientDescriptor = Assert.Single(
             services,

--- a/BeanBot.Tests/Services/BoundedLineReaderTests.cs
+++ b/BeanBot.Tests/Services/BoundedLineReaderTests.cs
@@ -7,6 +7,17 @@ namespace BeanBot.Tests.Services;
 public class BoundedLineReaderTests
 {
     [Fact]
+    public async Task ReadLineAsync_EmptyStreamReturnsNull()
+    {
+        await using var stream = new MemoryStream();
+        var reader = new BoundedLineReader(stream);
+
+        var line = await reader.ReadLineAsync(5, CancellationToken.None);
+
+        Assert.Null(line);
+    }
+
+    [Fact]
     public async Task ReadLineAsync_AcceptsLineExactlyAtLimit()
     {
         await using var stream = new MemoryStream(Encoding.ASCII.GetBytes("12345\r\n"));

--- a/BeanBot.Tests/Services/DiscordConnectionHealthTests.cs
+++ b/BeanBot.Tests/Services/DiscordConnectionHealthTests.cs
@@ -9,6 +9,28 @@ namespace BeanBot.Tests.Services;
 public class DiscordConnectionHealthTests
 {
     [Fact]
+    public void InitialSnapshot_HasNoDisconnectReason()
+    {
+        using var discordClient = new DiscordSocketClient();
+        var snapshot = new DiscordConnectionHealth().CreateSnapshot(discordClient);
+
+        Assert.Null(snapshot.MostRecentDisconnectReason);
+        Assert.False(snapshot.IsHealthy);
+    }
+
+    [Fact]
+    public void MarkDisconnected_NullExceptionUsesFallbackReason()
+    {
+        using var discordClient = new DiscordSocketClient();
+        var health = new DiscordConnectionHealth();
+
+        health.MarkDisconnected(null);
+        var snapshot = health.CreateSnapshot(discordClient);
+
+        Assert.Equal("Discord gateway disconnected.", snapshot.MostRecentDisconnectReason);
+    }
+
+    [Fact]
     public void MarkReady_PreservesMostRecentDisconnectReasonForDiagnostics()
     {
         using var discordClient = new DiscordSocketClient();

--- a/BeanBot.Tests/Services/DiscordGatewayRecoveryServiceTests.cs
+++ b/BeanBot.Tests/Services/DiscordGatewayRecoveryServiceTests.cs
@@ -152,7 +152,7 @@ public class DiscordGatewayRecoveryServiceTests
 
         public Task OpenAsync(
             DateTimeOffset disconnectedAtUtc,
-            string mostRecentDisconnectReason,
+            string? mostRecentDisconnectReason,
             CancellationToken cancellationToken = default)
         {
             CurrentOutage ??= CreateOutage(disconnectedAtUtc, mostRecentDisconnectReason);
@@ -161,11 +161,11 @@ public class DiscordGatewayRecoveryServiceTests
 
         public Task MarkManualRecoveryAttemptedAsync(
             DateTimeOffset disconnectedAtUtc,
-            string mostRecentDisconnectReason,
+            string? mostRecentDisconnectReason,
             CancellationToken cancellationToken = default)
         {
             CurrentOutage ??= CreateOutage(disconnectedAtUtc, mostRecentDisconnectReason);
-            CurrentOutage.MostRecentDisconnectReason = mostRecentDisconnectReason;
+            CurrentOutage.MostRecentDisconnectReason = NormalizeReason(mostRecentDisconnectReason);
             CurrentOutage.ManualRecoveryAttempted = true;
             StateTransitions.Add("manual");
             return Task.CompletedTask;
@@ -173,11 +173,11 @@ public class DiscordGatewayRecoveryServiceTests
 
         public Task MarkProcessRestartRequestedAsync(
             DateTimeOffset disconnectedAtUtc,
-            string mostRecentDisconnectReason,
+            string? mostRecentDisconnectReason,
             CancellationToken cancellationToken = default)
         {
             Assert.NotNull(CurrentOutage);
-            CurrentOutage.MostRecentDisconnectReason = mostRecentDisconnectReason;
+            CurrentOutage.MostRecentDisconnectReason = NormalizeReason(mostRecentDisconnectReason);
             CurrentOutage.ProcessRestartRequested = true;
             StateTransitions.Add("restart");
             return Task.CompletedTask;
@@ -191,12 +191,15 @@ public class DiscordGatewayRecoveryServiceTests
 
         private static DiscordOutage CreateOutage(
             DateTimeOffset disconnectedAtUtc,
-            string mostRecentDisconnectReason)
+            string? mostRecentDisconnectReason)
             => new()
             {
                 DisconnectedAtUtc = disconnectedAtUtc,
-                MostRecentDisconnectReason = mostRecentDisconnectReason
+                MostRecentDisconnectReason = NormalizeReason(mostRecentDisconnectReason)
             };
+
+        private static string NormalizeReason(string? reason)
+            => reason ?? "Discord gateway disconnected.";
     }
 
     private sealed class FakeHealthState

--- a/BeanBot.Tests/Services/DiscordOutageRecoveryNotifierTests.cs
+++ b/BeanBot.Tests/Services/DiscordOutageRecoveryNotifierTests.cs
@@ -101,20 +101,20 @@ public class DiscordOutageRecoveryNotifierTests
         public Task<DiscordOutage?> ReadAsync(CancellationToken cancellationToken = default)
             => Task.FromResult(CurrentOutage);
 
-        public Task OpenAsync(DateTimeOffset disconnectedAtUtc, string reason, CancellationToken cancellationToken = default)
+        public Task OpenAsync(DateTimeOffset disconnectedAtUtc, string? reason, CancellationToken cancellationToken = default)
         {
             CurrentOutage ??= new DiscordOutage
             {
                 DisconnectedAtUtc = disconnectedAtUtc,
-                MostRecentDisconnectReason = reason
+                MostRecentDisconnectReason = reason ?? "Discord gateway disconnected."
             };
             return Task.CompletedTask;
         }
 
-        public Task MarkManualRecoveryAttemptedAsync(DateTimeOffset disconnectedAtUtc, string reason, CancellationToken cancellationToken = default)
+        public Task MarkManualRecoveryAttemptedAsync(DateTimeOffset disconnectedAtUtc, string? reason, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
 
-        public Task MarkProcessRestartRequestedAsync(DateTimeOffset disconnectedAtUtc, string reason, CancellationToken cancellationToken = default)
+        public Task MarkProcessRestartRequestedAsync(DateTimeOffset disconnectedAtUtc, string? reason, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
 
         public Task ClearAsync(CancellationToken cancellationToken = default)

--- a/BeanBot.Tests/Services/DiscordOutageStoreTests.cs
+++ b/BeanBot.Tests/Services/DiscordOutageStoreTests.cs
@@ -96,6 +96,50 @@ public sealed class DiscordOutageStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task ReadAsync_MissingReasonUsesStableFallback()
+    {
+        var outagePath = Path.Combine(_temporaryDirectory, DiscordOutageStore.OutageFileName);
+        await File.WriteAllTextAsync(
+            outagePath,
+            "{\"DisconnectedAtUtc\":\"2026-08-12T07:42:15+00:00\"}");
+        using var store = new DiscordOutageStore(_temporaryDirectory);
+
+        var outage = await store.ReadAsync();
+
+        Assert.NotNull(outage);
+        Assert.Equal("Discord gateway disconnected.", outage.MostRecentDisconnectReason);
+        Assert.True(File.Exists(outagePath));
+    }
+
+    [Fact]
+    public async Task ReadAsync_ExplicitNullReasonUsesStableFallback()
+    {
+        var outagePath = Path.Combine(_temporaryDirectory, DiscordOutageStore.OutageFileName);
+        await File.WriteAllTextAsync(
+            outagePath,
+            "{\"DisconnectedAtUtc\":\"2026-08-12T07:42:15+00:00\",\"MostRecentDisconnectReason\":null}");
+        using var store = new DiscordOutageStore(_temporaryDirectory);
+
+        var outage = await store.ReadAsync();
+
+        Assert.NotNull(outage);
+        Assert.Equal("Discord gateway disconnected.", outage.MostRecentDisconnectReason);
+        Assert.True(File.Exists(outagePath));
+    }
+
+    [Fact]
+    public async Task OpenAsync_NullReasonPersistsStableFallback()
+    {
+        using var store = new DiscordOutageStore(_temporaryDirectory);
+
+        await store.OpenAsync(DateTimeOffset.UtcNow, null);
+        var outage = await store.ReadAsync();
+
+        Assert.NotNull(outage);
+        Assert.Equal("Discord gateway disconnected.", outage.MostRecentDisconnectReason);
+    }
+
+    [Fact]
     public async Task WriteAsync_LeavesCompleteFinalFileAndNoTemporaryFile()
     {
         using var store = new DiscordOutageStore(_temporaryDirectory);

--- a/BeanBot.Tests/Services/RoleReactServiceTests.cs
+++ b/BeanBot.Tests/Services/RoleReactServiceTests.cs
@@ -1,0 +1,71 @@
+using BeanBot.Repository;
+using BeanBot.Services;
+
+using MongoDB.Driver;
+
+using System.Reflection;
+
+using Xunit;
+
+namespace BeanBot.Tests.Services;
+
+public class RoleReactServiceTests
+{
+    [Fact]
+    public async Task DisposeAsync_DrainsTrackedHandlersBeforeDisposingCacheLock()
+    {
+        var service = CreateService(TimeSpan.FromSeconds(1));
+        var cacheLock = GetCacheLock(service);
+        var handlerCompletion = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var handler = service.TrackHandlerAsync(() => handlerCompletion.Task);
+
+        var firstDispose = service.DisposeAsync().AsTask();
+        var secondDispose = service.DisposeAsync().AsTask();
+
+        Assert.False(firstDispose.IsCompleted);
+        Assert.False(secondDispose.IsCompleted);
+        handlerCompletion.SetResult();
+
+        await handler;
+        await firstDispose;
+        await secondDispose;
+
+        Assert.Throws<ObjectDisposedException>(() => cacheLock.Wait(0));
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DrainTimeoutLeavesCacheLockForProcessExit()
+    {
+        var service = CreateService(TimeSpan.FromMilliseconds(20));
+        var cacheLock = GetCacheLock(service);
+        var handlerCompletion = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var handler = service.TrackHandlerAsync(() => handlerCompletion.Task);
+
+        await service.DisposeAsync();
+
+        Assert.True(cacheLock.Wait(0));
+        cacheLock.Release();
+        handlerCompletion.SetResult();
+        await handler;
+    }
+
+    private static RoleReactService CreateService(TimeSpan shutdownDrainTimeout)
+    {
+        var database = new MongoClient("mongodb://localhost:27017")
+            .GetDatabase("BeanBotNullableTests");
+        return new RoleReactService(
+            new RoleReactRepository(database),
+            client: null,
+            shutdownDrainTimeout);
+    }
+
+    private static SemaphoreSlim GetCacheLock(RoleReactService service)
+    {
+        var cacheLockField = typeof(RoleReactService).GetField(
+            "_cacheLock",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        return Assert.IsType<SemaphoreSlim>(cacheLockField?.GetValue(service));
+    }
+}

--- a/BeanBot.Tests/Util/FortuneAnswerStoreTests.cs
+++ b/BeanBot.Tests/Util/FortuneAnswerStoreTests.cs
@@ -3,12 +3,12 @@ using Xunit;
 
 namespace BeanBot.Tests.Util;
 
-public class FortuneAnswerQueueTests
+public class FortuneAnswerStoreTests
 {
     [Fact]
     public void Reservation_CanBeConsumedOnce()
     {
-        var queue = new FortuneAnswerQueue();
+        var queue = new FortuneAnswerStore();
         queue.Queue(42, positive: true);
 
         Assert.True(queue.TryReserve(42, out var reservation));
@@ -20,7 +20,7 @@ public class FortuneAnswerQueueTests
     [Fact]
     public void WrongRecipient_DoesNotReserveOrConsumeAnswer()
     {
-        var queue = new FortuneAnswerQueue();
+        var queue = new FortuneAnswerStore();
         queue.Queue(42, positive: false);
 
         Assert.False(queue.TryReserve(7, out _));
@@ -31,7 +31,7 @@ public class FortuneAnswerQueueTests
     [Fact]
     public void ReplacedAnswer_IsNotConsumedByAnOlderReservation()
     {
-        var queue = new FortuneAnswerQueue();
+        var queue = new FortuneAnswerStore();
         queue.Queue(42, positive: true);
         Assert.True(queue.TryReserve(42, out var oldReservation));
 

--- a/BeanBot/BeanBot.csproj
+++ b/BeanBot/BeanBot.csproj
@@ -3,6 +3,10 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AnalysisLevel>latest-recommended</AnalysisLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BeanBot/Configuration/BeanBotOptions.cs
+++ b/BeanBot/Configuration/BeanBotOptions.cs
@@ -35,7 +35,7 @@ namespace BeanBot.Configuration
             bool enabled,
             IPAddress bindAddress,
             int port,
-            string bearerToken,
+            string? bearerToken,
             TimeSpan minimumPollInterval)
         {
             Enabled = enabled;
@@ -49,7 +49,7 @@ namespace BeanBot.Configuration
         public IPAddress BindAddress { get; }
         public int Port { get; }
         public string Path { get; } = "/healthz";
-        public string BearerToken { get; }
+        public string? BearerToken { get; }
         public TimeSpan MinimumPollInterval { get; }
 
         public static HealthCheckOptions Disabled { get; } = new HealthCheckOptions(

--- a/BeanBot/Configuration/BeanBotOptionsLoader.cs
+++ b/BeanBot/Configuration/BeanBotOptionsLoader.cs
@@ -28,7 +28,7 @@ namespace BeanBot.Configuration
             return options;
         }
 
-        internal static BeanBotOptions Load(Func<string, string> getEnvironmentValue)
+        internal static BeanBotOptions Load(Func<string, string?> getEnvironmentValue)
         {
             var missingSettings = new List<string>();
             var botToken = GetRequired(getEnvironmentValue, BotTokenVariable, "botToken", missingSettings);
@@ -42,21 +42,21 @@ namespace BeanBot.Configuration
                 throw new InvalidOperationException($"Missing required environment variables: {string.Join(", ", missingSettings)}");
             }
 
-            if (!ulong.TryParse(generalChannel, NumberStyles.None, CultureInfo.InvariantCulture, out var generalChannelId))
+            if (!ulong.TryParse(generalChannel!, NumberStyles.None, CultureInfo.InvariantCulture, out var generalChannelId))
             {
-                throw InvalidValue(GeneralChannelVariable, generalChannel, "a Discord snowflake ID");
+                throw InvalidValue(GeneralChannelVariable, generalChannel!, "a Discord snowflake ID");
             }
 
             return new BeanBotOptions(
-                botToken,
-                mongoConnection,
+                botToken!,
+                mongoConnection!,
                 generalChannelId,
-                ParseHttpUri(HatoeteUrlVariable, hatoeteUrl),
-                ParseHttpUri(YoshimaruUrlVariable, yoshimaruUrl),
+                ParseHttpUri(HatoeteUrlVariable, hatoeteUrl!),
+                ParseHttpUri(YoshimaruUrlVariable, yoshimaruUrl!),
                 LoadHealthCheckOptions(getEnvironmentValue));
         }
 
-        private static HealthCheckOptions LoadHealthCheckOptions(Func<string, string> getEnvironmentValue)
+        private static HealthCheckOptions LoadHealthCheckOptions(Func<string, string?> getEnvironmentValue)
         {
             var portValue = GetOptional(getEnvironmentValue, HealthCheckPortVariable, "healthCheckPort");
             if (string.IsNullOrWhiteSpace(portValue))
@@ -106,11 +106,11 @@ namespace BeanBot.Configuration
             return uri;
         }
 
-        private static string GetRequired(
-            Func<string, string> getEnvironmentValue,
+        private static string? GetRequired(
+            Func<string, string?> getEnvironmentValue,
             string preferredName,
             string legacyName,
-            ICollection<string> missingSettings)
+            List<string> missingSettings)
         {
             var value = GetOptional(getEnvironmentValue, preferredName, legacyName);
             if (!string.IsNullOrWhiteSpace(value))
@@ -122,7 +122,7 @@ namespace BeanBot.Configuration
             return null;
         }
 
-        private static string GetOptional(Func<string, string> getEnvironmentValue, string preferredName, string legacyName)
+        private static string? GetOptional(Func<string, string?> getEnvironmentValue, string preferredName, string legacyName)
             => getEnvironmentValue(preferredName) ?? getEnvironmentValue(legacyName);
 
         private static InvalidOperationException InvalidValue(string variableName, string value, string expectation)
@@ -149,7 +149,7 @@ namespace BeanBot.Configuration
                 foreach (var rawLine in File.ReadAllLines(candidatePath))
                 {
                     var line = rawLine.Trim();
-                    if (string.IsNullOrWhiteSpace(line) || line.StartsWith("#", StringComparison.Ordinal))
+                    if (string.IsNullOrWhiteSpace(line) || line.StartsWith('#'))
                     {
                         continue;
                     }

--- a/BeanBot/Entities/Pun.cs
+++ b/BeanBot/Entities/Pun.cs
@@ -2,6 +2,6 @@
 {
     public class Pun
     {
-        public string BadPost { get; set; }
+        public string BadPost { get; set; } = string.Empty;
     }
 }

--- a/BeanBot/Entities/RoleSettings.cs
+++ b/BeanBot/Entities/RoleSettings.cs
@@ -11,12 +11,12 @@ namespace BeanBot.Entities
     public class RoleSettings
     {
         [BsonId]
-        public ObjectId id;
-        public List<RoleEmotePair> roleEmotePair;
-        public string guildId;
-        public string channelId;
-        public string messageId;
-        public DateTime lastAccessed;
+        public ObjectId id { get; set; }
+        public List<RoleEmotePair> roleEmotePair { get; set; } = new();
+        public string guildId { get; set; } = string.Empty;
+        public string channelId { get; set; } = string.Empty;
+        public string messageId { get; set; } = string.Empty;
+        public DateTime lastAccessed { get; set; }
 
         public RoleSettings() { }
 

--- a/BeanBot/EventHandlers/CommandHandler.cs
+++ b/BeanBot/EventHandlers/CommandHandler.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 using Serilog;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Threading.Tasks;
 
@@ -18,7 +19,7 @@ namespace BeanBot.EventHandlers
         private readonly DiscordSocketClient _discordClient;
         private readonly CommandService _commandService;
         private readonly IServiceProvider _services;
-        private readonly FortuneAnswerQueue _fortuneAnswers;
+        private readonly FortuneAnswerStore _fortuneAnswers;
         private readonly DiscordMessageWaiter _messageWaiter;
         private bool _initialized;
 
@@ -31,7 +32,7 @@ namespace BeanBot.EventHandlers
             _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
             _commandService = commandService ?? throw new ArgumentNullException(nameof(commandService));
             _services = services ?? throw new ArgumentNullException(nameof(services));
-            _fortuneAnswers = _services.GetRequiredService<FortuneAnswerQueue>();
+            _fortuneAnswers = _services.GetRequiredService<FortuneAnswerStore>();
             _messageWaiter = _services.GetRequiredService<DiscordMessageWaiter>();
         }
 
@@ -98,7 +99,7 @@ namespace BeanBot.EventHandlers
                             discordMessage.HasCharPrefix('%', ref argPos));
         }
 
-        internal bool MessageIsSystemMessage(SocketUserMessage discordMessage)
+        internal static bool MessageIsSystemMessage([NotNullWhen(false)] SocketUserMessage? discordMessage)
             => discordMessage == null;
 
     }

--- a/BeanBot/EventHandlers/PunHandler.cs
+++ b/BeanBot/EventHandlers/PunHandler.cs
@@ -18,7 +18,7 @@ namespace BeanBot.EventHandlers
         private readonly DiscordSocketClient _discordClient;
         private readonly ulong _generalChannelId;
         private readonly CancellationTokenSource _tokenSource = new();
-        private Task _runner;
+        private Task? _runner;
         private int _disposed;
 
         private static readonly TimeSpan PostTimeLocal = new TimeSpan(16, 20, 0);
@@ -32,10 +32,7 @@ namespace BeanBot.EventHandlers
 
         public void Start()
         {
-            if (Volatile.Read(ref _disposed) != 0)
-            {
-                throw new ObjectDisposedException(nameof(PunHandler));
-            }
+            ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
 
             if (_runner is not null)
             {
@@ -62,9 +59,9 @@ namespace BeanBot.EventHandlers
 
                     var chicagoNow = GetChicagoNow(timezone);
                     Log.Information("Next pun scheduled for {NextLocal} Chicago ({NextUtc} UTC). Now: {NowLocal} Chicago",
-                        TimeZoneInfo.ConvertTime(nextRunUtc, timezone).ToString("yyyy-MM-dd HH:mm:ss"),
-                        nextRunUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss"),
-                        chicagoNow.ToString("yyyy-MM-dd HH:mm:ss"));
+                        TimeZoneInfo.ConvertTime(nextRunUtc, timezone).ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture),
+                        nextRunUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture),
+                        chicagoNow.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture));
 
                     await Task.Delay(delay, token);
 

--- a/BeanBot/Hosting/BeanBotRuntime.cs
+++ b/BeanBot/Hosting/BeanBotRuntime.cs
@@ -211,7 +211,7 @@ namespace BeanBot.Hosting
             }
         }
 
-        private Task OnDiscordDisconnectedAsync(Exception exception)
+        private Task OnDiscordDisconnectedAsync(Exception? exception)
         {
             _discordConnectionHealth.MarkDisconnected(exception);
             var snapshot = _discordConnectionHealth.CreateSnapshot(_discordClient);
@@ -249,7 +249,7 @@ namespace BeanBot.Hosting
             }
         }
 
-        private static void HandleUnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs eventArgs)
+        private static void HandleUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs eventArgs)
         {
             Log.Error(eventArgs.Exception, "An unobserved task exception occurred");
             eventArgs.SetObserved();

--- a/BeanBot/Hosting/BeanBotServiceCollectionExtensions.cs
+++ b/BeanBot/Hosting/BeanBotServiceCollectionExtensions.cs
@@ -94,7 +94,7 @@ namespace BeanBot.Hosting
                     provider.GetRequiredService<IRecoveryDelay>());
             });
 
-            services.AddSingleton<FortuneAnswerQueue>();
+            services.AddSingleton<FortuneAnswerStore>();
             services.AddSingleton<DiscordMessageWaiter>();
             services.AddSingleton<DiscordPaginatorService>();
             services.AddSingleton<RoleReactRepository>();

--- a/BeanBot/Modules/AdministrativeModule.cs
+++ b/BeanBot/Modules/AdministrativeModule.cs
@@ -7,6 +7,7 @@ using Discord.WebSocket;
 using Serilog;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -84,13 +85,17 @@ namespace BeanBot.Modules
                         return;
                     }
 
-                    if (roleEmotePairs.Any(pair => pair.roleId == role.Id.ToString() || pair.emojiId == emote.Id.ToString()))
+                    if (roleEmotePairs.Any(pair =>
+                        pair.roleId == role.Id.ToString(CultureInfo.InvariantCulture)
+                        || pair.emojiId == emote.Id.ToString(CultureInfo.InvariantCulture)))
                     {
                         messagesInInteraction.Add(await ReplyAsync("That role or emote is already being configured. Please start again."));
                         return;
                     }
 
-                    roleEmotePairs.Add(new RoleEmotePair(role.Id.ToString(), emote.Id.ToString()));
+                    roleEmotePairs.Add(new RoleEmotePair(
+                        role.Id.ToString(CultureInfo.InvariantCulture),
+                        emote.Id.ToString(CultureInfo.InvariantCulture)));
                 }
 
                 messagesInInteraction.Add(await ReplyAsync("Please label this group of roles (i.e. Games, Position, NSFW, etc)."));
@@ -126,7 +131,8 @@ namespace BeanBot.Modules
             var roleEmbed = new EmbedBuilder();
             foreach (var pair in pairs)
             {
-                var emote = Context.Guild.Emotes.First(candidate => candidate.Id.ToString() == pair.emojiId);
+                var emote = Context.Guild.Emotes.First(candidate =>
+                    candidate.Id.ToString(CultureInfo.InvariantCulture) == pair.emojiId);
                 roleEmbed.AddField(emote.ToString(), $"<@&{pair.roleId}>", inline: true);
             }
 
@@ -139,13 +145,14 @@ namespace BeanBot.Modules
             var pairs = roleEmotePairs.ToList();
             foreach (var pair in pairs)
             {
-                var emote = Context.Guild.Emotes.First(candidate => candidate.Id.ToString() == pair.emojiId);
+                var emote = Context.Guild.Emotes.First(candidate =>
+                    candidate.Id.ToString(CultureInfo.InvariantCulture) == pair.emojiId);
                 await messageToListen.AddReactionAsync(emote);
                 await Task.Delay(TimeSpan.FromMilliseconds(250));
             }
         }
 
-        private async Task<(bool Success, int RoleCount)> GetRoleCountAsync(List<IMessage> messages, SocketMessage response)
+        private async Task<(bool Success, int RoleCount)> GetRoleCountAsync(List<IMessage> messages, SocketMessage? response)
         {
             if (response == null)
             {
@@ -163,7 +170,7 @@ namespace BeanBot.Modules
             return (true, roleCount);
         }
 
-        private async Task<SocketRole> GetRoleAsync(List<IMessage> messages, SocketMessage response)
+        private async Task<SocketRole?> GetRoleAsync(List<IMessage> messages, SocketMessage? response)
         {
             if (response == null)
             {
@@ -241,7 +248,7 @@ namespace BeanBot.Modules
             };
         }
 
-        private async Task<Emote> GetEmoteAsync(List<IMessage> messages, SocketMessage response)
+        private async Task<Emote?> GetEmoteAsync(List<IMessage> messages, SocketMessage? response)
         {
             if (response == null)
             {
@@ -261,7 +268,7 @@ namespace BeanBot.Modules
             return emote;
         }
 
-        private async Task CleanUpMessagesAsync(IReadOnlyCollection<IMessage> messages)
+        private async Task CleanUpMessagesAsync(List<IMessage> messages)
         {
             await Task.Delay(TimeSpan.FromSeconds(5));
             if (Context.Channel is not ITextChannel textChannel || messages.Count == 0)

--- a/BeanBot/Modules/HelpModule.cs
+++ b/BeanBot/Modules/HelpModule.cs
@@ -40,7 +40,7 @@ namespace BeanBot.Modules
                         continue;
                     }
 
-                    description.Append("**").Append(command.Aliases.First()).AppendLine("**");
+                    description.Append("**").Append(command.Aliases[0]).AppendLine("**");
                     if (command.Aliases.Count > 1)
                     {
                         description.AppendLine(command.Aliases.Count > 2

--- a/BeanBot/Modules/MemeModule.cs
+++ b/BeanBot/Modules/MemeModule.cs
@@ -24,12 +24,12 @@ namespace BeanBot.Modules
         private static readonly HttpClient HttpClient = new HttpClient();
         private readonly MemeMachine _memeMachine = new MemeMachine();
         private readonly BeanBotOptions _options;
-        private readonly FortuneAnswerQueue _fortuneAnswers;
+        private readonly FortuneAnswerStore _fortuneAnswers;
         private readonly DiscordPaginatorService _paginator;
 
         public MemeModule(
             BeanBotOptions options,
-            FortuneAnswerQueue fortuneAnswers,
+            FortuneAnswerStore fortuneAnswers,
             DiscordPaginatorService paginator)
         {
             _options = options ?? throw new ArgumentNullException(nameof(options));
@@ -165,7 +165,7 @@ namespace BeanBot.Modules
         }
         private async Task InvokeMemeApi(string subreddit)
         {
-            Meme meme;
+            Meme? meme;
             try
             {
                 if (string.IsNullOrEmpty(subreddit))

--- a/BeanBot/Program.cs
+++ b/BeanBot/Program.cs
@@ -19,7 +19,7 @@ namespace BeanBot
 
         private static async Task<int> Main(string[] args)
         {
-            IHost host = null;
+            IHost? host = null;
             try
             {
                 DirectorySetup.MakeSureAllDirectoriesExist();
@@ -70,7 +70,7 @@ namespace BeanBot
             }
         }
 
-        private static bool IsHostStopping(IHost host)
+        private static bool IsHostStopping(IHost? host)
             => host?.Services
                 .GetService<IHostApplicationLifetime>()
                 ?.ApplicationStopping

--- a/BeanBot/Repository/RoleReactRepository.cs
+++ b/BeanBot/Repository/RoleReactRepository.cs
@@ -4,6 +4,7 @@ using MongoDB.Driver;
 using Serilog;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Threading.Tasks;
 
 namespace BeanBot.Repository
@@ -48,11 +49,12 @@ namespace BeanBot.Repository
             }
         }
 
-        public async Task<RoleSettings> GetRoleSetting(IUserMessage message)
+        public async Task<RoleSettings?> GetRoleSetting(IUserMessage message)
         {
             try
             {
-                var filterByMessageId = Builders<RoleSettings>.Filter.Where(doc => doc.messageId == message.Id.ToString());
+                var messageId = message.Id.ToString(CultureInfo.InvariantCulture);
+                var filterByMessageId = Builders<RoleSettings>.Filter.Where(doc => doc.messageId == messageId);
                 return await _roleSettings.Find(filterByMessageId).FirstOrDefaultAsync();
             }
             catch (Exception e)

--- a/BeanBot/Services/BoundedClientRateLimiter.cs
+++ b/BeanBot/Services/BoundedClientRateLimiter.cs
@@ -18,17 +18,10 @@ namespace BeanBot.Services
         public BoundedClientRateLimiter(
             TimeSpan minimumPollInterval,
             int capacity,
-            Func<DateTimeOffset> getUtcNow = null)
+            Func<DateTimeOffset>? getUtcNow = null)
         {
-            if (minimumPollInterval <= TimeSpan.Zero)
-            {
-                throw new ArgumentOutOfRangeException(nameof(minimumPollInterval));
-            }
-
-            if (capacity <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(capacity));
-            }
+            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(minimumPollInterval, TimeSpan.Zero);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(capacity);
 
             _minimumPollInterval = minimumPollInterval;
             _retentionPeriod = minimumPollInterval.Ticks <= TimeSpan.MaxValue.Ticks / 2

--- a/BeanBot/Services/BoundedLineReader.cs
+++ b/BeanBot/Services/BoundedLineReader.cs
@@ -20,12 +20,9 @@ namespace BeanBot.Services
             _stream = stream ?? throw new ArgumentNullException(nameof(stream));
         }
 
-        public async Task<string> ReadLineAsync(int maximumLength, CancellationToken cancellationToken)
+        public async Task<string?> ReadLineAsync(int maximumLength, CancellationToken cancellationToken)
         {
-            if (maximumLength < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(maximumLength));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(maximumLength);
 
             var lineBuffer = ArrayPool<byte>.Shared.Rent(Math.Max(1, maximumLength + 1));
             var lineLength = 0;

--- a/BeanBot/Services/DiscordConnectionHealth.cs
+++ b/BeanBot/Services/DiscordConnectionHealth.cs
@@ -12,7 +12,7 @@ namespace BeanBot.Services
         private DateTimeOffset? _lastReadyAtUtc;
         private DateTimeOffset? _lastDisconnectedAtUtc;
         private DateTimeOffset? _unhealthySinceAtUtc;
-        private string _mostRecentDisconnectReason;
+        private string? _mostRecentDisconnectReason;
 
         public void MarkReady()
         {
@@ -24,7 +24,7 @@ namespace BeanBot.Services
             }
         }
 
-        public void MarkDisconnected(Exception exception)
+        public void MarkDisconnected(Exception? exception)
         {
             lock (_syncRoot)
             {
@@ -94,7 +94,7 @@ namespace BeanBot.Services
             DateTimeOffset? lastReadyAtUtc,
             DateTimeOffset? lastDisconnectedAtUtc,
             DateTimeOffset? unhealthySinceAtUtc,
-            string mostRecentDisconnectReason)
+            string? mostRecentDisconnectReason)
         {
             IsHealthy = isHealthy;
             StatusMessage = statusMessage;
@@ -113,6 +113,6 @@ namespace BeanBot.Services
         public DateTimeOffset? LastReadyAtUtc { get; }
         public DateTimeOffset? LastDisconnectedAtUtc { get; }
         public DateTimeOffset? UnhealthySinceAtUtc { get; }
-        public string MostRecentDisconnectReason { get; }
+        public string? MostRecentDisconnectReason { get; }
     }
 }

--- a/BeanBot/Services/DiscordGatewayRecoveryService.cs
+++ b/BeanBot/Services/DiscordGatewayRecoveryService.cs
@@ -122,17 +122,17 @@ namespace BeanBot.Services
         private readonly IRecoveryDelay _delay;
         private readonly Action<int> _exitProcess;
         private readonly CancellationTokenSource _shutdown = new();
-        private TaskCompletionSource<bool> _readySignal;
-        private Task _monitorTask;
+        private TaskCompletionSource<bool>? _readySignal;
+        private Task? _monitorTask;
         private bool _disposed;
 
         public DiscordGatewayRecoveryService(
             Func<DiscordHealthSnapshot> createHealthSnapshot,
             IDiscordGatewayLifecycle lifecycle,
             IDiscordOutageStore outageStore,
-            DiscordGatewayRecoveryOptions options = null,
-            IRecoveryDelay delay = null,
-            Action<int> exitProcess = null)
+            DiscordGatewayRecoveryOptions? options = null,
+            IRecoveryDelay? delay = null,
+            Action<int>? exitProcess = null)
         {
             _createHealthSnapshot = createHealthSnapshot ?? throw new ArgumentNullException(nameof(createHealthSnapshot));
             _lifecycle = lifecycle ?? throw new ArgumentNullException(nameof(lifecycle));
@@ -380,7 +380,8 @@ namespace BeanBot.Services
                 TaskCompletionSource<bool> readySignal;
                 lock (_syncRoot)
                 {
-                    readySignal = _readySignal;
+                    readySignal = _readySignal
+                        ?? throw new InvalidOperationException("Discord gateway recovery has no Ready signal.");
                 }
 
                 var remaining = timeout - stopwatch.Elapsed;
@@ -436,7 +437,7 @@ namespace BeanBot.Services
 
         public async ValueTask DisposeAsync()
         {
-            Task monitorTask;
+            Task? monitorTask;
             lock (_syncRoot)
             {
                 if (_disposed)

--- a/BeanBot/Services/DiscordMessageCleanupService.cs
+++ b/BeanBot/Services/DiscordMessageCleanupService.cs
@@ -11,15 +11,23 @@ namespace BeanBot.Services
     {
         internal const int MaximumBulkDeleteCount = 100;
         private static readonly TimeSpan MaximumBulkDeleteAge = TimeSpan.FromDays(14) - TimeSpan.FromMinutes(5);
+        private readonly Func<DateTimeOffset> _getUtcNow;
+
+        public DiscordMessageCleanupService()
+            : this(() => DateTimeOffset.UtcNow)
+        {
+        }
+
+        internal DiscordMessageCleanupService(Func<DateTimeOffset> getUtcNow)
+        {
+            _getUtcNow = getUtcNow ?? throw new ArgumentNullException(nameof(getUtcNow));
+        }
 
         public Task DeleteAsync(ITextChannel channel, IReadOnlyCollection<IMessage> messages)
         {
-            if (channel == null)
-            {
-                throw new ArgumentNullException(nameof(channel));
-            }
+            ArgumentNullException.ThrowIfNull(channel);
 
-            var plan = CreatePlan(messages, message => message.Timestamp, DateTimeOffset.UtcNow);
+            var plan = CreatePlan(messages, message => message.Timestamp, _getUtcNow());
             return ExecutePlanAsync(
                 plan,
                 batch => channel.DeleteMessagesAsync(batch),
@@ -36,15 +44,8 @@ namespace BeanBot.Services
             Func<T, DateTimeOffset> getTimestamp,
             DateTimeOffset now)
         {
-            if (messages == null)
-            {
-                throw new ArgumentNullException(nameof(messages));
-            }
-
-            if (getTimestamp == null)
-            {
-                throw new ArgumentNullException(nameof(getTimestamp));
-            }
+            ArgumentNullException.ThrowIfNull(messages);
+            ArgumentNullException.ThrowIfNull(getTimestamp);
 
             var oldestBulkDeleteTimestamp = now.Subtract(MaximumBulkDeleteAge);
             var recent = messages.Where(message => getTimestamp(message) >= oldestBulkDeleteTimestamp).ToList();

--- a/BeanBot/Services/DiscordMessageWaiter.cs
+++ b/BeanBot/Services/DiscordMessageWaiter.cs
@@ -14,15 +14,12 @@ namespace BeanBot.Services
         internal const int MaximumPendingWaits = 64;
         private readonly BoundedMessageWaiter<SocketMessage> _waiter = new(MaximumPendingWaits);
 
-        public Task<SocketMessage> WaitForNextMessageAsync(
+        public Task<SocketMessage?> WaitForNextMessageAsync(
             SocketCommandContext context,
             TimeSpan timeout,
             CancellationToken cancellationToken = default)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             return _waiter.WaitAsync(
                 context.User.Id,
@@ -57,29 +54,23 @@ namespace BeanBot.Services
 
         public BoundedMessageWaiter(int maximumPendingWaits)
         {
-            if (maximumPendingWaits <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(maximumPendingWaits));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumPendingWaits);
 
             _availableSlots = new SemaphoreSlim(maximumPendingWaits, maximumPendingWaits);
         }
 
         internal int PendingCount => _pending.Count;
 
-        public async Task<TMessage> WaitAsync(
+        public async Task<TMessage?> WaitAsync(
             ulong userId,
             ulong channelId,
             TimeSpan timeout,
             CancellationToken cancellationToken = default)
         {
             ThrowIfDisposed();
-            if (timeout <= TimeSpan.Zero)
-            {
-                throw new ArgumentOutOfRangeException(nameof(timeout));
-            }
+            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(timeout, TimeSpan.Zero);
 
-            if (!_availableSlots.Wait(0))
+            if (!_availableSlots.Wait(0, cancellationToken))
             {
                 throw new InvalidOperationException("Too many Discord message waits are already active.");
             }
@@ -152,10 +143,9 @@ namespace BeanBot.Services
 
         private void ThrowIfDisposed()
         {
-            if (Volatile.Read(ref _disposed) != 0)
-            {
-                throw new ObjectDisposedException(nameof(BoundedMessageWaiter<TMessage>));
-            }
+            ObjectDisposedException.ThrowIf(
+                Volatile.Read(ref _disposed) != 0,
+                this);
         }
 
         private void RemovePendingWait(MessageWaitKey key, PendingWait pending)

--- a/BeanBot/Services/DiscordOutageRecoveryNotifier.cs
+++ b/BeanBot/Services/DiscordOutageRecoveryNotifier.cs
@@ -3,6 +3,7 @@ using BeanBot.Util;
 using Serilog;
 
 using System;
+using System.Globalization;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -23,7 +24,7 @@ namespace BeanBot.Services
         public DiscordOutageRecoveryNotifier(
             IDiscordOutageStore outageStore,
             IOwnerAlertDelivery ownerAlertDelivery,
-            Func<int, TimeSpan> retryDelay = null,
+            Func<int, TimeSpan>? retryDelay = null,
             TimeSpan? deliveryTimeout = null)
         {
             _outageStore = outageStore ?? throw new ArgumentNullException(nameof(outageStore));
@@ -83,12 +84,20 @@ namespace BeanBot.Services
 
             var message = new StringBuilder()
                 .AppendLine("BeanBot recovered from a Discord outage.")
-                .AppendLine()
-                .AppendLine($"Disconnected: {outage.DisconnectedAtUtc.UtcDateTime:yyyy-MM-dd HH:mm:ss} UTC")
-                .AppendLine($"Approximate downtime: {FormatDuration(downtime)}")
-                .AppendLine($"Reason: {outage.MostRecentDisconnectReason}")
-                .AppendLine($"Manual recovery attempted: {FormatBoolean(outage.ManualRecoveryAttempted)}")
-                .Append($"Container restart requested: {FormatBoolean(outage.ProcessRestartRequested)}");
+                .AppendLine();
+            message.AppendLine(
+                CultureInfo.InvariantCulture,
+                $"Disconnected: {outage.DisconnectedAtUtc.UtcDateTime:yyyy-MM-dd HH:mm:ss} UTC");
+            message.AppendLine(
+                CultureInfo.InvariantCulture,
+                $"Approximate downtime: {FormatDuration(downtime)}");
+            message.AppendLine(CultureInfo.InvariantCulture, $"Reason: {outage.MostRecentDisconnectReason}");
+            message.AppendLine(
+                CultureInfo.InvariantCulture,
+                $"Manual recovery attempted: {FormatBoolean(outage.ManualRecoveryAttempted)}");
+            message.Append(
+                CultureInfo.InvariantCulture,
+                $"Container restart requested: {FormatBoolean(outage.ProcessRestartRequested)}");
 
             if (outage.ProcessRestartRequested)
             {
@@ -98,7 +107,9 @@ namespace BeanBot.Services
             var recoveryMessage = message.ToString();
             return recoveryMessage.Length <= MaximumDiscordMessageLength
                 ? recoveryMessage
-                : recoveryMessage.Substring(0, MaximumDiscordMessageLength - 15) + "\n...(truncated)";
+                : string.Concat(
+                    recoveryMessage.AsSpan(0, MaximumDiscordMessageLength - 15),
+                    "\n...(truncated)");
         }
 
         private async Task<bool> DeliverWithRetryAsync(
@@ -141,17 +152,17 @@ namespace BeanBot.Services
             var parts = new StringBuilder();
             if (duration.Days > 0)
             {
-                parts.Append($"{duration.Days}d ");
+                parts.Append(CultureInfo.InvariantCulture, $"{duration.Days}d ");
             }
             if (duration.Hours > 0 || duration.Days > 0)
             {
-                parts.Append($"{duration.Hours}h ");
+                parts.Append(CultureInfo.InvariantCulture, $"{duration.Hours}h ");
             }
             if (duration.Minutes > 0 || duration.Hours > 0 || duration.Days > 0)
             {
-                parts.Append($"{duration.Minutes}m ");
+                parts.Append(CultureInfo.InvariantCulture, $"{duration.Minutes}m ");
             }
-            parts.Append($"{duration.Seconds}s");
+            parts.Append(CultureInfo.InvariantCulture, $"{duration.Seconds}s");
             return parts.ToString();
         }
 

--- a/BeanBot/Services/DiscordOutageStore.cs
+++ b/BeanBot/Services/DiscordOutageStore.cs
@@ -11,25 +11,25 @@ namespace BeanBot.Services
     internal sealed class DiscordOutage
     {
         public DateTimeOffset DisconnectedAtUtc { get; set; }
-        public string MostRecentDisconnectReason { get; set; }
+        public string MostRecentDisconnectReason { get; set; } = "Discord gateway disconnected.";
         public bool ManualRecoveryAttempted { get; set; }
         public bool ProcessRestartRequested { get; set; }
     }
 
     internal interface IDiscordOutageStore
     {
-        Task<DiscordOutage> ReadAsync(CancellationToken cancellationToken = default);
+        Task<DiscordOutage?> ReadAsync(CancellationToken cancellationToken = default);
         Task OpenAsync(
             DateTimeOffset disconnectedAtUtc,
-            string mostRecentDisconnectReason,
+            string? mostRecentDisconnectReason,
             CancellationToken cancellationToken = default);
         Task MarkManualRecoveryAttemptedAsync(
             DateTimeOffset disconnectedAtUtc,
-            string mostRecentDisconnectReason,
+            string? mostRecentDisconnectReason,
             CancellationToken cancellationToken = default);
         Task MarkProcessRestartRequestedAsync(
             DateTimeOffset disconnectedAtUtc,
-            string mostRecentDisconnectReason,
+            string? mostRecentDisconnectReason,
             CancellationToken cancellationToken = default);
         Task ClearAsync(CancellationToken cancellationToken = default);
     }
@@ -51,7 +51,7 @@ namespace BeanBot.Services
             _outageFilePath = Path.Combine(persistentDataDirectory, OutageFileName);
         }
 
-        public async Task<DiscordOutage> ReadAsync(CancellationToken cancellationToken = default)
+        public async Task<DiscordOutage?> ReadAsync(CancellationToken cancellationToken = default)
         {
             await _fileAccess.WaitAsync(cancellationToken);
             try
@@ -66,7 +66,7 @@ namespace BeanBot.Services
 
         public async Task OpenAsync(
             DateTimeOffset disconnectedAtUtc,
-            string mostRecentDisconnectReason,
+            string? mostRecentDisconnectReason,
             CancellationToken cancellationToken = default)
         {
             await UpdateAsync(
@@ -81,7 +81,7 @@ namespace BeanBot.Services
 
         public async Task MarkManualRecoveryAttemptedAsync(
             DateTimeOffset disconnectedAtUtc,
-            string mostRecentDisconnectReason,
+            string? mostRecentDisconnectReason,
             CancellationToken cancellationToken = default)
         {
             await UpdateAsync(
@@ -101,7 +101,7 @@ namespace BeanBot.Services
 
         public async Task MarkProcessRestartRequestedAsync(
             DateTimeOffset disconnectedAtUtc,
-            string mostRecentDisconnectReason,
+            string? mostRecentDisconnectReason,
             CancellationToken cancellationToken = default)
         {
             await UpdateAsync(
@@ -135,7 +135,7 @@ namespace BeanBot.Services
         }
 
         private async Task UpdateAsync(
-            Func<DiscordOutage, DiscordOutage> updateOutage,
+            Func<DiscordOutage?, DiscordOutage> updateOutage,
             CancellationToken cancellationToken)
         {
             await _fileAccess.WaitAsync(cancellationToken);
@@ -154,7 +154,7 @@ namespace BeanBot.Services
             }
         }
 
-        private async Task<DiscordOutage> ReadWithoutLockAsync(CancellationToken cancellationToken)
+        private async Task<DiscordOutage?> ReadWithoutLockAsync(CancellationToken cancellationToken)
         {
             if (!File.Exists(_outageFilePath))
             {
@@ -177,6 +177,8 @@ namespace BeanBot.Services
                 {
                     throw new JsonException("The persisted Discord outage is missing required data.");
                 }
+
+                outage.MostRecentDisconnectReason = NormalizeReason(outage.MostRecentDisconnectReason);
 
                 Log.Information(
                     "Persisted Discord outage loaded. DisconnectedAtUtc={DisconnectedAtUtc}, ManualRecoveryAttempted={ManualRecoveryAttempted}, ProcessRestartRequested={ProcessRestartRequested}",
@@ -253,14 +255,14 @@ namespace BeanBot.Services
 
         private static DiscordOutage CreateOutage(
             DateTimeOffset disconnectedAtUtc,
-            string mostRecentDisconnectReason)
+            string? mostRecentDisconnectReason)
             => new()
             {
                 DisconnectedAtUtc = disconnectedAtUtc.ToUniversalTime(),
                 MostRecentDisconnectReason = NormalizeReason(mostRecentDisconnectReason)
             };
 
-        private static string NormalizeReason(string disconnectReason)
+        private static string NormalizeReason(string? disconnectReason)
             => string.IsNullOrWhiteSpace(disconnectReason)
                 ? "Discord gateway disconnected."
                 : disconnectReason;

--- a/BeanBot/Services/DiscordPaginatorService.cs
+++ b/BeanBot/Services/DiscordPaginatorService.cs
@@ -1,5 +1,6 @@
 using Discord;
 using Discord.Commands;
+using Discord.Rest;
 using Discord.WebSocket;
 
 using Serilog;
@@ -51,10 +52,7 @@ namespace BeanBot.Services
             TimeSpan? timeout = null)
         {
             ThrowIfDisposed();
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             var pageList = pages?.Where(page => page != null).ToList()
                 ?? throw new ArgumentNullException(nameof(pages));
@@ -78,8 +76,8 @@ namespace BeanBot.Services
                 }
             }
 
-            IUserMessage message = null;
-            PaginationSession session = null;
+            RestUserMessage? message = null;
+            PaginationSession? session = null;
             var sessionRegistered = false;
             var sessionAccessHeld = false;
             try
@@ -107,12 +105,11 @@ namespace BeanBot.Services
                     await message.AddReactionAsync(control, CreateRequestOptions(_shutdown.Token));
                 }
 
-                if (!_sessions.TryGetValue(message.Id, out var currentSession)
-                    || !ReferenceEquals(currentSession, session)
-                    || session.CompletionStarted)
-                {
-                    throw new ObjectDisposedException(nameof(DiscordPaginatorService));
-                }
+                ObjectDisposedException.ThrowIf(
+                    !_sessions.TryGetValue(message.Id, out var currentSession)
+                        || !ReferenceEquals(currentSession, session)
+                        || session.CompletionStarted,
+                    this);
 
                 return message;
             }
@@ -122,7 +119,7 @@ namespace BeanBot.Services
                 {
                     ReleaseAvailableSlot();
                 }
-                else
+                else if (message is not null && session is not null)
                 {
                     if (sessionAccessHeld)
                     {
@@ -138,7 +135,7 @@ namespace BeanBot.Services
             {
                 if (sessionAccessHeld)
                 {
-                    session.Access.Release();
+                    session?.Access.Release();
                 }
             }
         }
@@ -352,7 +349,7 @@ namespace BeanBot.Services
             }
         }
 
-        private void ReleaseAvailableSlot(PaginationSession session = null)
+        private void ReleaseAvailableSlot(PaginationSession? session = null)
         {
             lock (_syncRoot)
             {
@@ -478,10 +475,7 @@ namespace BeanBot.Services
 
         private void ThrowIfDisposed()
         {
-            if (Volatile.Read(ref _disposed) != 0)
-            {
-                throw new ObjectDisposedException(nameof(DiscordPaginatorService));
-            }
+            ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
         }
 
         private sealed class PaginationSession
@@ -582,10 +576,7 @@ namespace BeanBot.Services
     {
         public PaginationCursor(int pageCount)
         {
-            if (pageCount <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(pageCount));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pageCount);
 
             PageCount = pageCount;
         }

--- a/BeanBot/Services/DiscordStartupService.cs
+++ b/BeanBot/Services/DiscordStartupService.cs
@@ -24,15 +24,8 @@ namespace BeanBot.Services
             TimeSpan lifecycleOperationTimeout,
             Func<int, TimeSpan> retryDelay)
         {
-            if (maximumAttempts <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(maximumAttempts));
-            }
-
-            if (lifecycleOperationTimeout <= TimeSpan.Zero)
-            {
-                throw new ArgumentOutOfRangeException(nameof(lifecycleOperationTimeout));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumAttempts);
+            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(lifecycleOperationTimeout, TimeSpan.Zero);
 
             MaximumAttempts = maximumAttempts;
             LifecycleOperationTimeout = lifecycleOperationTimeout;
@@ -71,7 +64,7 @@ namespace BeanBot.Services
         private readonly Func<Task> _setPresence;
         private readonly TimeSpan _operationTimeout;
         private readonly Action<Exception, string> _lateFailureObserver;
-        private Task _unfinishedOperation;
+        private Task? _unfinishedOperation;
 
         public DiscordStartupLifecycle(
             DiscordSocketClient client,
@@ -92,7 +85,7 @@ namespace BeanBot.Services
             Func<Task> start,
             Func<Task> setPresence,
             TimeSpan operationTimeout,
-            Action<Exception, string> lateFailureObserver = null)
+            Action<Exception, string>? lateFailureObserver = null)
         {
             _login = login ?? throw new ArgumentNullException(nameof(login));
             _start = start ?? throw new ArgumentNullException(nameof(start));
@@ -167,7 +160,7 @@ namespace BeanBot.Services
                 {
                     if (completedTask.IsFaulted)
                     {
-                        _lateFailureObserver(completedTask.Exception, operationName);
+                            _lateFailureObserver(completedTask.Exception!, operationName);
                     }
 
                     lock (_syncRoot)
@@ -198,8 +191,8 @@ namespace BeanBot.Services
 
         public DiscordStartupService(
             IDiscordStartupLifecycle lifecycle,
-            DiscordStartupOptions options = null,
-            IDiscordStartupDelay delay = null)
+            DiscordStartupOptions? options = null,
+            IDiscordStartupDelay? delay = null)
         {
             _lifecycle = lifecycle ?? throw new ArgumentNullException(nameof(lifecycle));
             _options = options ?? DiscordStartupOptions.Default;

--- a/BeanBot/Services/EditMessageEventServices.cs
+++ b/BeanBot/Services/EditMessageEventServices.cs
@@ -2,6 +2,7 @@ using Discord;
 using Discord.WebSocket;
 using Serilog;
 using System;
+using System.Buffers;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -10,6 +11,7 @@ namespace BeanBot.Services
     public sealed class EditMessageEventServices
     {
         private const string EditWarning = "Do not edit your 8ball requests in my presence, mortal.";
+        private static readonly SearchValues<char> CommandSeparators = SearchValues.Create(" \t\r\n");
         private readonly DiscordSocketClient _discordClient;
 
         public EditMessageEventServices(DiscordSocketClient discordClient)
@@ -74,7 +76,7 @@ namespace BeanBot.Services
                 return false;
             }
 
-            var commandEnd = commandText.IndexOfAny(new[] { ' ', '\t', '\r', '\n' });
+            var commandEnd = commandText.AsSpan().IndexOfAny(CommandSeparators);
             var command = commandEnd < 0 ? commandText : commandText.Substring(0, commandEnd);
             return string.Equals(command, "8ball", StringComparison.OrdinalIgnoreCase) ||
                    string.Equals(command, "fortune", StringComparison.OrdinalIgnoreCase);

--- a/BeanBot/Services/HealthCheckServer.cs
+++ b/BeanBot/Services/HealthCheckServer.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
@@ -45,8 +46,8 @@ namespace BeanBot.Services
         private int _activeClientHandlers;
         private int _peakActiveClientHandlers;
         private int _disposed;
-        private TcpListener _listener;
-        private Task _listenerLoop;
+        private TcpListener? _listener;
+        private Task? _listenerLoop;
 
         public HealthCheckServer(
             HealthCheckOptions options,
@@ -56,10 +57,7 @@ namespace BeanBot.Services
             int maximumConcurrentClients = DefaultMaximumConcurrentClients,
             int maximumTrackedRateLimitClients = DefaultMaximumTrackedRateLimitClients)
         {
-            if (maximumConcurrentClients <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(maximumConcurrentClients));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumConcurrentClients);
 
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
@@ -69,7 +67,7 @@ namespace BeanBot.Services
             _clientCapacity = new SemaphoreSlim(maximumConcurrentClients, maximumConcurrentClients);
         }
 
-        public static HealthCheckServer Create(
+        public static HealthCheckServer? Create(
             HealthCheckOptions options,
             DiscordSocketClient discordClient,
             DiscordConnectionHealth discordConnectionHealth)
@@ -86,10 +84,7 @@ namespace BeanBot.Services
                 return;
             }
 
-            if (Volatile.Read(ref _disposed) != 0)
-            {
-                throw new ObjectDisposedException(nameof(HealthCheckServer));
-            }
+            ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
 
             if (_listener is not null)
             {
@@ -175,15 +170,16 @@ namespace BeanBot.Services
 
         private async Task AcceptLoopAsync(CancellationToken cancellationToken)
         {
+            var listener = _listener ?? throw new InvalidOperationException("The health check listener has not been started.");
             while (!cancellationToken.IsCancellationRequested)
             {
-                TcpClient client = null;
+                TcpClient? client = null;
                 try
                 {
-                    client = await _listener.AcceptTcpClientAsync(cancellationToken);
+                    client = await listener.AcceptTcpClientAsync(cancellationToken);
                     RemoveCompletedClientTasks();
 
-                    if (!_clientCapacity.Wait(0))
+                    if (!_clientCapacity.Wait(0, cancellationToken))
                     {
                         // Capacity is enforced before a handler task is created. Closing
                         // here bounds sockets, tasks, and queued work during connection bursts.
@@ -199,10 +195,12 @@ namespace BeanBot.Services
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
+                    client?.Dispose();
                     break;
                 }
                 catch (ObjectDisposedException) when (cancellationToken.IsCancellationRequested)
                 {
+                    client?.Dispose();
                     break;
                 }
                 catch (Exception exception)
@@ -287,7 +285,7 @@ namespace BeanBot.Services
                     client.ReceiveTimeout = 5000;
                     client.SendTimeout = 5000;
 
-                    string requestLine;
+                    string? requestLine;
                     try
                     {
                         requestLine = await reader.ReadLineAsync(MaxRequestLineLength, requestToken);
@@ -423,7 +421,7 @@ namespace BeanBot.Services
             }
         }
 
-        private bool IsAuthorized(IReadOnlyDictionary<string, string> headers)
+        private bool IsAuthorized(Dictionary<string, string> headers)
         {
             if (string.IsNullOrWhiteSpace(_options.BearerToken))
             {
@@ -451,7 +449,7 @@ namespace BeanBot.Services
             var headerCount = 0;
             while (true)
             {
-                string headerLine;
+                string? headerLine;
                 try
                 {
                     headerLine = await reader.ReadLineAsync(MaxHeaderLineLength, cancellationToken);
@@ -512,7 +510,10 @@ namespace BeanBot.Services
             }
         }
 
-        internal static bool TryParseRequestLine(string requestLine, out string method, out string target)
+        internal static bool TryParseRequestLine(
+            string requestLine,
+            [NotNullWhen(true)] out string? method,
+            [NotNullWhen(true)] out string? target)
         {
             method = null;
             target = null;
@@ -530,7 +531,7 @@ namespace BeanBot.Services
             return true;
         }
 
-        internal static bool TryExtractPath(string requestTarget, out string path)
+        internal static bool TryExtractPath(string? requestTarget, [NotNullWhen(true)] out string? path)
         {
             path = null;
             if (requestTarget == null)

--- a/BeanBot/Services/ReactionRoleSetupTransaction.cs
+++ b/BeanBot/Services/ReactionRoleSetupTransaction.cs
@@ -12,7 +12,7 @@ namespace BeanBot.Services
             Action<Exception> onCompensationFailure)
             where TMessage : class
         {
-            TMessage message = null;
+            TMessage? message = null;
             try
             {
                 message = await createMessage();

--- a/BeanBot/Services/RoleReactService.cs
+++ b/BeanBot/Services/RoleReactService.cs
@@ -6,31 +6,84 @@ using Serilog;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace BeanBot.Services
 {
-    public class RoleReactService
+    public class RoleReactService : IDisposable, IAsyncDisposable
     {
+        private static readonly TimeSpan DefaultShutdownDrainTimeout = TimeSpan.FromSeconds(5);
         private readonly RoleReactRepository _roleReactRepository;
-        private readonly DiscordSocketClient _client;
+        private readonly DiscordSocketClient? _client;
         private readonly SemaphoreSlim _cacheLock = new SemaphoreSlim(1, 1);
         private readonly ConcurrentDictionary<string, RoleSettings> _roleSettings = new ConcurrentDictionary<string, RoleSettings>();
+        private readonly object _operationSync = new();
+        private readonly HashSet<Task> _inFlightOperations = new();
+        private readonly TimeSpan _shutdownDrainTimeout;
+        private readonly TaskCompletionSource _disposeCompletion = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
         private volatile bool _cacheLoaded;
+        private bool _stopping;
+        private int _disposeStarted;
 
-        public RoleReactService(RoleReactRepository roleReactRepository, DiscordSocketClient client = null)
+        public RoleReactService(RoleReactRepository roleReactRepository, DiscordSocketClient? client = null)
+            : this(roleReactRepository, client, DefaultShutdownDrainTimeout)
         {
+        }
+
+        internal RoleReactService(
+            RoleReactRepository roleReactRepository,
+            DiscordSocketClient? client,
+            TimeSpan shutdownDrainTimeout)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(shutdownDrainTimeout, TimeSpan.Zero);
             _roleReactRepository = roleReactRepository ?? throw new ArgumentNullException(nameof(roleReactRepository));
             _client = client;
+            _shutdownDrainTimeout = shutdownDrainTimeout;
         }
 
         public Task HandleReact(Cacheable<IUserMessage, ulong> message, Cacheable<IMessageChannel, ulong> channel, SocketReaction reaction)
-            => HandleReactionAsync(message, channel, reaction, addRole: true);
+            => TrackHandlerAsync(() => HandleReactionAsync(message, channel, reaction, addRole: true));
 
         public Task HandleRemoveReact(Cacheable<IUserMessage, ulong> message, Cacheable<IMessageChannel, ulong> channel, SocketReaction reaction)
-            => HandleReactionAsync(message, channel, reaction, addRole: false);
+            => TrackHandlerAsync(() => HandleReactionAsync(message, channel, reaction, addRole: false));
+
+        internal Task TrackHandlerAsync(Func<Task> beginOperation)
+        {
+            ArgumentNullException.ThrowIfNull(beginOperation);
+
+            Task operation;
+            lock (_operationSync)
+            {
+                if (_stopping)
+                {
+                    return Task.CompletedTask;
+                }
+
+                operation = beginOperation();
+                _inFlightOperations.Add(operation);
+            }
+
+            return ObserveHandlerAsync(operation);
+        }
+
+        private async Task ObserveHandlerAsync(Task operation)
+        {
+            try
+            {
+                await operation;
+            }
+            finally
+            {
+                lock (_operationSync)
+                {
+                    _inFlightOperations.Remove(operation);
+                }
+            }
+        }
 
         private async Task HandleReactionAsync(
             Cacheable<IUserMessage, ulong> message,
@@ -65,7 +118,8 @@ namespace BeanBot.Services
 
                 var roleSetting = await GetCachedRoleSettingAsync(message.Id, cachedMessage);
                 var pair = roleSetting?.roleEmotePair?
-                    .FirstOrDefault(candidate => candidate.emojiId == customEmote.Id.ToString());
+                    .FirstOrDefault(candidate =>
+                        candidate.emojiId == customEmote.Id.ToString(CultureInfo.InvariantCulture));
                 if (pair == null || !ulong.TryParse(pair.roleId, out var roleId))
                 {
                     return;
@@ -94,10 +148,10 @@ namespace BeanBot.Services
             }
         }
 
-        private async Task<RoleSettings> GetCachedRoleSettingAsync(ulong messageId, IUserMessage message)
+        private async Task<RoleSettings?> GetCachedRoleSettingAsync(ulong messageId, IUserMessage message)
         {
             await EnsureCacheLoadedAsync();
-            var messageIdText = messageId.ToString();
+            var messageIdText = messageId.ToString(CultureInfo.InvariantCulture);
             if (_roleSettings.TryGetValue(messageIdText, out var cached))
             {
                 return cached;
@@ -151,11 +205,64 @@ namespace BeanBot.Services
 
             var settings = new RoleSettings(
                 roleEmotePair,
-                textChannel.Guild.Id.ToString(),
-                messageToListen.Channel.Id.ToString(),
-                messageToListen.Id.ToString());
+                textChannel.Guild.Id.ToString(CultureInfo.InvariantCulture),
+                messageToListen.Channel.Id.ToString(CultureInfo.InvariantCulture),
+                messageToListen.Id.ToString(CultureInfo.InvariantCulture));
             await _roleReactRepository.InsertNewRoleSettings(settings);
             _roleSettings[settings.messageId] = settings;
+        }
+
+        public void Dispose()
+        {
+            DisposeAsync().AsTask().GetAwaiter().GetResult();
+            GC.SuppressFinalize(this);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _disposeStarted, 1) != 0)
+            {
+                await _disposeCompletion.Task;
+                return;
+            }
+
+            try
+            {
+                Task[] inFlightOperations;
+                lock (_operationSync)
+                {
+                    _stopping = true;
+                    inFlightOperations = _inFlightOperations.ToArray();
+                }
+
+                if (inFlightOperations.Length > 0)
+                {
+                    try
+                    {
+                        await Task.WhenAll(inFlightOperations).WaitAsync(_shutdownDrainTimeout);
+                    }
+                    catch (TimeoutException)
+                    {
+                        Log.Warning(
+                            "Timed out draining {InFlightReactionHandlerCount} reaction-role handler(s); leaving the cache lock for process exit",
+                            inFlightOperations.Length);
+                        return;
+                    }
+                    catch (Exception exception)
+                    {
+                        Log.Warning(
+                            exception,
+                            "A reaction-role handler failed while shutdown was draining in-flight work");
+                    }
+                }
+
+                _cacheLock.Dispose();
+                GC.SuppressFinalize(this);
+            }
+            finally
+            {
+                _disposeCompletion.TrySetResult();
+            }
         }
     }
 }

--- a/BeanBot/Util/DiscordOwnerErrorSink.cs
+++ b/BeanBot/Util/DiscordOwnerErrorSink.cs
@@ -3,6 +3,7 @@ using Discord.WebSocket;
 using Serilog.Core;
 using Serilog.Events;
 using System;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -40,10 +41,10 @@ namespace BeanBot.Util
         {
             const int maximumLength = 1900;
             var exception = logEvent.Exception == null ? string.Empty : $"\n{logEvent.Exception}";
-            var alert = $"BeanBot {logEvent.Level} at {logEvent.Timestamp:O}\n{logEvent.RenderMessage()}{exception}";
+            var alert = $"BeanBot {logEvent.Level} at {logEvent.Timestamp:O}\n{logEvent.RenderMessage(CultureInfo.InvariantCulture)}{exception}";
             return alert.Length <= maximumLength
                 ? alert
-                : alert.Substring(0, maximumLength - 15) + "\n...(truncated)";
+                : string.Concat(alert.AsSpan(0, maximumLength - 15), "\n...(truncated)");
         }
     }
 
@@ -66,7 +67,7 @@ namespace BeanBot.Util
 
         internal DiscordOwnerErrorNotifier(
             IOwnerAlertDelivery delivery,
-            Func<int, TimeSpan> retryDelay = null,
+            Func<int, TimeSpan>? retryDelay = null,
             TimeSpan? shutdownFlushTimeout = null)
         {
             _delivery = delivery ?? throw new ArgumentNullException(nameof(delivery));

--- a/BeanBot/Util/FortuneAnswerStore.cs
+++ b/BeanBot/Util/FortuneAnswerStore.cs
@@ -2,10 +2,10 @@ namespace BeanBot.Util
 {
     public readonly record struct FortuneAnswerReservation(ulong RecipientId, string Answer, long Version);
 
-    public sealed class FortuneAnswerQueue
+    public sealed class FortuneAnswerStore
     {
         private readonly object _sync = new object();
-        private string _answer;
+        private string? _answer;
         private ulong _recipientId;
         private long _version;
 

--- a/BeanBot/Util/FortuneResponseOverrides.cs
+++ b/BeanBot/Util/FortuneResponseOverrides.cs
@@ -1,4 +1,3 @@
-#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -7,7 +6,7 @@ using System.Text.RegularExpressions;
 
 namespace BeanBot.Util
 {
-    public static class FortuneResponseOverrides
+    public static partial class FortuneResponseOverrides
     {
         public const string ShowerResponse = "Yes. Go take a shower.";
 
@@ -319,9 +318,10 @@ namespace BeanBot.Util
             "yes"
         };
 
-        private static readonly Regex WordRegex = new Regex(
+        [GeneratedRegex(
             @"[\p{L}\p{N}]+(?:['\u2019][\p{L}\p{N}]+)*",
-            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+            RegexOptions.CultureInvariant)]
+        private static partial Regex WordRegex();
 
         public static string? GetResponse(string? question)
         {
@@ -340,7 +340,7 @@ namespace BeanBot.Util
                 : null;
         }
 
-        private static bool IsPersonalShowerAdvice(IReadOnlyList<string> words)
+        private static bool IsPersonalShowerAdvice(List<string> words)
         {
             for (var subjectIndex = 0; subjectIndex < words.Count; subjectIndex++)
             {
@@ -371,7 +371,7 @@ namespace BeanBot.Util
             return false;
         }
 
-        private static bool IsImpersonalShowerAdvice(IReadOnlyList<string> words)
+        private static bool IsImpersonalShowerAdvice(List<string> words)
         {
             for (var cueIndex = 0; cueIndex < words.Count; cueIndex++)
             {
@@ -400,7 +400,7 @@ namespace BeanBot.Util
         }
 
         private static bool HasPersonalAdviceFrame(
-            IReadOnlyList<string> words,
+            List<string> words,
             int subjectIndex,
             int actionIndex)
         {
@@ -448,7 +448,7 @@ namespace BeanBot.Util
         }
 
         private static bool HasAllowedPathToAction(
-            IReadOnlyList<string> words,
+            List<string> words,
             int startIndex,
             int actionIndex)
         {
@@ -463,7 +463,7 @@ namespace BeanBot.Util
             return true;
         }
 
-        private static bool IsReflexiveBathingConstruction(IReadOnlyList<string> words, int actionIndex)
+        private static bool IsReflexiveBathingConstruction(List<string> words, int actionIndex)
         {
             if (actionIndex < words.Count - 1 && IsReflexive(words[actionIndex + 1]))
             {
@@ -485,7 +485,7 @@ namespace BeanBot.Util
         }
 
         private static bool IsCoordinatedBathingConstruction(
-            IReadOnlyList<string> words,
+            List<string> words,
             int startIndex,
             int actionIndex)
         {
@@ -506,7 +506,7 @@ namespace BeanBot.Util
         }
 
         private static bool IsExplicitBathingConstruction(
-            IReadOnlyList<string> words,
+            List<string> words,
             int startIndex,
             int actionIndex)
         {
@@ -523,7 +523,7 @@ namespace BeanBot.Util
         }
 
         private static bool IsBathingActionConstruction(
-            IReadOnlyList<string> words,
+            List<string> words,
             int startIndex,
             int actionIndex)
         {
@@ -555,7 +555,7 @@ namespace BeanBot.Util
         }
 
         private static bool TryFindBoundBathingAction(
-            IReadOnlyList<string> words,
+            List<string> words,
             int startIndex,
             bool validateFollowingWord,
             out int actionIndex)
@@ -586,7 +586,7 @@ namespace BeanBot.Util
             return false;
         }
 
-        private static bool IsSelfBathingUse(IReadOnlyList<string> words, int actionIndex)
+        private static bool IsSelfBathingUse(List<string> words, int actionIndex)
         {
             if (actionIndex == words.Count - 1 || IsReflexive(words[actionIndex + 1]))
             {
@@ -596,7 +596,7 @@ namespace BeanBot.Util
             return AllowedAfterAction.Contains(words[actionIndex + 1]);
         }
 
-        private static bool HasEvaluationCueAfter(IReadOnlyList<string> words, int actionIndex)
+        private static bool HasEvaluationCueAfter(List<string> words, int actionIndex)
         {
             var endIndex = Math.Min(words.Count - 1, actionIndex + 8);
             for (var index = actionIndex + 1; index <= endIndex; index++)
@@ -610,7 +610,7 @@ namespace BeanBot.Util
             return false;
         }
 
-        private static bool IsEvaluatedBathingUse(IReadOnlyList<string> words, int actionIndex)
+        private static bool IsEvaluatedBathingUse(List<string> words, int actionIndex)
         {
             if (actionIndex >= words.Count - 1 || !HasEvaluationCueAfter(words, actionIndex))
             {
@@ -634,7 +634,7 @@ namespace BeanBot.Util
 
         private static List<string> GetWords(string text)
         {
-            var matches = WordRegex.Matches(text);
+            var matches = WordRegex().Matches(text);
             var words = new List<string>(matches.Count);
 
             foreach (Match match in matches)

--- a/BeanBot/Util/LogHandler.cs
+++ b/BeanBot/Util/LogHandler.cs
@@ -3,6 +3,7 @@ using Discord.Commands;
 using Discord.WebSocket;
 using Serilog;
 
+using System.Globalization;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -14,8 +15,11 @@ namespace BeanBot.Util
         {
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Verbose()
-                .WriteTo.Console()
-                .WriteTo.Async(a => a.File(Path.Combine(DirectorySetup.botBaseDirectory, "Logs", "BeanBotLogs.txt"), rollingInterval: RollingInterval.Day))
+                .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
+                .WriteTo.Async(a => a.File(
+                    Path.Combine(DirectorySetup.botBaseDirectory, "Logs", "BeanBotLogs.txt"),
+                    formatProvider: CultureInfo.InvariantCulture,
+                    rollingInterval: RollingInterval.Day))
                 .WriteTo.Sink(new DiscordOwnerErrorSink(ownerErrorNotifier))
                 .CreateLogger();
             Log.Information("Logger Configuration complete");

--- a/BeanBot/Util/QuestionValidator.cs
+++ b/BeanBot/Util/QuestionValidator.cs
@@ -6,7 +6,7 @@ using System.Text.RegularExpressions;
 
 namespace BeanBot.Util
 {
-    public static class QuestionValidator
+    public static partial class QuestionValidator
     {
         private static readonly HashSet<string> InterrogativeWords = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
@@ -170,17 +170,20 @@ namespace BeanBot.Util
             "ve"
         };
 
-        private static readonly Regex DiscordObjectRegex = new Regex(
+        [GeneratedRegex(
             @"<(?:(?:@!?|@&|#)\d+|a?:[^:>\s]+:\d+)>",
-            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+            RegexOptions.CultureInvariant)]
+        private static partial Regex DiscordObjectRegex();
 
-        private static readonly Regex UrlRegex = new Regex(
+        [GeneratedRegex(
             @"\b(?:https?://|www\.)[^\s,;]+",
-            RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+            RegexOptions.CultureInvariant | RegexOptions.IgnoreCase)]
+        private static partial Regex UrlRegex();
 
-        private static readonly Regex WordRegex = new Regex(
+        [GeneratedRegex(
             @"[\p{L}\p{N}]+(?:['\u2019][\p{L}\p{N}]+)*",
-            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+            RegexOptions.CultureInvariant)]
+        private static partial Regex WordRegex();
 
         private static readonly char[] ClosingCharacters =
         {
@@ -202,8 +205,8 @@ namespace BeanBot.Util
                 return false;
             }
 
-            questionBody = DiscordObjectRegex.Replace(questionBody, " item ");
-            questionBody = UrlRegex.Replace(questionBody, " item ");
+            questionBody = DiscordObjectRegex().Replace(questionBody, " item ");
+            questionBody = UrlRegex().Replace(questionBody, " item ");
 
             if (IsInterrogativeClause(questionBody))
             {
@@ -239,7 +242,7 @@ namespace BeanBot.Util
 
         private static bool IsInterrogativeClause(string clause)
         {
-            var words = WordRegex.Matches(clause);
+            var words = WordRegex().Matches(clause);
             if (words.Count == 0)
             {
                 return false;
@@ -286,8 +289,8 @@ namespace BeanBot.Util
 
         private static bool IsConfirmationTag(string leadingClause, string finalClause)
         {
-            var leadingWords = WordRegex.Matches(leadingClause);
-            var finalWords = WordRegex.Matches(finalClause);
+            var leadingWords = WordRegex().Matches(leadingClause);
+            var finalWords = WordRegex().Matches(finalClause);
 
             return leadingWords.Count >= 2 &&
                 finalWords.Count == 1 &&


### PR DESCRIPTION
## Summary

- enable nullable reference types, implicit usings, latest recommended analysis, and warnings-as-errors for production code
- correct nullable contracts and analyzer findings without broad warning suppressions
- preserve outage persistence normalization, reaction-role shutdown safety, health behavior, and serialization compatibility
- add focused regression coverage for nullable state, persisted outage reasons, BSON/JSON member names, and bounded reaction-role disposal

## Impact

Production builds now enforce modern compiler and analyzer defaults. Optional runtime states are represented explicitly, and shutdown handling safely drains reaction-role work before disposing owned synchronization resources.

## Validation

- `dotnet build BeanBot/BeanBot.csproj -c Release --no-restore` — 0 warnings, 0 errors
- focused correction suite — 17/17 passed
- `./scripts/verify.sh fast` — passed
- `./scripts/verify.sh full` — passed
- full test suite — 312/312 passed, 0 skipped
- vulnerability scan — clean
- .NET 10 Docker publish/image build — passed
- independent Verifier — PASS
- independent Reviewer — CLEAN

Closes #87