### PR TITLE
Centralize .NET repository configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,90 @@
+root = true
+
+[*]
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{cs,csx}]
+indent_size = 4
+
+csharp_using_directive_placement = outside_namespace:suggestion
+
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = false:suggestion
+
+csharp_new_line_before_open_brace = all
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+
+dotnet_naming_rule.interfaces_should_be_prefixed.severity = suggestion
+dotnet_naming_rule.interfaces_should_be_prefixed.symbols = interfaces
+dotnet_naming_rule.interfaces_should_be_prefixed.style = prefixed_pascal_case
+
+dotnet_naming_symbols.interfaces.applicable_kinds = interface
+dotnet_naming_symbols.interfaces.applicable_accessibilities = *
+
+dotnet_naming_style.prefixed_pascal_case.required_prefix = I
+dotnet_naming_style.prefixed_pascal_case.capitalization = pascal_case
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, enum, delegate
+dotnet_naming_symbols.types.applicable_accessibilities = *
+
+dotnet_naming_rule.members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.members_should_be_pascal_case.symbols = members
+dotnet_naming_rule.members_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_symbols.members.applicable_kinds = property, event, method
+dotnet_naming_symbols.members.applicable_accessibilities = *
+
+dotnet_naming_rule.constants_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constants_should_be_pascal_case.symbols = constants
+dotnet_naming_rule.constants_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_symbols.constants.applicable_kinds = field, local
+dotnet_naming_symbols.constants.required_modifiers = const
+
+dotnet_naming_rule.private_fields_should_be_underscored.severity = suggestion
+dotnet_naming_rule.private_fields_should_be_underscored.symbols = private_fields
+dotnet_naming_rule.private_fields_should_be_underscored.style = underscored_camel_case
+
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+
+dotnet_naming_style.underscored_camel_case.required_prefix = _
+dotnet_naming_style.underscored_camel_case.capitalization = camel_case
+
+dotnet_naming_rule.parameters_and_locals_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.parameters_and_locals_should_be_camel_case.symbols = parameters_and_locals
+dotnet_naming_rule.parameters_and_locals_should_be_camel_case.style = camel_case
+
+dotnet_naming_symbols.parameters_and_locals.applicable_kinds = parameter, local
+
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+dotnet_naming_style.camel_case.capitalization = camel_case
+
+[BeanBot.Tests/**.cs]
+# Underscore-separated xUnit names and short-lived test fixtures intentionally favor
+# scenario readability over public API and allocation guidance.
+dotnet_diagnostic.CA1707.severity = suggestion
+dotnet_diagnostic.CA1711.severity = suggestion
+dotnet_diagnostic.CA1861.severity = suggestion
+
+[*.{json,yml,yaml,props,targets,csproj}]
+indent_size = 2
+
+[*.sh]
+indent_size = 2
+
+[*.py]
+indent_size = 4

--- a/BeanBot.Tests/BeanBot.Tests.csproj
+++ b/BeanBot.Tests/BeanBot.Tests.csproj
@@ -1,17 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/BeanBot.sln
+++ b/BeanBot.sln
@@ -9,7 +9,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BeanBot.Tests", "BeanBot.Te
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1374A34B-D07F-4AC5-B198-D695033F4D09}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		.gitignore = .gitignore
+		Directory.Build.props = Directory.Build.props
+		Directory.Packages.props = Directory.Packages.props
+		global.json = global.json
 		LICENSE = LICENSE
 		README.md = README.md
 	EndProjectSection

--- a/BeanBot/BeanBot.csproj
+++ b/BeanBot/BeanBot.csproj
@@ -2,11 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <AnalysisLevel>latest-recommended</AnalysisLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,27 +17,27 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="15.0.5" />
-    <PackageReference Include="Discord.Net.Commands" Version="3.20.1" />
-    <PackageReference Include="Discord.Net.Core" Version="3.20.1" />
-    <PackageReference Include="Discord.Net.Rest" Version="3.20.1" />
-    <PackageReference Include="Discord.Net.Webhook" Version="3.20.1" />
-    <PackageReference Include="Discord.Net.WebSocket" Version="3.20.1" />
-    <PackageReference Include="LQ.MemeApiDotNetWrapper" Version="1.5.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
-    <PackageReference Include="MongoDB.Bson" Version="2.30.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.30.0" />
-    <PackageReference Include="MongoDB.Driver.Core" Version="2.30.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.Async" Version="1.4.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
+    <PackageReference Include="CsvHelper" />
+    <PackageReference Include="Discord.Net.Commands" />
+    <PackageReference Include="Discord.Net.Core" />
+    <PackageReference Include="Discord.Net.Rest" />
+    <PackageReference Include="Discord.Net.Webhook" />
+    <PackageReference Include="Discord.Net.WebSocket" />
+    <PackageReference Include="LQ.MemeApiDotNetWrapper" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="MongoDB.Bson" />
+    <PackageReference Include="MongoDB.Driver" />
+    <PackageReference Include="MongoDB.Driver.Core" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Settings.Configuration" />
+    <PackageReference Include="Serilog.Sinks.Async" />
+    <PackageReference Include="Serilog.Sinks.Console" />
+    <PackageReference Include="Serilog.Sinks.File" />
     <!-- Pin secure versions of vulnerable transitive MongoDB.Driver dependencies. -->
-    <PackageReference Include="SharpCompress" Version="0.50.0" />
-    <PackageReference Include="Snappier" Version="1.3.1" />
+    <PackageReference Include="SharpCompress" />
+    <PackageReference Include="Snappier" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BeanBot/Services/DiscordStartupService.cs
+++ b/BeanBot/Services/DiscordStartupService.cs
@@ -160,7 +160,7 @@ namespace BeanBot.Services
                 {
                     if (completedTask.IsFaulted)
                     {
-                            _lateFailureObserver(completedTask.Exception!, operationName);
+                        _lateFailureObserver(completedTask.Exception!, operationName);
                     }
 
                     lock (_syncRoot)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AnalysisLevel>latest-recommended</AnalysisLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,32 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="CsvHelper" Version="15.0.5" />
+    <PackageVersion Include="Discord.Net.Commands" Version="3.20.1" />
+    <PackageVersion Include="Discord.Net.Core" Version="3.20.1" />
+    <PackageVersion Include="Discord.Net.Rest" Version="3.20.1" />
+    <PackageVersion Include="Discord.Net.Webhook" Version="3.20.1" />
+    <PackageVersion Include="Discord.Net.WebSocket" Version="3.20.1" />
+    <PackageVersion Include="LQ.MemeApiDotNetWrapper" Version="1.5.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="MongoDB.Bson" Version="2.30.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="2.30.0" />
+    <PackageVersion Include="MongoDB.Driver.Core" Version="2.30.0" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageVersion Include="Serilog" Version="2.8.0" />
+    <PackageVersion Include="Serilog.Settings.Configuration" Version="3.1.0" />
+    <PackageVersion Include="Serilog.Sinks.Async" Version="1.4.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="4.0.0" />
+    <!-- Pin secure versions of vulnerable transitive MongoDB.Driver dependencies. -->
+    <PackageVersion Include="SharpCompress" Version="0.50.0" />
+    <PackageVersion Include="Snappier" Version="1.3.1" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+</Project>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
+COPY ["Directory.Build.props", "Directory.Packages.props", "global.json", "./"]
 COPY ["BeanBot/BeanBot.csproj", "BeanBot/"]
 RUN dotnet restore "BeanBot/BeanBot.csproj"
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ If you bind the endpoint to anything other than `127.0.0.1`, set `BEANBOT_HEALTH
 
 ## Local Development
 
-Install the .NET 10 SDK, then restore, build, and run the test suite from the repo root:
+Install a stable .NET 10 SDK. The repository's `global.json` accepts SDK 10.0.100 or
+newer .NET 10 patches and feature bands while excluding preview and other major SDKs.
+Then restore, build, and run the test suite from the repo root:
 
 ```powershell
 dotnet restore BeanBot.sln
@@ -58,6 +60,11 @@ dotnet test BeanBot.sln --configuration Release --no-build
 ```
 
 Repository changes use a Codex-native Planner → Implementer → Verifier → Reviewer loop with one writer and independent verification/review. See [Codex development loop](docs/codex-development-loop.md) for role handoffs and the shared fast/full verification commands.
+
+Repository-wide compiler settings are defined in `Directory.Build.props`, package
+versions in `Directory.Packages.props`, and formatting and naming conventions in
+`.editorconfig`. Run `./scripts/verify.sh fast` before submitting changes; it checks
+formatting and analyzers in addition to building and testing the solution.
 
 To start the bot:
 

--- a/docs/codex-development-loop.md
+++ b/docs/codex-development-loop.md
@@ -22,7 +22,7 @@ Run commands from any directory; each script resolves the repository root itself
 /path/to/BeanBot-DEPRACATED/scripts/verify.sh full
 ```
 
-`fast` is the normal implementation loop. It tests the verifier's orchestration and failure propagation, validates Codex/CI configuration, restores the solution, builds Release without a second restore, runs Release tests without a second build, and checks committed, staged, and unstaged diffs for whitespace errors.
+`fast` is the normal implementation loop. It tests the verifier's orchestration and failure propagation, validates Codex/CI configuration, restores the solution, verifies `.editorconfig` formatting and warning-level analyzers without another restore, builds Release, runs Release tests without a second build, and checks committed, staged, and unstaged diffs for whitespace errors.
 
 `full` runs every fast gate once, then requests a machine-readable report for direct and transitive NuGet dependencies across the complete solution, fails explicitly if that report contains a known vulnerability, and builds the Docker image. The internal `build-test` mode gives the master-only release workflow the same orchestration self-test, validation, restore, Release build, Release test, and diff gates without duplicating full-only Docker and vulnerability work.
 
@@ -36,7 +36,7 @@ The gates have these dependencies:
 - GitHub evaluates Actions syntax/triggers and supplies exact-head required-check evidence.
 - Real Discord, production MongoDB, deployment health, and post-deployment behavior remain manual. Tests must not connect to them.
 
-Formatting is not a mandatory gate because the repository has no established formatting baseline. No coverage threshold is imposed.
+Formatting and warning-level analyzer conventions are mandatory gates backed by the repository's `.editorconfig`. No coverage threshold is imposed.
 
 ## Repair and infrastructure failures
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}

--- a/scripts/test-verification.sh
+++ b/scripts/test-verification.sh
@@ -81,6 +81,7 @@ fast_log="$temporary_directory/fast.log"
     BEANBOT_VERIFY_SKIP_SELF_TEST=1 "$verify_script" fast
 )
 assert_contains "$repository_root|dotnet|restore BeanBot.sln" "$fast_log"
+assert_contains "$repository_root|dotnet|format BeanBot.sln --verify-no-changes --no-restore --severity warn" "$fast_log"
 assert_contains "$repository_root|dotnet|test BeanBot.sln --configuration Release --no-build" "$fast_log"
 assert_not_contains "|dotnet|list " "$fast_log"
 assert_not_contains "|docker|" "$fast_log"
@@ -96,6 +97,7 @@ assert_contains "$repository_root|dotnet|list BeanBot.sln package --vulnerable -
 assert_contains "$repository_root|docker|build --tag beanbot-verification:local ." "$full_log"
 assert_count 1 "|python3|scripts/validate-workflow.py" "$full_log"
 assert_count 1 "|dotnet|restore BeanBot.sln" "$full_log"
+assert_count 1 "|dotnet|format BeanBot.sln --verify-no-changes --no-restore --severity warn" "$full_log"
 assert_count 1 "|dotnet|build BeanBot.sln --configuration Release --no-restore" "$full_log"
 assert_count 1 "|dotnet|test BeanBot.sln --configuration Release --no-build" "$full_log"
 assert_count 1 "|dotnet|list BeanBot.sln package --vulnerable --include-transitive --format json --output-version 1" "$full_log"
@@ -108,6 +110,17 @@ if PATH="$stub_directory:$PATH" BEANBOT_VERIFY_TEST_LOG="$invalid_log" \
   exit 1
 fi
 assert_contains "Unknown verification mode: unsupported" "$temporary_directory/invalid.out"
+
+format_failure_log="$temporary_directory/format-failure.log"
+if PATH="$stub_directory:$PATH" BEANBOT_VERIFY_TEST_LOG="$format_failure_log" \
+  BEANBOT_VERIFY_TEST_FAIL="dotnet format BeanBot.sln" BEANBOT_VERIFY_SKIP_SELF_TEST=1 \
+  "$verify_script" fast; then
+  echo "Injected formatter failure unexpectedly succeeded" >&2
+  exit 1
+fi
+assert_contains "|dotnet|format BeanBot.sln --verify-no-changes --no-restore --severity warn" "$format_failure_log"
+assert_not_contains "|dotnet|build " "$format_failure_log"
+assert_not_contains "|dotnet|test " "$format_failure_log"
 
 failure_log="$temporary_directory/failure.log"
 if PATH="$stub_directory:$PATH" BEANBOT_VERIFY_TEST_LOG="$failure_log" \

--- a/scripts/validate-workflow.py
+++ b/scripts/validate-workflow.py
@@ -133,6 +133,8 @@ def validate_policy_and_scripts() -> None:
     verifier = (REPOSITORY_ROOT / "scripts" / "verify.sh").read_text(encoding="utf-8")
     if 'run_stage "Test verification orchestration" scripts/test-verification.sh' not in verifier:
         fail("scripts/verify.sh must run the orchestration self-test")
+    if "dotnet format BeanBot.sln --verify-no-changes --no-restore --severity warn" not in verifier:
+        fail("repository verification must enforce .NET formatting and analyzer conventions")
     if "--vulnerable --include-transitive" not in verifier or "--format json --output-version 1" not in verifier:
         fail("full verification must request a machine-readable solution vulnerability report")
     if "scripts/check-vulnerable-packages.py" not in verifier:

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -46,6 +46,8 @@ self_test_workflow() {
 
 build_and_test() {
   run_stage "Restore .NET dependencies" dotnet restore BeanBot.sln
+  run_stage "Verify .NET formatting and analyzers" \
+    dotnet format BeanBot.sln --verify-no-changes --no-restore --severity warn
   run_stage "Build Release" dotnet build BeanBot.sln --configuration Release --no-restore
   run_stage "Run Release tests" dotnet test BeanBot.sln --configuration Release --no-build
 }


### PR DESCRIPTION
Closes #93

## What changed

- add repository-wide `.editorconfig`, `Directory.Build.props`, `Directory.Packages.props`, and `global.json`
- centralize shared .NET 10 compiler/analyzer settings and all 23 direct NuGet package versions without version changes
- preserve the explicit `SharpCompress` and `Snappier` security pins
- add a fail-closed `dotnet format` gate to the repository verification workflow, including orchestration success/count/failure tests
- copy central build, package, and SDK configuration into Docker's pre-restore layer
- document the SDK, formatting, analyzer, and package-management expectations
- fix the single pre-existing indentation violation identified by the formatter

## Why

The production and test projects previously declared overlapping compiler defaults and package versions independently. Repository-level configuration reduces drift and makes local, CI, and Docker builds use the same explicit expectations.

## Impact

This is an infrastructure-only change. It does not alter BeanBot runtime behavior, Discord lifecycle handling, persistence, health checks, authentication, or rate limiting. Existing package versions remain unchanged.

## Validation

- `scripts/test-verification.sh`
- `python3 scripts/validate-workflow.py`
- evaluated shared MSBuild properties for both projects
- confirmed all 23 centralized packages resolve to their original versions
- `./scripts/verify.sh fast`
- `./scripts/verify.sh full`
  - Release build: 0 warnings, 0 errors
  - tests: 312 passed
  - vulnerable package scan: clean
  - Docker restore and publish: passed
