### PR TITLE
Integrate Serilog with hosted logging

### DIFF
--- a/BeanBot.Tests/EventHandlers/PunHandlerTests.cs
+++ b/BeanBot.Tests/EventHandlers/PunHandlerTests.cs
@@ -2,6 +2,7 @@ using BeanBot.Configuration;
 using BeanBot.EventHandlers;
 
 using Discord.WebSocket;
+using Microsoft.Extensions.Logging.Abstractions;
 
 using Xunit;
 
@@ -20,7 +21,7 @@ public class PunHandlerTests
             new Uri("https://example.com/hatoete"),
             new Uri("https://example.com/yoshimaru"),
             HealthCheckOptions.Disabled);
-        var handler = new PunHandler(client, options);
+        var handler = new PunHandler(client, options, NullLogger<PunHandler>.Instance);
 
         await handler.DisposeAsync();
         await handler.DisposeAsync();

--- a/BeanBot.Tests/Hosting/BeanBotApplicationTests.cs
+++ b/BeanBot.Tests/Hosting/BeanBotApplicationTests.cs
@@ -1,4 +1,5 @@
 using BeanBot.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
 
 using Xunit;
 
@@ -10,7 +11,7 @@ public class BeanBotApplicationTests
     public async Task StartAsync_StartsHealthBeforeDiscordAndInitializesInOrderOnce()
     {
         var runtime = new RecordingRuntime();
-        var application = new BeanBotApplication(runtime);
+        var application = new BeanBotApplication(runtime, NullLogger<BeanBotApplication>.Instance);
 
         await application.StartAsync(CancellationToken.None);
         await application.StartAsync(CancellationToken.None);
@@ -32,7 +33,7 @@ public class BeanBotApplicationTests
     public async Task StopAsync_NormalShutdown_CleansUpInOrderOnce()
     {
         var runtime = new RecordingRuntime();
-        var application = new BeanBotApplication(runtime);
+        var application = new BeanBotApplication(runtime, NullLogger<BeanBotApplication>.Instance);
 
         await application.StopAsync(CancellationToken.None);
         await application.StopAsync(CancellationToken.None);
@@ -59,7 +60,7 @@ public class BeanBotApplicationTests
         {
             HasUnfinishedDiscordStartupOperation = true
         };
-        var application = new BeanBotApplication(runtime);
+        var application = new BeanBotApplication(runtime, NullLogger<BeanBotApplication>.Instance);
 
         await application.StopAsync(CancellationToken.None);
 
@@ -75,7 +76,7 @@ public class BeanBotApplicationTests
     public async Task StartupFailure_AllowsCompletePartialStartupCleanup(string failingOperation)
     {
         var runtime = new RecordingRuntime { FailingOperation = failingOperation };
-        var application = new BeanBotApplication(runtime);
+        var application = new BeanBotApplication(runtime, NullLogger<BeanBotApplication>.Instance);
 
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => application.StartAsync(CancellationToken.None));

--- a/BeanBot.Tests/Hosting/BeanBotHostedServiceTests.cs
+++ b/BeanBot.Tests/Hosting/BeanBotHostedServiceTests.cs
@@ -3,6 +3,7 @@ using BeanBot.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 using Xunit;
 
@@ -46,7 +47,10 @@ public class BeanBotHostedServiceTests
     public async Task StartAsync_ForwardsCancellationToken()
     {
         var application = new RecordingApplication { BlockUntilCancelled = true };
-        var hostedService = new BeanBotHostedService(application, new RecordingHostLifetime());
+        var hostedService = new BeanBotHostedService(
+            application,
+            new RecordingHostLifetime(),
+            NullLogger<BeanBotHostedService>.Instance);
         using var cancellation = new CancellationTokenSource();
 
         var startup = hostedService.StartAsync(cancellation.Token);
@@ -62,7 +66,10 @@ public class BeanBotHostedServiceTests
     public async Task StopAsync_ForwardsCancellationToken()
     {
         var application = new RecordingApplication();
-        var hostedService = new BeanBotHostedService(application, new RecordingHostLifetime());
+        var hostedService = new BeanBotHostedService(
+            application,
+            new RecordingHostLifetime(),
+            NullLogger<BeanBotHostedService>.Instance);
         using var cancellation = new CancellationTokenSource();
 
         await hostedService.StopAsync(cancellation.Token);
@@ -75,7 +82,10 @@ public class BeanBotHostedServiceTests
     {
         var startupFailure = new InvalidOperationException("startup failed");
         var application = new RecordingApplication { StartFailure = startupFailure };
-        var hostedService = new BeanBotHostedService(application, new RecordingHostLifetime());
+        var hostedService = new BeanBotHostedService(
+            application,
+            new RecordingHostLifetime(),
+            NullLogger<BeanBotHostedService>.Instance);
 
         var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
             () => hostedService.StartAsync(CancellationToken.None));
@@ -94,7 +104,10 @@ public class BeanBotHostedServiceTests
             StartFailure = startupFailure,
             StopFailure = new InvalidOperationException("cleanup failed")
         };
-        var hostedService = new BeanBotHostedService(application, new RecordingHostLifetime());
+        var hostedService = new BeanBotHostedService(
+            application,
+            new RecordingHostLifetime(),
+            NullLogger<BeanBotHostedService>.Instance);
 
         var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
             () => hostedService.StartAsync(CancellationToken.None));

--- a/BeanBot.Tests/Hosting/BeanBotServiceRegistrationTests.cs
+++ b/BeanBot.Tests/Hosting/BeanBotServiceRegistrationTests.cs
@@ -1,6 +1,7 @@
 using BeanBot.Configuration;
 using BeanBot.Hosting;
 using BeanBot.Services;
+using BeanBot.Util;
 
 using Discord.WebSocket;
 
@@ -30,6 +31,8 @@ public class BeanBotServiceRegistrationTests
         AssertSingleton<IBeanBotApplication>(services);
         AssertSingleton<BeanBotHostedService>(services);
         AssertSingleton<RoleReactService>(services);
+        AssertSingleton<EditMessageEventServices>(services);
+        AssertSingleton<LogHandler>(services);
 
         var clientDescriptor = Assert.Single(
             services,

--- a/BeanBot.Tests/Services/DiscordGatewayRecoveryServiceTests.cs
+++ b/BeanBot.Tests/Services/DiscordGatewayRecoveryServiceTests.cs
@@ -1,4 +1,5 @@
 using BeanBot.Services;
+using Microsoft.Extensions.Logging.Abstractions;
 
 using System.Collections.Concurrent;
 
@@ -134,6 +135,7 @@ public class DiscordGatewayRecoveryServiceTests
             state.CreateSnapshot,
             lifecycle,
             outageStore,
+            NullLogger<DiscordGatewayRecoveryService>.Instance,
             TestOptions,
             delay,
             exitCode =>

--- a/BeanBot.Tests/Services/DiscordOutageRecoveryNotifierTests.cs
+++ b/BeanBot.Tests/Services/DiscordOutageRecoveryNotifierTests.cs
@@ -1,5 +1,6 @@
 using BeanBot.Services;
 using BeanBot.Util;
+using Microsoft.Extensions.Logging.Abstractions;
 
 using Xunit;
 
@@ -83,7 +84,11 @@ public class DiscordOutageRecoveryNotifierTests
     private static DiscordOutageRecoveryNotifier CreateNotifier(
         InMemoryOutageStore store,
         RecordingDelivery delivery)
-        => new(store, delivery, _ => TimeSpan.Zero);
+        => new(
+            store,
+            delivery,
+            NullLogger<DiscordOutageRecoveryNotifier>.Instance,
+            _ => TimeSpan.Zero);
 
     private static DiscordOutage CreateOutage()
         => new()

--- a/BeanBot.Tests/Services/DiscordOutageStoreTests.cs
+++ b/BeanBot.Tests/Services/DiscordOutageStoreTests.cs
@@ -1,4 +1,5 @@
 using BeanBot.Services;
+using Microsoft.Extensions.Logging.Abstractions;
 
 using Xunit;
 
@@ -15,7 +16,7 @@ public sealed class DiscordOutageStoreTests : IDisposable
     [Fact]
     public async Task OpenAsync_PersistsOutageStartAndReason()
     {
-        using var store = new DiscordOutageStore(_temporaryDirectory);
+        using var store = new DiscordOutageStore(_temporaryDirectory, NullLogger<DiscordOutageStore>.Instance);
         var disconnectedAtUtc = new DateTimeOffset(2026, 8, 12, 7, 42, 15, TimeSpan.Zero);
 
         await store.OpenAsync(disconnectedAtUtc, "Gateway timed out");
@@ -29,7 +30,7 @@ public sealed class DiscordOutageStoreTests : IDisposable
     [Fact]
     public async Task RepeatedOpenAsync_PreservesOriginalOutageStart()
     {
-        using var store = new DiscordOutageStore(_temporaryDirectory);
+        using var store = new DiscordOutageStore(_temporaryDirectory, NullLogger<DiscordOutageStore>.Instance);
         var originalDisconnect = new DateTimeOffset(2026, 8, 12, 7, 42, 15, TimeSpan.Zero);
 
         await store.OpenAsync(originalDisconnect, "First disconnect");
@@ -43,7 +44,7 @@ public sealed class DiscordOutageStoreTests : IDisposable
     [Fact]
     public async Task MarkManualRecoveryAttemptedAsync_OpensAndUpdatesOutage()
     {
-        using var store = new DiscordOutageStore(_temporaryDirectory);
+        using var store = new DiscordOutageStore(_temporaryDirectory, NullLogger<DiscordOutageStore>.Instance);
         var disconnectedAtUtc = new DateTimeOffset(2026, 8, 12, 7, 42, 15, TimeSpan.Zero);
 
         await store.OpenAsync(disconnectedAtUtc, "Initial disconnect");
@@ -59,7 +60,7 @@ public sealed class DiscordOutageStoreTests : IDisposable
     [Fact]
     public async Task MarkProcessRestartRequestedAsync_UpdatesExistingOutage()
     {
-        using var store = new DiscordOutageStore(_temporaryDirectory);
+        using var store = new DiscordOutageStore(_temporaryDirectory, NullLogger<DiscordOutageStore>.Instance);
         await store.MarkManualRecoveryAttemptedAsync(DateTimeOffset.UtcNow, "Initial reason");
 
         await store.MarkProcessRestartRequestedAsync(DateTimeOffset.UtcNow, "Ready timeout");
@@ -72,7 +73,7 @@ public sealed class DiscordOutageStoreTests : IDisposable
     [Fact]
     public async Task ClearAsync_RemovesPersistedOutage()
     {
-        using var store = new DiscordOutageStore(_temporaryDirectory);
+        using var store = new DiscordOutageStore(_temporaryDirectory, NullLogger<DiscordOutageStore>.Instance);
         await store.OpenAsync(DateTimeOffset.UtcNow, "Disconnect");
 
         await store.ClearAsync();
@@ -86,7 +87,7 @@ public sealed class DiscordOutageStoreTests : IDisposable
     {
         var outagePath = Path.Combine(_temporaryDirectory, DiscordOutageStore.OutageFileName);
         await File.WriteAllTextAsync(outagePath, "{ definitely not valid JSON");
-        using var store = new DiscordOutageStore(_temporaryDirectory);
+        using var store = new DiscordOutageStore(_temporaryDirectory, NullLogger<DiscordOutageStore>.Instance);
 
         var outage = await store.ReadAsync();
 
@@ -102,7 +103,7 @@ public sealed class DiscordOutageStoreTests : IDisposable
         await File.WriteAllTextAsync(
             outagePath,
             "{\"DisconnectedAtUtc\":\"2026-08-12T07:42:15+00:00\"}");
-        using var store = new DiscordOutageStore(_temporaryDirectory);
+        using var store = new DiscordOutageStore(_temporaryDirectory, NullLogger<DiscordOutageStore>.Instance);
 
         var outage = await store.ReadAsync();
 
@@ -118,7 +119,7 @@ public sealed class DiscordOutageStoreTests : IDisposable
         await File.WriteAllTextAsync(
             outagePath,
             "{\"DisconnectedAtUtc\":\"2026-08-12T07:42:15+00:00\",\"MostRecentDisconnectReason\":null}");
-        using var store = new DiscordOutageStore(_temporaryDirectory);
+        using var store = new DiscordOutageStore(_temporaryDirectory, NullLogger<DiscordOutageStore>.Instance);
 
         var outage = await store.ReadAsync();
 
@@ -130,7 +131,7 @@ public sealed class DiscordOutageStoreTests : IDisposable
     [Fact]
     public async Task OpenAsync_NullReasonPersistsStableFallback()
     {
-        using var store = new DiscordOutageStore(_temporaryDirectory);
+        using var store = new DiscordOutageStore(_temporaryDirectory, NullLogger<DiscordOutageStore>.Instance);
 
         await store.OpenAsync(DateTimeOffset.UtcNow, null);
         var outage = await store.ReadAsync();
@@ -142,7 +143,7 @@ public sealed class DiscordOutageStoreTests : IDisposable
     [Fact]
     public async Task WriteAsync_LeavesCompleteFinalFileAndNoTemporaryFile()
     {
-        using var store = new DiscordOutageStore(_temporaryDirectory);
+        using var store = new DiscordOutageStore(_temporaryDirectory, NullLogger<DiscordOutageStore>.Instance);
 
         await store.OpenAsync(DateTimeOffset.UtcNow, "Disconnect");
 

--- a/BeanBot.Tests/Services/DiscordPaginatorServiceTests.cs
+++ b/BeanBot.Tests/Services/DiscordPaginatorServiceTests.cs
@@ -2,6 +2,7 @@ using BeanBot.Services;
 
 using Discord;
 using Discord.WebSocket;
+using Microsoft.Extensions.Logging.Abstractions;
 
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -180,8 +181,16 @@ public class DiscordPaginatorServiceTests
         var recorder = (ReactionRemovalMessageProxy)message;
         var control = new Emoji("▶");
 
-        await DiscordPaginatorService.TryRemoveUserReactionAsync(message, control, 42);
-        await DiscordPaginatorService.TryRemoveUserReactionAsync(message, control, 42);
+        await DiscordPaginatorService.TryRemoveUserReactionAsync(
+            message,
+            control,
+            42,
+            NullLogger<DiscordPaginatorService>.Instance);
+        await DiscordPaginatorService.TryRemoveUserReactionAsync(
+            message,
+            control,
+            42,
+            NullLogger<DiscordPaginatorService>.Instance);
 
         Assert.Equal(new ulong[] { 42, 42 }, recorder.RemovedUserIds);
         Assert.All(recorder.RemovedEmotes, emote => Assert.Equal(control, emote));
@@ -207,7 +216,9 @@ public class DiscordPaginatorServiceTests
     public void Dispose_DisposesOwnedSlotSemaphore()
     {
         using var client = new DiscordSocketClient();
-        var paginator = new DiscordPaginatorService(client);
+        var paginator = new DiscordPaginatorService(
+            client,
+            NullLogger<DiscordPaginatorService>.Instance);
         var slotsField = typeof(DiscordPaginatorService).GetField(
             "_availableSlots",
             BindingFlags.Instance | BindingFlags.NonPublic);

--- a/BeanBot.Tests/Services/DiscordStartupServiceTests.cs
+++ b/BeanBot.Tests/Services/DiscordStartupServiceTests.cs
@@ -1,5 +1,7 @@
 using BeanBot.Services;
 
+using Microsoft.Extensions.Logging.Abstractions;
+
 using System.Net;
 
 using Xunit;
@@ -13,7 +15,7 @@ public class DiscordStartupServiceTests
     {
         var lifecycle = new FakeStartupLifecycle();
         var delay = new RecordingDelay();
-        var service = new DiscordStartupService(lifecycle, DiscordStartupOptions.Default, delay);
+        var service = CreateService(lifecycle, DiscordStartupOptions.Default, delay);
 
         await service.StartAsync(CancellationToken.None);
 
@@ -30,7 +32,7 @@ public class DiscordStartupServiceTests
             CreateHttpException(HttpStatusCode.ServiceUnavailable),
             null);
         var delay = new RecordingDelay();
-        var service = new DiscordStartupService(lifecycle, DiscordStartupOptions.Default, delay);
+        var service = CreateService(lifecycle, DiscordStartupOptions.Default, delay);
 
         await service.StartAsync(CancellationToken.None);
 
@@ -43,7 +45,7 @@ public class DiscordStartupServiceTests
     public async Task CancellationBeforeStartup_DoesNotAttemptLogin()
     {
         var lifecycle = new FakeStartupLifecycle();
-        var service = new DiscordStartupService(lifecycle, DiscordStartupOptions.Default, new RecordingDelay());
+        var service = CreateService(lifecycle, DiscordStartupOptions.Default, new RecordingDelay());
         using var cancellation = new CancellationTokenSource();
         cancellation.Cancel();
 
@@ -60,7 +62,7 @@ public class DiscordStartupServiceTests
         var lifecycle = new FakeStartupLifecycle(
             CreateHttpException(HttpStatusCode.ServiceUnavailable));
         var delay = new BlockingDelay();
-        var service = new DiscordStartupService(lifecycle, DiscordStartupOptions.Default, delay);
+        var service = CreateService(lifecycle, DiscordStartupOptions.Default, delay);
         using var cancellation = new CancellationTokenSource();
 
         var startup = service.StartAsync(cancellation.Token);
@@ -78,7 +80,7 @@ public class DiscordStartupServiceTests
         var unauthorized = CreateHttpException(HttpStatusCode.Unauthorized);
         var lifecycle = new FakeStartupLifecycle(unauthorized);
         var delay = new RecordingDelay();
-        var service = new DiscordStartupService(lifecycle, DiscordStartupOptions.Default, delay);
+        var service = CreateService(lifecycle, DiscordStartupOptions.Default, delay);
 
         var thrown = await Assert.ThrowsAsync<Discord.Net.HttpException>(
             () => service.StartAsync(CancellationToken.None));
@@ -98,7 +100,7 @@ public class DiscordStartupServiceTests
             CreateHttpException(HttpStatusCode.TooManyRequests),
             finalFailure);
         var delay = new RecordingDelay();
-        var service = new DiscordStartupService(lifecycle, DiscordStartupOptions.Default, delay);
+        var service = CreateService(lifecycle, DiscordStartupOptions.Default, delay);
 
         var thrown = await Assert.ThrowsAsync<Discord.Net.HttpException>(
             () => service.StartAsync(CancellationToken.None));
@@ -117,7 +119,7 @@ public class DiscordStartupServiceTests
         var timeout = new TimeoutException("Test timeout");
         var lifecycle = new FakeStartupLifecycle(timeout);
         var delay = new RecordingDelay();
-        var service = new DiscordStartupService(lifecycle, DiscordStartupOptions.Default, delay);
+        var service = CreateService(lifecycle, DiscordStartupOptions.Default, delay);
 
         var thrown = await Assert.ThrowsAsync<TimeoutException>(
             () => service.StartAsync(CancellationToken.None));
@@ -141,8 +143,9 @@ public class DiscordStartupServiceTests
                 return Task.CompletedTask;
             },
             () => Task.CompletedTask,
-            TimeSpan.FromMinutes(1));
-        var service = new DiscordStartupService(
+            TimeSpan.FromMinutes(1),
+            NullLogger<DiscordStartupLifecycle>.Instance);
+        var service = CreateService(
             lifecycle,
             DiscordStartupOptions.Default,
             new RecordingDelay());
@@ -171,6 +174,7 @@ public class DiscordStartupServiceTests
             () => Task.CompletedTask,
             () => Task.CompletedTask,
             TimeSpan.FromMilliseconds(20),
+            NullLogger<DiscordStartupLifecycle>.Instance,
             (exception, operation) => lateFailure.TrySetResult((exception, operation)));
 
         await Assert.ThrowsAsync<TimeoutException>(
@@ -193,7 +197,7 @@ public class DiscordStartupServiceTests
         {
             PresenceFailure = new InvalidOperationException("Test presence failure")
         };
-        var service = new DiscordStartupService(lifecycle, DiscordStartupOptions.Default, new RecordingDelay());
+        var service = CreateService(lifecycle, DiscordStartupOptions.Default, new RecordingDelay());
 
         await service.StartAsync(CancellationToken.None);
 
@@ -210,8 +214,9 @@ public class DiscordStartupServiceTests
             () => Task.CompletedTask,
             () => Task.CompletedTask,
             () => presence.Task,
-            TimeSpan.FromMilliseconds(20));
-        var service = new DiscordStartupService(
+            TimeSpan.FromMilliseconds(20),
+            NullLogger<DiscordStartupLifecycle>.Instance);
+        var service = CreateService(
             lifecycle,
             DiscordStartupOptions.Default,
             new RecordingDelay());
@@ -237,8 +242,9 @@ public class DiscordStartupServiceTests
                 presenceStarted.TrySetResult(true);
                 return presence.Task;
             },
-            TimeSpan.FromMinutes(1));
-        var service = new DiscordStartupService(
+            TimeSpan.FromMinutes(1),
+            NullLogger<DiscordStartupLifecycle>.Instance);
+        var service = CreateService(
             lifecycle,
             DiscordStartupOptions.Default,
             new RecordingDelay());
@@ -255,6 +261,16 @@ public class DiscordStartupServiceTests
         presence.TrySetResult(true);
         await WaitForNoUnfinishedOperationAsync(lifecycle);
     }
+
+    private static DiscordStartupService CreateService(
+        IDiscordStartupLifecycle lifecycle,
+        DiscordStartupOptions options,
+        IDiscordStartupDelay delay)
+        => new(
+            lifecycle,
+            NullLogger<DiscordStartupService>.Instance,
+            options,
+            delay);
 
     private static Discord.Net.HttpException CreateHttpException(HttpStatusCode statusCode)
         => new(statusCode, null, null, "Test Discord failure", null);

--- a/BeanBot.Tests/Services/HealthCheckServerTests.cs
+++ b/BeanBot.Tests/Services/HealthCheckServerTests.cs
@@ -11,6 +11,7 @@ using System.Text.Json;
 using Serilog;
 using Serilog.Core;
 using Serilog.Events;
+using Microsoft.Extensions.Logging.Abstractions;
 
 using Xunit;
 
@@ -221,7 +222,10 @@ public class HealthCheckServerTests
             0,
             null,
             TimeSpan.FromSeconds(90));
-        await using var server = new HealthCheckServer(options, () => UnhealthySnapshot);
+        await using var server = new HealthCheckServer(
+            options,
+            () => UnhealthySnapshot,
+            NullLogger<HealthCheckServer>.Instance);
 
         await server.StartAsync(CancellationToken.None);
 
@@ -338,6 +342,7 @@ public class HealthCheckServerTests
         return new HealthCheckServer(
             options,
             createSnapshot,
+            NullLogger<HealthCheckServer>.Instance,
             requestHeadersTimeout,
             maximumConcurrentClients: 2,
             maximumTrackedRateLimitClients: 10);

--- a/BeanBot.Tests/Services/RoleReactServiceTests.cs
+++ b/BeanBot.Tests/Services/RoleReactServiceTests.cs
@@ -2,6 +2,7 @@ using BeanBot.Repository;
 using BeanBot.Services;
 
 using MongoDB.Driver;
+using Microsoft.Extensions.Logging.Abstractions;
 
 using System.Reflection;
 
@@ -56,9 +57,10 @@ public class RoleReactServiceTests
         var database = new MongoClient("mongodb://localhost:27017")
             .GetDatabase("BeanBotNullableTests");
         return new RoleReactService(
-            new RoleReactRepository(database),
+            new RoleReactRepository(database, NullLogger<RoleReactRepository>.Instance),
             client: null,
-            shutdownDrainTimeout);
+            shutdownDrainTimeout,
+            NullLogger<RoleReactService>.Instance);
     }
 
     private static SemaphoreSlim GetCacheLock(RoleReactService service)

--- a/BeanBot.Tests/Util/LogHandlerTests.cs
+++ b/BeanBot.Tests/Util/LogHandlerTests.cs
@@ -89,19 +89,46 @@ public class LogHandlerTests
             Assert.IsType<ScalarValue>(logEvent.Properties["SourceContext"]).Value);
     }
 
+    [Theory]
+    [InlineData("BeanBot.Services.CategoryFilterProbe", LogLevel.Trace, true)]
+    [InlineData("Microsoft.AspNetCore.CategoryFilterProbe", LogLevel.Debug, false)]
+    [InlineData("System.Net.Http.CategoryFilterProbe", LogLevel.Trace, false)]
+    [InlineData("Microsoft.Hosting.Lifetime", LogLevel.Information, true)]
+    public void ProductionConfiguration_AppliesCategoryMinimumLevels(
+        string category,
+        LogLevel logLevel,
+        bool expectedEnabled)
+    {
+        var sink = new CapturingSerilogSink();
+        var notifier = new CapturingNotifier();
+        using var serilogLogger = CreateProductionLogger(sink, notifier);
+        using var loggerFactory = CreateLoggerFactory(serilogLogger);
+        var logger = loggerFactory.CreateLogger(category);
+
+        Assert.Equal(expectedEnabled, logger.IsEnabled(logLevel));
+        WriteTestLog(logger, logLevel, "category filter probe");
+
+        if (expectedEnabled)
+        {
+            var logEvent = Assert.Single(sink.Events);
+            Assert.Equal(
+                category,
+                Assert.IsType<ScalarValue>(logEvent.Properties["SourceContext"]).Value);
+        }
+        else
+        {
+            Assert.Empty(sink.Events);
+        }
+        Assert.Empty(notifier.Alerts);
+    }
+
     [Fact]
-    public void MicrosoftLogger_ErrorReachesOwnerSinkOnceButWarningDoesNot()
+    public void ProductionConfiguration_BeanBotErrorReachesOwnerSinkOnceButWarningDoesNot()
     {
         var notifier = new CapturingNotifier();
-        using var serilogLogger = new LoggerConfiguration()
-            .MinimumLevel.Verbose()
-            .WriteTo.Sink(new DiscordOwnerErrorSink(notifier))
-            .CreateLogger();
-        using var loggerFactory = LoggerFactory.Create(builder =>
-        {
-            builder.ClearProviders();
-            builder.AddSerilog(serilogLogger, dispose: false);
-        });
+        var sink = new CapturingSerilogSink();
+        using var serilogLogger = CreateProductionLogger(sink, notifier);
+        using var loggerFactory = CreateLoggerFactory(serilogLogger);
         var logger = loggerFactory.CreateLogger<LogHandlerTests>();
 
         BeanBotLog.DiscordPresenceFailed(logger, new InvalidOperationException("handled"));
@@ -111,6 +138,35 @@ public class LogHandlerTests
         Assert.Contains("Error retrieving reaction-role settings for message 42", alert);
         Assert.DoesNotContain("Discord started", alert);
     }
+
+    private static Serilog.Core.Logger CreateProductionLogger(
+        CapturingSerilogSink sink,
+        CapturingNotifier notifier)
+    {
+        var loggerConfiguration = new LoggerConfiguration();
+        LogHandler.ConfigureLogger(loggerConfiguration, notifier);
+        return loggerConfiguration
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+    }
+
+    private static ILoggerFactory CreateLoggerFactory(Serilog.ILogger serilogLogger)
+        => LoggerFactory.Create(builder =>
+        {
+            builder.ClearProviders();
+            builder.AddSerilog(serilogLogger, dispose: false);
+        });
+
+    private static void WriteTestLog(
+        Microsoft.Extensions.Logging.ILogger logger,
+        LogLevel logLevel,
+        string message)
+        => logger.Log(
+            logLevel,
+            eventId: default,
+            message,
+            exception: null,
+            static (state, _) => state);
 
     private sealed record LogEntry(
         LogLevel Level,

--- a/BeanBot.Tests/Util/LogHandlerTests.cs
+++ b/BeanBot.Tests/Util/LogHandlerTests.cs
@@ -1,0 +1,174 @@
+using BeanBot.Util;
+
+using Discord;
+using Discord.Commands;
+
+using Microsoft.Extensions.Logging;
+
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+using Xunit;
+
+namespace BeanBot.Tests.Util;
+
+public class LogHandlerTests
+{
+    [Theory]
+    [InlineData(LogSeverity.Critical, LogLevel.Critical)]
+    [InlineData(LogSeverity.Error, LogLevel.Error)]
+    [InlineData(LogSeverity.Warning, LogLevel.Warning)]
+    [InlineData(LogSeverity.Info, LogLevel.Information)]
+    [InlineData(LogSeverity.Verbose, LogLevel.Trace)]
+    [InlineData(LogSeverity.Debug, LogLevel.Debug)]
+    public async Task LogMessages_MapsDiscordSeverityAndPreservesStructuredMessage(
+        LogSeverity severity,
+        LogLevel expectedLevel)
+    {
+        var logger = new RecordingLogger<LogHandler>();
+        var handler = new LogHandler(logger);
+        var exception = new InvalidOperationException("discord failure");
+
+        await handler.LogMessages(new LogMessage(severity, "Gateway", "test message", exception));
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(expectedLevel, entry.Level);
+        Assert.Same(exception, entry.Exception);
+        Assert.Equal(
+            "Discord:\tGateway\ttest message",
+            Assert.Single(entry.Properties, property => property.Key == "DiscordMessage").Value);
+    }
+
+    [Theory]
+    [InlineData(CommandError.BadArgCount, LogLevel.Warning)]
+    [InlineData(CommandError.Exception, LogLevel.Error)]
+    public async Task LogCommands_LogsSafeFailureMetadataWithoutReadingMessagePayload(
+        CommandError error,
+        LogLevel expectedLevel)
+    {
+        var logger = new RecordingLogger<LogHandler>();
+        var handler = new LogHandler(logger);
+        var result = new FakeResult(error, "safe reason");
+
+        await handler.LogCommands(default, new MessageThrowingCommandContext(), result);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(expectedLevel, entry.Level);
+        Assert.DoesNotContain(entry.Properties, property => property.Key == "Input");
+        Assert.Contains(entry.Properties, property =>
+            property.Key == "Error" && Equals(property.Value, error));
+        Assert.Contains(entry.Properties, property =>
+            property.Key == "Reason" && Equals(property.Value, "safe reason"));
+    }
+
+    [Fact]
+    public void MicrosoftLogger_RoutesOnceThroughSerilogWithCategoryAndProperties()
+    {
+        var sink = new CapturingSerilogSink();
+        using var serilogLogger = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+        using var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.ClearProviders();
+            builder.AddSerilog(serilogLogger, dispose: false);
+        });
+        var logger = loggerFactory.CreateLogger<LogHandlerTests>();
+        var exception = new InvalidOperationException("failed");
+
+        BeanBotLog.ReactionRoleReadFailed(logger, 42UL, exception);
+
+        var logEvent = Assert.Single(sink.Events);
+        Assert.Equal(LogEventLevel.Error, logEvent.Level);
+        Assert.Same(exception, logEvent.Exception);
+        Assert.Equal(42UL, Assert.IsType<ScalarValue>(logEvent.Properties["MessageId"]).Value);
+        Assert.Equal(
+            typeof(LogHandlerTests).FullName,
+            Assert.IsType<ScalarValue>(logEvent.Properties["SourceContext"]).Value);
+    }
+
+    [Fact]
+    public void MicrosoftLogger_ErrorReachesOwnerSinkOnceButWarningDoesNot()
+    {
+        var notifier = new CapturingNotifier();
+        using var serilogLogger = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .WriteTo.Sink(new DiscordOwnerErrorSink(notifier))
+            .CreateLogger();
+        using var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.ClearProviders();
+            builder.AddSerilog(serilogLogger, dispose: false);
+        });
+        var logger = loggerFactory.CreateLogger<LogHandlerTests>();
+
+        BeanBotLog.DiscordPresenceFailed(logger, new InvalidOperationException("handled"));
+        BeanBotLog.ReactionRoleReadFailed(logger, 42UL, new InvalidOperationException("failed"));
+
+        var alert = Assert.Single(notifier.Alerts);
+        Assert.Contains("Error retrieving reaction-role settings for message 42", alert);
+        Assert.DoesNotContain("Discord started", alert);
+    }
+
+    private sealed record LogEntry(
+        LogLevel Level,
+        Exception? Exception,
+        IReadOnlyList<KeyValuePair<string, object?>> Properties);
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<LogEntry> Entries { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            var properties = state as IReadOnlyList<KeyValuePair<string, object?>>
+                ?? Array.Empty<KeyValuePair<string, object?>>();
+            Entries.Add(new LogEntry(logLevel, exception, properties));
+        }
+    }
+
+    private sealed class FakeResult : IResult
+    {
+        public FakeResult(CommandError error, string errorReason)
+        {
+            Error = error;
+            ErrorReason = errorReason;
+        }
+
+        public CommandError? Error { get; }
+        public string ErrorReason { get; }
+        public bool IsSuccess => false;
+    }
+
+    private sealed class MessageThrowingCommandContext : ICommandContext
+    {
+        public IDiscordClient Client => throw new NotSupportedException();
+        public IGuild Guild => throw new NotSupportedException();
+        public IMessageChannel Channel => throw new NotSupportedException();
+        public IUser User => throw new NotSupportedException();
+        public IUserMessage Message => throw new InvalidOperationException("Message payload must not be read while logging.");
+    }
+
+    private sealed class CapturingSerilogSink : ILogEventSink
+    {
+        public List<LogEvent> Events { get; } = new();
+        public void Emit(LogEvent logEvent) => Events.Add(logEvent);
+    }
+
+    private sealed class CapturingNotifier : IOwnerErrorNotifier
+    {
+        public List<string> Alerts { get; } = new();
+        public void Enqueue(string alert) => Alerts.Add(alert);
+    }
+}

--- a/BeanBot/BeanBot.csproj
+++ b/BeanBot/BeanBot.csproj
@@ -33,8 +33,7 @@
     <PackageReference Include="MongoDB.Driver.Core" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Serilog" />
-    <PackageReference Include="Serilog.Extensions.Logging" />
-    <PackageReference Include="Serilog.Settings.Configuration" />
+    <PackageReference Include="Serilog.Extensions.Hosting" />
     <PackageReference Include="Serilog.Sinks.Async" />
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="Serilog.Sinks.File" />

--- a/BeanBot/BeanBot.csproj
+++ b/BeanBot/BeanBot.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.Extensions.Hosting" />
+    <PackageReference Include="Serilog.Extensions.Logging" />
     <PackageReference Include="Serilog.Sinks.Async" />
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="Serilog.Sinks.File" />

--- a/BeanBot/EventHandlers/CommandHandler.cs
+++ b/BeanBot/EventHandlers/CommandHandler.cs
@@ -5,8 +5,8 @@ using Discord.Commands;
 using Discord.WebSocket;
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
-using Serilog;
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -21,19 +21,25 @@ namespace BeanBot.EventHandlers
         private readonly IServiceProvider _services;
         private readonly FortuneAnswerStore _fortuneAnswers;
         private readonly DiscordMessageWaiter _messageWaiter;
+        private readonly LogHandler _logHandler;
+        private readonly ILogger<CommandHandler> _logger;
         private bool _initialized;
 
         public CommandHandler(
             DiscordSocketClient discordClient,
             CommandService commandService,
-            IServiceProvider services)
+            IServiceProvider services,
+            LogHandler logHandler,
+            ILogger<CommandHandler> logger)
         {
-            Log.Information("Instantiating Command Handler");
             _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
             _commandService = commandService ?? throw new ArgumentNullException(nameof(commandService));
             _services = services ?? throw new ArgumentNullException(nameof(services));
+            _logHandler = logHandler ?? throw new ArgumentNullException(nameof(logHandler));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _fortuneAnswers = _services.GetRequiredService<FortuneAnswerStore>();
             _messageWaiter = _services.GetRequiredService<DiscordMessageWaiter>();
+            BeanBotLog.CommandHandlerCreated(_logger);
         }
 
         public async Task InitializeCommandsAsync()
@@ -43,9 +49,9 @@ namespace BeanBot.EventHandlers
                 return;
             }
 
-            Log.Information("Installing Commands");
+            BeanBotLog.CommandsInstalling(_logger);
             _discordClient.MessageReceived += HandleCommandAsync;
-            _commandService.CommandExecuted += LogHandler.LogCommands;
+            _commandService.CommandExecuted += _logHandler.LogCommands;
             await _commandService.AddModulesAsync(assembly: Assembly.GetEntryAssembly() ?? typeof(CommandHandler).Assembly,
                                                   services: _services);
             _initialized = true;
@@ -56,7 +62,7 @@ namespace BeanBot.EventHandlers
             if (_initialized)
             {
                 _discordClient.MessageReceived -= HandleCommandAsync;
-                _commandService.CommandExecuted -= LogHandler.LogCommands;
+                _commandService.CommandExecuted -= _logHandler.LogCommands;
                 _initialized = false;
             }
 

--- a/BeanBot/EventHandlers/EditMessageHandler.cs
+++ b/BeanBot/EventHandlers/EditMessageHandler.cs
@@ -10,10 +10,12 @@ namespace BeanBot.EventHandlers
         private readonly EditMessageEventServices _editMessageEventService;
         private bool _initialized;
 
-        public EditMessageHandler(DiscordSocketClient discordClient)
+        public EditMessageHandler(
+            DiscordSocketClient discordClient,
+            EditMessageEventServices editMessageEventService)
         {
             _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
-            _editMessageEventService = new EditMessageEventServices(_discordClient);
+            _editMessageEventService = editMessageEventService ?? throw new ArgumentNullException(nameof(editMessageEventService));
         }
 
         public void InitializeEventListener()

--- a/BeanBot/EventHandlers/NewMemberHandler.cs
+++ b/BeanBot/EventHandlers/NewMemberHandler.cs
@@ -1,6 +1,6 @@
 using BeanBot.Util;
 using Discord.WebSocket;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
 
@@ -9,11 +9,18 @@ namespace BeanBot.EventHandlers
     internal sealed class NewMemberHandler : IDisposable
     {
         private readonly DiscordSocketClient _discordClient;
+        private readonly LogHandler _logHandler;
+        private readonly ILogger<NewMemberHandler> _logger;
         private bool _initialized;
 
-        public NewMemberHandler(DiscordSocketClient client)
+        public NewMemberHandler(
+            DiscordSocketClient client,
+            LogHandler logHandler,
+            ILogger<NewMemberHandler> logger)
         {
             _discordClient = client ?? throw new ArgumentNullException(nameof(client));
+            _logHandler = logHandler ?? throw new ArgumentNullException(nameof(logHandler));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public void InitializeNewMembers()
@@ -23,13 +30,13 @@ namespace BeanBot.EventHandlers
                 return;
             }
 
-            Log.Information("Initializing New Member Handler");
+            BeanBotLog.NewMemberHandlerInitializing(_logger);
             _discordClient.UserJoined += WelcomeNewMemberAsync;
-            _discordClient.UserJoined += LogHandler.LogNewMember;
+            _discordClient.UserJoined += _logHandler.LogNewMember;
             _initialized = true;
         }
 
-        private static async Task WelcomeNewMemberAsync(SocketGuildUser user)
+        private async Task WelcomeNewMemberAsync(SocketGuildUser user)
         {
             if (user.IsBot)
             {
@@ -40,11 +47,11 @@ namespace BeanBot.EventHandlers
             {
                 var userDmChannel = await user.CreateDMChannelAsync();
                 await userDmChannel.SendMessageAsync("Please read the rules in the Eli's Charter channel. If you agree to these rules and are over the age of 17, please DM one of the moderators with the blue role \"Student Council\" (i.e discount Hatate/Makoto Kikuchi#2351) for full access to the server! (I promise it's worth it)");
-                Log.Debug("Sent the welcome message to {UserId}", user.Id);
+                BeanBotLog.WelcomeMessageSent(_logger, user.Id);
             }
             catch (Exception exception)
             {
-                Log.Warning(exception, "Could not send the welcome message to {UserId}", user.Id);
+                BeanBotLog.WelcomeMessageFailed(_logger, user.Id, exception);
             }
         }
 
@@ -56,7 +63,7 @@ namespace BeanBot.EventHandlers
             }
 
             _discordClient.UserJoined -= WelcomeNewMemberAsync;
-            _discordClient.UserJoined -= LogHandler.LogNewMember;
+            _discordClient.UserJoined -= _logHandler.LogNewMember;
             _initialized = false;
         }
     }

--- a/BeanBot/EventHandlers/PunHandler.cs
+++ b/BeanBot/EventHandlers/PunHandler.cs
@@ -1,8 +1,9 @@
 ﻿using BeanBot.Entities;
 using BeanBot.Configuration;
+using BeanBot.Util;
 using CsvHelper;
 using Discord.WebSocket;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Globalization;
 using System.IO;
@@ -17,17 +18,22 @@ namespace BeanBot.EventHandlers
     {
         private readonly DiscordSocketClient _discordClient;
         private readonly ulong _generalChannelId;
+        private readonly ILogger<PunHandler> _logger;
         private readonly CancellationTokenSource _tokenSource = new();
         private Task? _runner;
         private int _disposed;
 
         private static readonly TimeSpan PostTimeLocal = new TimeSpan(16, 20, 0);
 
-        public PunHandler(DiscordSocketClient discordSocketClient, BeanBotOptions options)
+        public PunHandler(
+            DiscordSocketClient discordSocketClient,
+            BeanBotOptions options,
+            ILogger<PunHandler> logger)
         {
-            Log.Information("Initializing Daily Pun Posting Service");
             _discordClient = discordSocketClient ?? throw new ArgumentNullException(nameof(discordSocketClient));
             _generalChannelId = (options ?? throw new ArgumentNullException(nameof(options))).GeneralChannelId;
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            BeanBotLog.PunServiceInitializing(_logger);
         }
 
         public void Start()
@@ -58,10 +64,19 @@ namespace BeanBot.EventHandlers
                     }
 
                     var chicagoNow = GetChicagoNow(timezone);
-                    Log.Information("Next pun scheduled for {NextLocal} Chicago ({NextUtc} UTC). Now: {NowLocal} Chicago",
-                        TimeZoneInfo.ConvertTime(nextRunUtc, timezone).ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture),
-                        nextRunUtc.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture),
-                        chicagoNow.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture));
+                    if (_logger.IsEnabled(LogLevel.Information))
+                    {
+                        var nextLocal = TimeZoneInfo.ConvertTime(nextRunUtc, timezone)
+                            .ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+                        var nextUtc = nextRunUtc.UtcDateTime
+                            .ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+                        var nowLocal = chicagoNow.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+                        BeanBotLog.PunScheduled(
+                            _logger,
+                            nextLocal,
+                            nextUtc,
+                            nowLocal);
+                    }
 
                     await Task.Delay(delay, token);
 
@@ -69,11 +84,11 @@ namespace BeanBot.EventHandlers
                 }
                 catch (OperationCanceledException)
                 {
-                    Log.Warning("Shutting down pun service");
+                    BeanBotLog.PunServiceShuttingDown(_logger);
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "Error in PunHandler loop; retrying in 30s");
+                    BeanBotLog.PunLoopFailed(_logger, ex);
                     await Task.Delay(TimeSpan.FromSeconds(30), token);
                 }
             }
@@ -82,12 +97,12 @@ namespace BeanBot.EventHandlers
         private async Task PostDailyAsync(TimeZoneInfo timezone, CancellationToken token)
         {
             var chicagoNow = GetChicagoNow(timezone);
-            Log.Information("Posting daily pun at {LocalTime} Chicago", chicagoNow);
+            BeanBotLog.PunPosting(_logger, chicagoNow);
 
             var channel = _discordClient.GetChannel(_generalChannelId) as SocketTextChannel;
             if (channel is null)
             {
-                Log.Error("Could not find general channel with ID {ChannelId} to post daily pun", _generalChannelId);
+                BeanBotLog.PunChannelMissing(_logger, _generalChannelId);
                 return;
             }
 
@@ -104,7 +119,7 @@ namespace BeanBot.EventHandlers
 
                 if (puns.Count == 0)
                 {
-                    Log.Error("No puns found in puns.csv");
+                    BeanBotLog.PunFileEmpty(_logger);
                     return;
                 }
 
@@ -115,11 +130,11 @@ namespace BeanBot.EventHandlers
             }
             catch (FileNotFoundException)
             {
-                Log.Error("puns.csv file not found; cannot post daily pun");
+                BeanBotLog.PunFileMissing(_logger);
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "Error occurred while posting daily pun");
+                BeanBotLog.PunPostingFailed(_logger, ex);
             }
         }
 

--- a/BeanBot/EventHandlers/ReactHandler.cs
+++ b/BeanBot/EventHandlers/ReactHandler.cs
@@ -1,6 +1,7 @@
 using BeanBot.Services;
+using BeanBot.Util;
 using Discord.WebSocket;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 
 namespace BeanBot.EventHandlers
@@ -9,13 +10,18 @@ namespace BeanBot.EventHandlers
     {
         private readonly DiscordSocketClient _discordClient;
         private readonly RoleReactService _roleService;
+        private readonly ILogger<ReactHandler> _logger;
         private bool _initialized;
 
-        public ReactHandler(DiscordSocketClient discordClient, RoleReactService roleReactService)
+        public ReactHandler(
+            DiscordSocketClient discordClient,
+            RoleReactService roleReactService,
+            ILogger<ReactHandler> logger)
         {
-            Log.Information("Instantiating React Handler");
             _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
             _roleService = roleReactService ?? throw new ArgumentNullException(nameof(roleReactService));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            BeanBotLog.ReactHandlerCreated(_logger);
         }
 
         public void InitializeReactDependentServices()
@@ -25,7 +31,7 @@ namespace BeanBot.EventHandlers
                 return;
             }
 
-            Log.Information("Instantiating Role Services");
+            BeanBotLog.RoleServicesCreated(_logger);
             _discordClient.ReactionAdded += _roleService.HandleReact;
             _discordClient.ReactionRemoved += _roleService.HandleRemoveReact;
             _initialized = true;

--- a/BeanBot/Hosting/BeanBotApplication.cs
+++ b/BeanBot/Hosting/BeanBotApplication.cs
@@ -1,4 +1,5 @@
-using Serilog;
+using BeanBot.Util;
+using Microsoft.Extensions.Logging;
 
 using System;
 using System.Threading;
@@ -27,12 +28,16 @@ namespace BeanBot.Hosting
     internal sealed class BeanBotApplication : IBeanBotApplication
     {
         private readonly IBeanBotRuntime _runtime;
+        private readonly ILogger<BeanBotApplication> _logger;
         private int _startRequested;
         private int _stopRequested;
 
-        public BeanBotApplication(IBeanBotRuntime runtime)
+        public BeanBotApplication(
+            IBeanBotRuntime runtime,
+            ILogger<BeanBotApplication> logger)
         {
             _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public async Task StartAsync(CancellationToken cancellationToken)
@@ -65,8 +70,7 @@ namespace BeanBot.Hosting
             await _runtime.FlushOwnerAlertsAsync();
             if (_runtime.HasUnfinishedDiscordStartupOperation)
             {
-                Log.Warning(
-                    "Skipping Discord stop/logout and client disposal because a startup lifecycle operation is still running; process exit will reclaim it");
+                BeanBotLog.DiscordStopSkipped(_logger);
             }
             else
             {

--- a/BeanBot/Hosting/BeanBotHostedService.cs
+++ b/BeanBot/Hosting/BeanBotHostedService.cs
@@ -1,6 +1,6 @@
+using BeanBot.Util;
 using Microsoft.Extensions.Hosting;
-
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 using System;
 using System.Threading;
@@ -18,13 +18,16 @@ namespace BeanBot.Hosting
     {
         private readonly IBeanBotApplication _application;
         private readonly IHostApplicationLifetime _hostLifetime;
+        private readonly ILogger<BeanBotHostedService> _logger;
 
         public BeanBotHostedService(
             IBeanBotApplication application,
-            IHostApplicationLifetime hostLifetime)
+            IHostApplicationLifetime hostLifetime,
+            ILogger<BeanBotHostedService> logger)
         {
             _application = application ?? throw new ArgumentNullException(nameof(application));
             _hostLifetime = hostLifetime ?? throw new ArgumentNullException(nameof(hostLifetime));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public async Task StartAsync(CancellationToken cancellationToken)
@@ -44,9 +47,7 @@ namespace BeanBot.Hosting
                 }
                 catch (Exception cleanupException)
                 {
-                    Log.Error(
-                        cleanupException,
-                        "BeanBot cleanup failed after application startup did not complete");
+                    BeanBotLog.StartupCleanupFailed(_logger, cleanupException);
                 }
 
                 throw;

--- a/BeanBot/Hosting/BeanBotRuntime.cs
+++ b/BeanBot/Hosting/BeanBotRuntime.cs
@@ -4,7 +4,7 @@ using BeanBot.Util;
 
 using Discord.WebSocket;
 
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 using System;
 using System.Threading;
@@ -29,6 +29,8 @@ namespace BeanBot.Hosting
         private readonly ReactHandler _reactHandler;
         private readonly DiscordMessageWaiter _messageWaiter;
         private readonly DiscordPaginatorService _paginatorService;
+        private readonly LogHandler _logHandler;
+        private readonly ILogger<BeanBotRuntime> _logger;
 
         public BeanBotRuntime(
             DiscordSocketClient discordClient,
@@ -45,7 +47,9 @@ namespace BeanBot.Hosting
             NewMemberHandler newMemberHandler,
             ReactHandler reactHandler,
             DiscordMessageWaiter messageWaiter,
-            DiscordPaginatorService paginatorService)
+            DiscordPaginatorService paginatorService,
+            LogHandler logHandler,
+            ILogger<BeanBotRuntime> logger)
         {
             _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
             _discordConnectionHealth = discordConnectionHealth ?? throw new ArgumentNullException(nameof(discordConnectionHealth));
@@ -62,6 +66,8 @@ namespace BeanBot.Hosting
             _reactHandler = reactHandler ?? throw new ArgumentNullException(nameof(reactHandler));
             _messageWaiter = messageWaiter ?? throw new ArgumentNullException(nameof(messageWaiter));
             _paginatorService = paginatorService ?? throw new ArgumentNullException(nameof(paginatorService));
+            _logHandler = logHandler ?? throw new ArgumentNullException(nameof(logHandler));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public bool HasUnfinishedDiscordStartupOperation
@@ -85,13 +91,13 @@ namespace BeanBot.Hosting
 
         public async Task StartCommandServicesAsync()
         {
-            Log.Information("Instantiating Command Services");
+            BeanBotLog.CommandServicesCreated(_logger);
             await _commandHandler.InitializeCommandsAsync();
         }
 
         public void StartEventAndBackgroundServices()
         {
-            _discordClient.Log += LogHandler.LogMessages;
+            _discordClient.Log += _logHandler.LogMessages;
             _punHandler.Start();
             _editMessageHandler.InitializeEventListener();
             _newMemberHandler.InitializeNewMembers();
@@ -106,7 +112,7 @@ namespace BeanBot.Hosting
             _commandHandler.Dispose();
             _messageWaiter.Dispose();
             _paginatorService.Dispose();
-            _discordClient.Log -= LogHandler.LogMessages;
+            _discordClient.Log -= _logHandler.LogMessages;
         }
 
         public Task StopGatewayRecoveryAsync()
@@ -150,7 +156,7 @@ namespace BeanBot.Hosting
 
         public void DisposeDiscordClient() => _discordClient.Dispose();
 
-        private static async Task<bool> RunBoundedShutdownOperationAsync(
+        private async Task<bool> RunBoundedShutdownOperationAsync(
             Func<Task> beginOperation,
             string operationName,
             TimeSpan timeout,
@@ -158,9 +164,7 @@ namespace BeanBot.Hosting
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                Log.Warning(
-                    "Skipping Discord {Operation} operation because the host shutdown deadline elapsed",
-                    operationName);
+                BeanBotLog.DiscordShutdownOperationSkipped(_logger, operationName);
                 return false;
             }
 
@@ -175,19 +179,16 @@ namespace BeanBot.Hosting
                 if (!operation.IsCompleted)
                 {
                     _ = operation.ContinueWith(
-                        completedTask => Log.Error(
-                            completedTask.Exception,
-                            "Discord {Operation} operation failed after its shutdown wait ended",
-                            operationName),
+                        completedTask => BeanBotLog.DiscordShutdownLateFailure(
+                            _logger,
+                            operationName,
+                            completedTask.Exception),
                         CancellationToken.None,
                         TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
                         TaskScheduler.Default);
                 }
 
-                Log.Error(
-                    exception,
-                    "Discord {Operation} operation did not complete during bounded shutdown",
-                    operationName);
+                BeanBotLog.DiscordShutdownOperationFailed(_logger, operationName, exception);
                 return false;
             }
         }
@@ -196,19 +197,22 @@ namespace BeanBot.Hosting
         {
             _discordConnectionHealth.MarkReady();
             _discordGatewayRecovery.NotifyReady();
-            Log.Information(
-                "BeanBot Discord gateway reached Ready. LoginState={LoginState}, ConnectionState={ConnectionState}",
-                _discordClient.LoginState,
-                _discordClient.ConnectionState);
+            if (_logger.IsEnabled(LogLevel.Information))
+            {
+                var loginState = _discordClient.LoginState;
+                var connectionState = _discordClient.ConnectionState;
+                BeanBotLog.DiscordReady(
+                    _logger,
+                    loginState,
+                    connectionState);
+            }
             try
             {
                 await _discordOutageRecoveryNotifier.NotifyIfOutageRecoveredAsync(DateTimeOffset.UtcNow);
             }
             catch (Exception exception)
             {
-                Log.Error(
-                    exception,
-                    "Discord reached Ready, but the persisted outage recovery notification could not be processed");
+                BeanBotLog.OutageRecoveryProcessingFailed(_logger, exception);
             }
         }
 
@@ -218,41 +222,41 @@ namespace BeanBot.Hosting
             var snapshot = _discordConnectionHealth.CreateSnapshot(_discordClient);
             if (exception is null)
             {
-                Log.Warning(
-                    "BeanBot disconnected from Discord. LoginState={LoginState}, ConnectionState={ConnectionState}, MostRecentDisconnectReason={MostRecentDisconnectReason}",
+                BeanBotLog.DiscordDisconnected(
+                    _logger,
                     snapshot.LoginState,
                     snapshot.ConnectionState,
                     snapshot.MostRecentDisconnectReason);
             }
             else
             {
-                Log.Warning(
-                    exception,
-                    "BeanBot disconnected from Discord. LoginState={LoginState}, ConnectionState={ConnectionState}, MostRecentDisconnectReason={MostRecentDisconnectReason}",
+                BeanBotLog.DiscordDisconnected(
+                    _logger,
                     snapshot.LoginState,
                     snapshot.ConnectionState,
-                    snapshot.MostRecentDisconnectReason);
+                    snapshot.MostRecentDisconnectReason,
+                    exception);
             }
 
             _discordGatewayRecovery.StartMonitoring();
             return Task.CompletedTask;
         }
 
-        private static void HandleUnhandledException(object sender, UnhandledExceptionEventArgs eventArgs)
+        private void HandleUnhandledException(object sender, UnhandledExceptionEventArgs eventArgs)
         {
             if (eventArgs.ExceptionObject is Exception exception)
             {
-                Log.Fatal(exception, "An unhandled application exception occurred");
+                BeanBotLog.UnhandledApplicationException(_logger, exception);
             }
             else
             {
-                Log.Fatal("An unhandled non-Exception error occurred: {Error}", eventArgs.ExceptionObject);
+                BeanBotLog.UnhandledApplicationError(_logger, eventArgs.ExceptionObject);
             }
         }
 
-        private static void HandleUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs eventArgs)
+        private void HandleUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs eventArgs)
         {
-            Log.Error(eventArgs.Exception, "An unobserved task exception occurred");
+            BeanBotLog.UnobservedTaskException(_logger, eventArgs.Exception);
             eventArgs.SetObserved();
         }
     }

--- a/BeanBot/Hosting/BeanBotServiceCollectionExtensions.cs
+++ b/BeanBot/Hosting/BeanBotServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ using Discord.WebSocket;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 using MongoDB.Driver;
@@ -60,7 +61,8 @@ namespace BeanBot.Hosting
                 return new DiscordStartupLifecycle(
                     provider.GetRequiredService<DiscordSocketClient>(),
                     provider.GetRequiredService<BeanBotOptions>().BotToken,
-                    options.LifecycleOperationTimeout);
+                    options.LifecycleOperationTimeout,
+                    provider.GetRequiredService<ILogger<DiscordStartupLifecycle>>());
             });
             services.AddSingleton<IDiscordStartupLifecycle>(provider =>
                 provider.GetRequiredService<DiscordStartupLifecycle>());
@@ -74,12 +76,14 @@ namespace BeanBot.Hosting
                 return new DiscordGatewayLifecycle(
                     provider.GetRequiredService<DiscordSocketClient>(),
                     provider.GetRequiredService<BeanBotOptions>().BotToken,
-                    options.LifecycleOperationTimeout);
+                    options.LifecycleOperationTimeout,
+                    provider.GetRequiredService<ILogger<DiscordGatewayLifecycle>>());
             });
             services.AddSingleton<IRecoveryDelay, TaskRecoveryDelay>();
 
-            services.AddSingleton<DiscordOutageStore>(_ => new DiscordOutageStore(
-                Path.GetFullPath(DirectorySetup.botBaseDirectory)));
+            services.AddSingleton<DiscordOutageStore>(provider => new DiscordOutageStore(
+                Path.GetFullPath(DirectorySetup.botBaseDirectory),
+                provider.GetRequiredService<ILogger<DiscordOutageStore>>()));
             services.AddSingleton<IDiscordOutageStore>(provider =>
                 provider.GetRequiredService<DiscordOutageStore>());
 
@@ -91,6 +95,7 @@ namespace BeanBot.Hosting
             services.AddSingleton<IOwnerErrorNotifier>(provider =>
                 provider.GetRequiredService<DiscordOwnerErrorNotifier>());
             services.AddSingleton<DiscordOutageRecoveryNotifier>();
+            services.AddSingleton<LogHandler>();
 
             services.AddSingleton<DiscordGatewayRecoveryService>(provider =>
             {
@@ -100,6 +105,7 @@ namespace BeanBot.Hosting
                     () => connectionHealth.CreateSnapshot(client),
                     provider.GetRequiredService<IDiscordGatewayLifecycle>(),
                     provider.GetRequiredService<IDiscordOutageStore>(),
+                    provider.GetRequiredService<ILogger<DiscordGatewayRecoveryService>>(),
                     provider.GetRequiredService<DiscordGatewayRecoveryOptions>(),
                     provider.GetRequiredService<IRecoveryDelay>());
             });
@@ -107,6 +113,7 @@ namespace BeanBot.Hosting
             services.AddSingleton<FortuneAnswerStore>();
             services.AddSingleton<DiscordMessageWaiter>();
             services.AddSingleton<DiscordPaginatorService>();
+            services.AddSingleton<EditMessageEventServices>();
             services.AddSingleton<RoleReactRepository>();
             services.AddSingleton<RoleReactService>();
             services.AddSingleton<DiscordMessageCleanupService>();
@@ -119,7 +126,8 @@ namespace BeanBot.Hosting
             services.AddSingleton<HealthCheckServer>(provider => new HealthCheckServer(
                 provider.GetRequiredService<BeanBotOptions>().HealthCheck,
                 provider.GetRequiredService<DiscordSocketClient>(),
-                provider.GetRequiredService<DiscordConnectionHealth>()));
+                provider.GetRequiredService<DiscordConnectionHealth>(),
+                provider.GetRequiredService<ILogger<HealthCheckServer>>()));
 
             services.AddSingleton<BeanBotRuntime>();
             services.AddSingleton<IBeanBotRuntime>(provider =>

--- a/BeanBot/Modules/AdministrativeModule.cs
+++ b/BeanBot/Modules/AdministrativeModule.cs
@@ -1,10 +1,11 @@
 using BeanBot.Attributes;
 using BeanBot.Entities;
 using BeanBot.Services;
+using BeanBot.Util;
 using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -33,15 +34,18 @@ namespace BeanBot.Modules
         private readonly RoleReactService _roleReactService;
         private readonly DiscordMessageCleanupService _messageCleanupService;
         private readonly DiscordMessageWaiter _messageWaiter;
+        private readonly ILogger<AdministrativeModule> _logger;
 
         public AdministrativeModule(
             RoleReactService roleReactService,
             DiscordMessageCleanupService messageCleanupService,
-            DiscordMessageWaiter messageWaiter)
+            DiscordMessageWaiter messageWaiter,
+            ILogger<AdministrativeModule> logger)
         {
             _roleReactService = roleReactService ?? throw new ArgumentNullException(nameof(roleReactService));
             _messageCleanupService = messageCleanupService ?? throw new ArgumentNullException(nameof(messageCleanupService));
             _messageWaiter = messageWaiter ?? throw new ArgumentNullException(nameof(messageWaiter));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         [Command("role setting", RunMode = RunMode.Async)]
@@ -115,9 +119,7 @@ namespace BeanBot.Modules
                         await _roleReactService.SaveRoleSettings(roleEmotePairs, messageToListen);
                     },
                     messageToListen => messageToListen.DeleteAsync(),
-                    exception => Log.Warning(
-                        exception,
-                        "Could not delete incomplete reaction-role message after setup failed"));
+                    exception => BeanBotLog.IncompleteReactionRoleCleanupFailed(_logger, exception));
             }
             finally
             {
@@ -282,7 +284,7 @@ namespace BeanBot.Modules
             }
             catch (Exception exception)
             {
-                Log.Warning(exception, "Could not clean up the reaction-role setup messages");
+                BeanBotLog.ReactionRoleCleanupFailed(_logger, exception);
             }
         }
     }

--- a/BeanBot/Modules/MemeModule.cs
+++ b/BeanBot/Modules/MemeModule.cs
@@ -7,7 +7,7 @@ using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
 using MemeApiDotNetWrapper;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -26,15 +26,18 @@ namespace BeanBot.Modules
         private readonly BeanBotOptions _options;
         private readonly FortuneAnswerStore _fortuneAnswers;
         private readonly DiscordPaginatorService _paginator;
+        private readonly ILogger<MemeModule> _logger;
 
         public MemeModule(
             BeanBotOptions options,
             FortuneAnswerStore fortuneAnswers,
-            DiscordPaginatorService paginator)
+            DiscordPaginatorService paginator,
+            ILogger<MemeModule> logger)
         {
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _fortuneAnswers = fortuneAnswers ?? throw new ArgumentNullException(nameof(fortuneAnswers));
             _paginator = paginator ?? throw new ArgumentNullException(nameof(paginator));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         private static readonly string[] EightBallResponses = new string[8]
@@ -133,7 +136,7 @@ namespace BeanBot.Modules
             }
             catch (Exception exception)
             {
-                Log.Warning(exception, "Could not delete the source message for echo command {MessageId}", Context.Message.Id);
+                BeanBotLog.EchoSourceDeleteFailed(_logger, Context.Message.Id, exception);
             }
             await ReplyAsync(text);
         }
@@ -179,7 +182,7 @@ namespace BeanBot.Modules
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "The meme API request failed");
+                BeanBotLog.MemeApiFailed(_logger, ex);
                 meme = null;
             }
 
@@ -238,7 +241,7 @@ namespace BeanBot.Modules
 
                 if (puns.Count == 0)
                 {
-                    Log.Warning("No usable puns were found in Resources/puns.csv");
+                    BeanBotLog.ModulePunFileEmpty(_logger);
                     await ReplyAsync("The PunMaster is temporarily out of material.");
                     return;
                 }
@@ -298,7 +301,7 @@ namespace BeanBot.Modules
                 }
                 catch (Exception exception)
                 {
-                    Log.Warning(exception, "Could not attach the invalid-question Gordon GIF");
+                    BeanBotLog.GordonAttachmentFailed(_logger, exception);
                     await ReplyAsync(rejection);
                 }
             }
@@ -349,7 +352,7 @@ namespace BeanBot.Modules
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "Failed to download an image from {ImageUrl}", url);
+                BeanBotLog.ImageDownloadFailed(_logger, url, ex);
                 await ReplyAsync("I couldn't download that image right now.");
             }
         }

--- a/BeanBot/Program.cs
+++ b/BeanBot/Program.cs
@@ -21,6 +21,7 @@ namespace BeanBot
         private static async Task<int> Main(string[] args)
         {
             IHost? host = null;
+            Log.Logger = LogHandler.CreateBootstrapLogger();
             try
             {
                 DirectorySetup.MakeSureAllDirectoriesExist();
@@ -31,10 +32,12 @@ namespace BeanBot
                 builder.Services.Configure<HostOptions>(options =>
                     options.ShutdownTimeout = HostShutdownTimeout);
                 builder.Services.AddBeanBot(builder.Configuration);
+                builder.Services.AddSerilog((services, loggerConfiguration) =>
+                    LogHandler.ConfigureLogger(
+                        loggerConfiguration,
+                        services.GetRequiredService<DiscordOwnerErrorNotifier>()));
 
                 host = builder.Build();
-                LogHandler.CreateLoggerConfiguration(
-                    host.Services.GetRequiredService<DiscordOwnerErrorNotifier>());
 
                 await host.RunAsync();
                 return 0;
@@ -67,7 +70,7 @@ namespace BeanBot
                 }
                 finally
                 {
-                    Log.CloseAndFlush();
+                    await Log.CloseAndFlushAsync();
                 }
             }
         }

--- a/BeanBot/Repository/RoleReactRepository.cs
+++ b/BeanBot/Repository/RoleReactRepository.cs
@@ -1,7 +1,8 @@
 ﻿using BeanBot.Entities;
+using BeanBot.Util;
 using Discord;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
-using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -12,9 +13,13 @@ namespace BeanBot.Repository
     public class RoleReactRepository
     {
         private readonly IMongoCollection<RoleSettings> _roleSettings;
+        private readonly ILogger<RoleReactRepository> _logger;
 
-        public RoleReactRepository(IMongoDatabase database)
+        public RoleReactRepository(
+            IMongoDatabase database,
+            ILogger<RoleReactRepository> logger)
         {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _roleSettings = (database ?? throw new ArgumentNullException(nameof(database)))
                 .GetCollection<RoleSettings>("roleSettings");
         }
@@ -25,11 +30,11 @@ namespace BeanBot.Repository
             {
                 roleSettings.lastAccessed = DateTime.UtcNow;
                 await _roleSettings.InsertOneAsync(roleSettings);
-                Log.Information("Reaction-role settings successfully created for message {MessageId}", roleSettings.messageId);
+                BeanBotLog.ReactionRoleSettingsCreated(_logger, roleSettings.messageId);
             }
             catch (Exception e)
             {
-                Log.Error(e, "Error inserting reaction-role settings into the database");
+                BeanBotLog.ReactionRoleInsertFailed(_logger, e);
                 throw;
             }
         }
@@ -44,7 +49,7 @@ namespace BeanBot.Repository
             }
             catch (Exception e)
             {
-                Log.Error(e, "Error retrieving recent reaction-role settings from the database");
+                BeanBotLog.RecentReactionRoleReadFailed(_logger, e);
                 throw;
             }
         }
@@ -59,7 +64,7 @@ namespace BeanBot.Repository
             }
             catch (Exception e)
             {
-                Log.Error(e, "Error retrieving reaction-role settings for message {MessageId}", message.Id);
+                BeanBotLog.ReactionRoleReadFailed(_logger, message.Id, e);
                 return null;
             }
         }

--- a/BeanBot/Services/DiscordGatewayRecoveryService.cs
+++ b/BeanBot/Services/DiscordGatewayRecoveryService.cs
@@ -1,7 +1,8 @@
+using BeanBot.Util;
 using Discord;
 using Discord.WebSocket;
 
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 using System;
 using System.Diagnostics;
@@ -53,15 +54,18 @@ namespace BeanBot.Services
         private readonly DiscordSocketClient _client;
         private readonly string _botToken;
         private readonly TimeSpan _operationTimeout;
+        private readonly ILogger<DiscordGatewayLifecycle> _logger;
 
         public DiscordGatewayLifecycle(
             DiscordSocketClient client,
             string botToken,
-            TimeSpan operationTimeout)
+            TimeSpan operationTimeout,
+            ILogger<DiscordGatewayLifecycle> logger)
         {
             _client = client ?? throw new ArgumentNullException(nameof(client));
             _botToken = botToken ?? throw new ArgumentNullException(nameof(botToken));
             _operationTimeout = operationTimeout;
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public async Task ReconnectAsync(CancellationToken cancellationToken)
@@ -99,13 +103,13 @@ namespace BeanBot.Services
             }
         }
 
-        private static void ObserveLateFailure(Task operation, string operationName)
+        private void ObserveLateFailure(Task operation, string operationName)
         {
             _ = operation.ContinueWith(
-                completedTask => Log.Error(
-                    completedTask.Exception,
-                    "Discord gateway {Operation} operation failed after its recovery wait ended",
-                    operationName),
+                completedTask => BeanBotLog.DiscordRecoveryLateFailure(
+                    _logger,
+                    operationName,
+                    completedTask.Exception),
                 CancellationToken.None,
                 TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
                 TaskScheduler.Default);
@@ -121,6 +125,7 @@ namespace BeanBot.Services
         private readonly DiscordGatewayRecoveryOptions _options;
         private readonly IRecoveryDelay _delay;
         private readonly Action<int> _exitProcess;
+        private readonly ILogger<DiscordGatewayRecoveryService> _logger;
         private readonly CancellationTokenSource _shutdown = new();
         private TaskCompletionSource<bool>? _readySignal;
         private Task? _monitorTask;
@@ -130,6 +135,7 @@ namespace BeanBot.Services
             Func<DiscordHealthSnapshot> createHealthSnapshot,
             IDiscordGatewayLifecycle lifecycle,
             IDiscordOutageStore outageStore,
+            ILogger<DiscordGatewayRecoveryService> logger,
             DiscordGatewayRecoveryOptions? options = null,
             IRecoveryDelay? delay = null,
             Action<int>? exitProcess = null)
@@ -137,6 +143,7 @@ namespace BeanBot.Services
             _createHealthSnapshot = createHealthSnapshot ?? throw new ArgumentNullException(nameof(createHealthSnapshot));
             _lifecycle = lifecycle ?? throw new ArgumentNullException(nameof(lifecycle));
             _outageStore = outageStore ?? throw new ArgumentNullException(nameof(outageStore));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _options = options ?? DiscordGatewayRecoveryOptions.Default;
             _delay = delay ?? new TaskRecoveryDelay();
             _exitProcess = exitProcess ?? Environment.Exit;
@@ -182,8 +189,8 @@ namespace BeanBot.Services
         private async Task MonitorAsync(DiscordHealthSnapshot initialSnapshot)
         {
             var unhealthySince = initialSnapshot.UnhealthySinceAtUtc ?? DateTimeOffset.UtcNow;
-            Log.Warning(
-                "Discord gateway recovery grace period started. LoginState={LoginState}, ConnectionState={ConnectionState}, GracePeriod={GracePeriod}, MostRecentDisconnectReason={MostRecentDisconnectReason}",
+            BeanBotLog.DiscordRecoveryGraceStarted(
+                _logger,
                 initialSnapshot.LoginState,
                 initialSnapshot.ConnectionState,
                 _options.BuiltInRecoveryGracePeriod,
@@ -211,8 +218,8 @@ namespace BeanBot.Services
                     return;
                 }
 
-                Log.Warning(
-                    "Discord gateway remained unhealthy for {UnhealthyDuration}; beginning one manual reconnect cycle. LoginState={LoginState}, ConnectionState={ConnectionState}, MostRecentDisconnectReason={MostRecentDisconnectReason}",
+                BeanBotLog.DiscordManualRecoveryStarting(
+                    _logger,
                     DateTimeOffset.UtcNow - unhealthySince,
                     snapshot.LoginState,
                     snapshot.ConnectionState,
@@ -231,12 +238,12 @@ namespace BeanBot.Services
                 catch (Exception exception)
                 {
                     snapshot = _createHealthSnapshot();
-                    Log.Error(
-                        exception,
-                        "Discord manual reconnect cycle failed. LoginState={LoginState}, ConnectionState={ConnectionState}, MostRecentDisconnectReason={MostRecentDisconnectReason}",
+                    BeanBotLog.DiscordManualRecoveryFailed(
+                        _logger,
                         snapshot.LoginState,
                         snapshot.ConnectionState,
-                        snapshot.MostRecentDisconnectReason);
+                        snapshot.MostRecentDisconnectReason,
+                        exception);
                 }
 
                 if (await WaitForReadyAsync(
@@ -244,8 +251,8 @@ namespace BeanBot.Services
                     _shutdown.Token))
                 {
                     snapshot = _createHealthSnapshot();
-                    Log.Information(
-                        "Discord manual reconnect succeeded after {UnhealthyDuration}. LoginState={LoginState}, ConnectionState={ConnectionState}",
+                    BeanBotLog.DiscordManualRecoverySucceeded(
+                        _logger,
                         DateTimeOffset.UtcNow - unhealthySince,
                         snapshot.LoginState,
                         snapshot.ConnectionState);
@@ -260,16 +267,16 @@ namespace BeanBot.Services
                 snapshot = _createHealthSnapshot();
                 if (snapshot.IsHealthy)
                 {
-                    Log.Information(
-                        "Discord manual reconnect succeeded after {UnhealthyDuration}. LoginState={LoginState}, ConnectionState={ConnectionState}",
+                    BeanBotLog.DiscordManualRecoverySucceeded(
+                        _logger,
                         DateTimeOffset.UtcNow - unhealthySince,
                         snapshot.LoginState,
                         snapshot.ConnectionState);
                     return;
                 }
 
-                Log.Error(
-                    "Discord manual reconnect failed to reach Ready after {UnhealthyDuration}. LoginState={LoginState}, ConnectionState={ConnectionState}, MostRecentDisconnectReason={MostRecentDisconnectReason}",
+                BeanBotLog.DiscordManualRecoveryNotReady(
+                    _logger,
                     DateTimeOffset.UtcNow - unhealthySince,
                     snapshot.LoginState,
                     snapshot.ConnectionState,
@@ -280,8 +287,7 @@ namespace BeanBot.Services
                     return;
                 }
 
-                Log.Fatal(
-                    "Discord gateway recovery was exhausted; exiting with code 1 so Docker can restart BeanBot");
+                BeanBotLog.DiscordRecoveryExhausted(_logger);
                 await PersistRestartRequestAsync(unhealthySince, snapshot);
 
                 if (_shutdown.IsCancellationRequested)
@@ -296,11 +302,10 @@ namespace BeanBot.Services
             }
             catch (Exception exception)
             {
-                Log.Fatal(exception, "Discord gateway recovery monitor failed unexpectedly");
+                BeanBotLog.DiscordRecoveryMonitorFailed(_logger, exception);
                 if (!_shutdown.IsCancellationRequested)
                 {
-                    Log.Fatal(
-                        "Exiting with code 1 because the Discord gateway recovery monitor cannot continue safely");
+                    BeanBotLog.DiscordRecoveryMonitorExiting(_logger);
                     var snapshot = _createHealthSnapshot();
                     await PersistRestartRequestAsync(
                         snapshot.UnhealthySinceAtUtc ?? unhealthySince,
@@ -334,10 +339,7 @@ namespace BeanBot.Services
             catch (Exception exception)
             {
                 // Recovery must still proceed if the durable incident record cannot be written.
-                Log.Error(
-                    exception,
-                    "Could not persist the meaningful Discord outage before manual recovery. DisconnectedAtUtc={DisconnectedAtUtc}",
-                    unhealthySince);
+                BeanBotLog.DiscordOutagePersistBeforeRecoveryFailed(_logger, unhealthySince, exception);
             }
         }
 
@@ -359,9 +361,7 @@ namespace BeanBot.Services
             catch (Exception exception)
             {
                 // The process must still exit so Docker can restore service even if persistence is unavailable.
-                Log.Error(
-                    exception,
-                    "Could not persist the Discord outage restart request before process exit");
+                BeanBotLog.DiscordOutageRestartPersistFailed(_logger, exception);
             }
         }
 
@@ -428,8 +428,8 @@ namespace BeanBot.Services
         private void LogNaturalRecovery(DateTimeOffset unhealthySince)
         {
             var snapshot = _createHealthSnapshot();
-            Log.Information(
-                "Discord gateway recovered naturally after {UnhealthyDuration}; manual reconnect was not needed. LoginState={LoginState}, ConnectionState={ConnectionState}",
+            BeanBotLog.DiscordNaturalRecovery(
+                _logger,
                 DateTimeOffset.UtcNow - unhealthySince,
                 snapshot.LoginState,
                 snapshot.ConnectionState);

--- a/BeanBot/Services/DiscordMessageCleanupService.cs
+++ b/BeanBot/Services/DiscordMessageCleanupService.cs
@@ -1,5 +1,6 @@
+using BeanBot.Util;
 using Discord;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -12,15 +13,19 @@ namespace BeanBot.Services
         internal const int MaximumBulkDeleteCount = 100;
         private static readonly TimeSpan MaximumBulkDeleteAge = TimeSpan.FromDays(14) - TimeSpan.FromMinutes(5);
         private readonly Func<DateTimeOffset> _getUtcNow;
+        private readonly ILogger<DiscordMessageCleanupService> _logger;
 
-        public DiscordMessageCleanupService()
-            : this(() => DateTimeOffset.UtcNow)
+        public DiscordMessageCleanupService(ILogger<DiscordMessageCleanupService> logger)
+            : this(() => DateTimeOffset.UtcNow, logger)
         {
         }
 
-        internal DiscordMessageCleanupService(Func<DateTimeOffset> getUtcNow)
+        internal DiscordMessageCleanupService(
+            Func<DateTimeOffset> getUtcNow,
+            ILogger<DiscordMessageCleanupService> logger)
         {
             _getUtcNow = getUtcNow ?? throw new ArgumentNullException(nameof(getUtcNow));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public Task DeleteAsync(ITextChannel channel, IReadOnlyCollection<IMessage> messages)
@@ -32,11 +37,11 @@ namespace BeanBot.Services
                 plan,
                 batch => channel.DeleteMessagesAsync(batch),
                 message => message.DeleteAsync(),
-                (exception, itemCount, isBatch) => Log.Warning(
-                    exception,
-                    "Could not delete {MessageCount} setup message(s) using {DeleteMode}; continuing cleanup",
+                (exception, itemCount, isBatch) => BeanBotLog.MessageCleanupFailed(
+                    _logger,
                     itemCount,
-                    isBatch ? "bulk deletion" : "individual deletion"));
+                    isBatch ? "bulk deletion" : "individual deletion",
+                    exception));
         }
 
         internal static MessageCleanupPlan<T> CreatePlan<T>(

--- a/BeanBot/Services/DiscordOutageRecoveryNotifier.cs
+++ b/BeanBot/Services/DiscordOutageRecoveryNotifier.cs
@@ -1,6 +1,6 @@
 using BeanBot.Util;
 
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 using System;
 using System.Globalization;
@@ -19,16 +19,19 @@ namespace BeanBot.Services
         private readonly IOwnerAlertDelivery _ownerAlertDelivery;
         private readonly Func<int, TimeSpan> _retryDelay;
         private readonly TimeSpan _deliveryTimeout;
+        private readonly ILogger<DiscordOutageRecoveryNotifier> _logger;
         private readonly SemaphoreSlim _notificationAccess = new(1, 1);
 
         public DiscordOutageRecoveryNotifier(
             IDiscordOutageStore outageStore,
             IOwnerAlertDelivery ownerAlertDelivery,
+            ILogger<DiscordOutageRecoveryNotifier> logger,
             Func<int, TimeSpan>? retryDelay = null,
             TimeSpan? deliveryTimeout = null)
         {
             _outageStore = outageStore ?? throw new ArgumentNullException(nameof(outageStore));
             _ownerAlertDelivery = ownerAlertDelivery ?? throw new ArgumentNullException(nameof(ownerAlertDelivery));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _retryDelay = retryDelay ?? (attempt => TimeSpan.FromSeconds(attempt));
             _deliveryTimeout = deliveryTimeout ?? DefaultDeliveryTimeout;
         }
@@ -46,23 +49,23 @@ namespace BeanBot.Services
                     return;
                 }
 
-                Log.Information(
-                    "Attempting Discord outage recovery notification. DisconnectedAtUtc={DisconnectedAtUtc}, ProcessRestartRequested={ProcessRestartRequested}",
+                BeanBotLog.OutageNotificationAttempting(
+                    _logger,
                     outage.DisconnectedAtUtc,
                     outage.ProcessRestartRequested);
 
                 var recoveryMessage = FormatRecoveryMessage(outage, recoveredAtUtc);
                 if (!await DeliverWithRetryAsync(recoveryMessage, cancellationToken))
                 {
-                    Log.Error(
-                        "Discord outage recovery notification failed after {DeliveryAttempts} attempts; persisted outage retained. DisconnectedAtUtc={DisconnectedAtUtc}",
+                    BeanBotLog.OutageNotificationFailed(
+                        _logger,
                         MaximumDeliveryAttempts,
                         outage.DisconnectedAtUtc);
                     return;
                 }
 
-                Log.Information(
-                    "Discord outage recovery notification delivered. DisconnectedAtUtc={DisconnectedAtUtc}",
+                BeanBotLog.OutageNotificationDelivered(
+                    _logger,
                     outage.DisconnectedAtUtc);
                 await _outageStore.ClearAsync(cancellationToken);
             }
@@ -131,11 +134,11 @@ namespace BeanBot.Services
                 }
                 catch (Exception exception)
                 {
-                    Log.Warning(
-                        exception,
-                        "Discord outage recovery notification delivery attempt failed. DeliveryAttempt={DeliveryAttempt}, MaximumDeliveryAttempts={MaximumDeliveryAttempts}",
+                    BeanBotLog.OutageNotificationDeliveryFailed(
+                        _logger,
                         attempt,
-                        MaximumDeliveryAttempts);
+                        MaximumDeliveryAttempts,
+                        exception);
 
                     if (attempt < MaximumDeliveryAttempts)
                     {

--- a/BeanBot/Services/DiscordOutageStore.cs
+++ b/BeanBot/Services/DiscordOutageStore.cs
@@ -1,4 +1,5 @@
-using Serilog;
+using BeanBot.Util;
+using Microsoft.Extensions.Logging;
 
 using System;
 using System.IO;
@@ -39,8 +40,11 @@ namespace BeanBot.Services
         internal const string OutageFileName = "discord-outage.json";
         private readonly string _outageFilePath;
         private readonly SemaphoreSlim _fileAccess = new(1, 1);
+        private readonly ILogger<DiscordOutageStore> _logger;
 
-        public DiscordOutageStore(string persistentDataDirectory)
+        public DiscordOutageStore(
+            string persistentDataDirectory,
+            ILogger<DiscordOutageStore> logger)
         {
             if (string.IsNullOrWhiteSpace(persistentDataDirectory))
             {
@@ -49,6 +53,7 @@ namespace BeanBot.Services
 
             Directory.CreateDirectory(persistentDataDirectory);
             _outageFilePath = Path.Combine(persistentDataDirectory, OutageFileName);
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public async Task<DiscordOutage?> ReadAsync(CancellationToken cancellationToken = default)
@@ -94,9 +99,7 @@ namespace BeanBot.Services
                 },
                 cancellationToken);
 
-            Log.Information(
-                "Discord outage manual recovery attempt persisted. DisconnectedAtUtc={DisconnectedAtUtc}",
-                disconnectedAtUtc);
+            BeanBotLog.OutageManualRecoveryPersisted(_logger, disconnectedAtUtc);
         }
 
         public async Task MarkProcessRestartRequestedAsync(
@@ -114,7 +117,7 @@ namespace BeanBot.Services
                 },
                 cancellationToken);
 
-            Log.Information("Discord outage process restart request persisted");
+            BeanBotLog.OutageRestartPersisted(_logger);
         }
 
         public async Task ClearAsync(CancellationToken cancellationToken = default)
@@ -125,7 +128,7 @@ namespace BeanBot.Services
                 if (File.Exists(_outageFilePath))
                 {
                     File.Delete(_outageFilePath);
-                    Log.Information("Persisted Discord outage cleared");
+                    BeanBotLog.OutageCleared(_logger);
                 }
             }
             finally
@@ -180,8 +183,8 @@ namespace BeanBot.Services
 
                 outage.MostRecentDisconnectReason = NormalizeReason(outage.MostRecentDisconnectReason);
 
-                Log.Information(
-                    "Persisted Discord outage loaded. DisconnectedAtUtc={DisconnectedAtUtc}, ManualRecoveryAttempted={ManualRecoveryAttempted}, ProcessRestartRequested={ProcessRestartRequested}",
+                BeanBotLog.OutageLoaded(
+                    _logger,
                     outage.DisconnectedAtUtc,
                     outage.ManualRecoveryAttempted,
                     outage.ProcessRestartRequested);
@@ -218,8 +221,8 @@ namespace BeanBot.Services
                 }
 
                 File.Move(temporaryFilePath, _outageFilePath, overwrite: true);
-                Log.Information(
-                    "Meaningful Discord outage persisted. DisconnectedAtUtc={DisconnectedAtUtc}, ManualRecoveryAttempted={ManualRecoveryAttempted}, ProcessRestartRequested={ProcessRestartRequested}",
+                BeanBotLog.OutagePersisted(
+                    _logger,
                     outage.DisconnectedAtUtc,
                     outage.ManualRecoveryAttempted,
                     outage.ProcessRestartRequested);
@@ -239,17 +242,11 @@ namespace BeanBot.Services
             try
             {
                 File.Move(_outageFilePath, quarantinePath);
-                Log.Error(
-                    exception,
-                    "Corrupted Discord outage state encountered and quarantined. QuarantinePath={QuarantinePath}",
-                    quarantinePath);
+                BeanBotLog.OutageQuarantined(_logger, quarantinePath, exception);
             }
             catch (Exception quarantineException)
             {
-                Log.Error(
-                    quarantineException,
-                    "Corrupted Discord outage state encountered but could not be quarantined. OutageFilePath={OutageFilePath}",
-                    _outageFilePath);
+                BeanBotLog.OutageQuarantineFailed(_logger, _outageFilePath, quarantineException);
             }
         }
 

--- a/BeanBot/Services/DiscordPaginatorService.cs
+++ b/BeanBot/Services/DiscordPaginatorService.cs
@@ -1,9 +1,10 @@
+using BeanBot.Util;
 using Discord;
 using Discord.Commands;
 using Discord.Rest;
 using Discord.WebSocket;
 
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 using System;
 using System.Collections.Concurrent;
@@ -38,11 +39,15 @@ namespace BeanBot.Services
         private readonly SemaphoreSlim _availableSlots = new(MaximumActivePaginators, MaximumActivePaginators);
         private readonly CancellationTokenSource _shutdown = new();
         private readonly object _syncRoot = new();
+        private readonly ILogger<DiscordPaginatorService> _logger;
         private int _disposed;
 
-        public DiscordPaginatorService(DiscordSocketClient discordClient)
+        public DiscordPaginatorService(
+            DiscordSocketClient discordClient,
+            ILogger<DiscordPaginatorService> logger)
         {
             _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _discordClient.ReactionAdded += HandleReactionAsync;
         }
 
@@ -189,6 +194,7 @@ namespace BeanBot.Services
                             session.Message,
                             reaction.Emote,
                             reaction.UserId,
+                            _logger,
                             _shutdown.Token);
                     }
                 }
@@ -207,10 +213,7 @@ namespace BeanBot.Services
             }
             catch (Exception exception)
             {
-                Log.Warning(
-                    exception,
-                    "Could not process Discord paginator reaction for message {MessageId}",
-                    message.Id);
+                BeanBotLog.PaginatorReactionFailed(_logger, message.Id, exception);
             }
         }
 
@@ -256,10 +259,7 @@ namespace BeanBot.Services
                     }
                     catch (Exception exception)
                     {
-                        Log.Debug(
-                            exception,
-                            "Could not remove expired paginator control from message {MessageId}",
-                            messageId);
+                        BeanBotLog.PaginatorControlRemoveFailed(_logger, messageId, exception);
                     }
                 }
             }
@@ -268,7 +268,7 @@ namespace BeanBot.Services
             }
             catch (Exception exception)
             {
-                Log.Warning(exception, "Discord paginator expiration failed for message {MessageId}", messageId);
+                BeanBotLog.PaginatorExpirationFailed(_logger, messageId, exception);
             }
             finally
             {
@@ -313,8 +313,10 @@ namespace BeanBot.Services
             IUserMessage message,
             IEmote emote,
             ulong userId,
+            ILogger<DiscordPaginatorService> logger,
             CancellationToken cancellationToken = default)
         {
+            ArgumentNullException.ThrowIfNull(logger);
             try
             {
                 await message.RemoveReactionAsync(
@@ -324,10 +326,7 @@ namespace BeanBot.Services
             }
             catch (Exception exception)
             {
-                Log.Debug(
-                    exception,
-                    "Could not remove paginator reaction from user {UserId}",
-                    userId);
+                BeanBotLog.PaginatorUserReactionRemoveFailed(logger, userId, exception);
             }
         }
 
@@ -424,13 +423,11 @@ namespace BeanBot.Services
                     return;
                 }
 
-                Log.Warning(
-                    "Discord paginator shutdown exceeded {Timeout}; cleanup will finish in the background",
-                    ShutdownTimeout);
+                BeanBotLog.PaginatorShutdownTimedOut(_logger, ShutdownTimeout);
             }
             catch (Exception exception)
             {
-                Log.Warning(exception, "Discord paginator shutdown encountered a cleanup failure");
+                BeanBotLog.PaginatorShutdownFailed(_logger, exception);
                 _shutdown.Dispose();
                 return;
             }
@@ -465,7 +462,7 @@ namespace BeanBot.Services
             }
             catch (Exception exception)
             {
-                Log.Warning(exception, "Deferred Discord paginator cleanup failed");
+                BeanBotLog.PaginatorDeferredCleanupFailed(_logger, exception);
             }
             finally
             {

--- a/BeanBot/Services/DiscordStartupService.cs
+++ b/BeanBot/Services/DiscordStartupService.cs
@@ -1,7 +1,8 @@
+using BeanBot.Util;
 using Discord;
 using Discord.WebSocket;
 
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 using System;
 using System.Net;
@@ -64,12 +65,14 @@ namespace BeanBot.Services
         private readonly Func<Task> _setPresence;
         private readonly TimeSpan _operationTimeout;
         private readonly Action<Exception, string> _lateFailureObserver;
+        private readonly ILogger<DiscordStartupLifecycle> _logger;
         private Task? _unfinishedOperation;
 
         public DiscordStartupLifecycle(
             DiscordSocketClient client,
             string botToken,
-            TimeSpan operationTimeout)
+            TimeSpan operationTimeout,
+            ILogger<DiscordStartupLifecycle> logger)
         {
             ArgumentNullException.ThrowIfNull(client);
             ArgumentNullException.ThrowIfNull(botToken);
@@ -77,6 +80,7 @@ namespace BeanBot.Services
             _start = client.StartAsync;
             _setPresence = () => client.SetGameAsync(GameStatus, null, ActivityType.Playing);
             _operationTimeout = operationTimeout;
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _lateFailureObserver = LogLateFailure;
         }
 
@@ -85,12 +89,14 @@ namespace BeanBot.Services
             Func<Task> start,
             Func<Task> setPresence,
             TimeSpan operationTimeout,
+            ILogger<DiscordStartupLifecycle> logger,
             Action<Exception, string>? lateFailureObserver = null)
         {
             _login = login ?? throw new ArgumentNullException(nameof(login));
             _start = start ?? throw new ArgumentNullException(nameof(start));
             _setPresence = setPresence ?? throw new ArgumentNullException(nameof(setPresence));
             _operationTimeout = operationTimeout;
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _lateFailureObserver = lateFailureObserver ?? LogLateFailure;
         }
 
@@ -176,11 +182,8 @@ namespace BeanBot.Services
                 TaskScheduler.Default);
         }
 
-        private static void LogLateFailure(Exception exception, string operationName)
-            => Log.Error(
-                exception,
-                "Discord {Operation} operation failed after its startup wait ended",
-                operationName);
+        private void LogLateFailure(Exception exception, string operationName)
+            => BeanBotLog.DiscordStartupLateFailure(_logger, operationName, exception);
     }
 
     internal sealed class DiscordStartupService
@@ -188,13 +191,16 @@ namespace BeanBot.Services
         private readonly IDiscordStartupLifecycle _lifecycle;
         private readonly DiscordStartupOptions _options;
         private readonly IDiscordStartupDelay _delay;
+        private readonly ILogger<DiscordStartupService> _logger;
 
         public DiscordStartupService(
             IDiscordStartupLifecycle lifecycle,
+            ILogger<DiscordStartupService> logger,
             DiscordStartupOptions? options = null,
             IDiscordStartupDelay? delay = null)
         {
             _lifecycle = lifecycle ?? throw new ArgumentNullException(nameof(lifecycle));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _options = options ?? DiscordStartupOptions.Default;
             _delay = delay ?? new DiscordStartupDelay();
         }
@@ -222,7 +228,7 @@ namespace BeanBot.Services
             {
                 // A completed presence failure is cosmetic and must not fail an
                 // otherwise valid gateway lifecycle.
-                Log.Warning(exception, "Discord started, but the initial presence could not be set");
+                BeanBotLog.DiscordPresenceFailed(_logger, exception);
             }
         }
 
@@ -231,16 +237,16 @@ namespace BeanBot.Services
             for (var attempt = 1; attempt <= _options.MaximumAttempts; attempt++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                Log.Information(
-                    "Attempting Discord login. Attempt={Attempt}, MaximumAttempts={MaximumAttempts}",
+                BeanBotLog.DiscordLoginAttempting(
+                    _logger,
                     attempt,
                     _options.MaximumAttempts);
 
                 try
                 {
                     await _lifecycle.LoginAsync(cancellationToken);
-                    Log.Information(
-                        "Discord login succeeded. Attempt={Attempt}, MaximumAttempts={MaximumAttempts}",
+                    BeanBotLog.DiscordLoginSucceeded(
+                        _logger,
                         attempt,
                         _options.MaximumAttempts);
                     return;
@@ -251,41 +257,41 @@ namespace BeanBot.Services
                 }
                 catch (Discord.Net.HttpException exception) when (exception.HttpCode == HttpStatusCode.Unauthorized)
                 {
-                    Log.Fatal(
-                        exception,
-                        "Discord rejected the configured bot token. Update BEANBOT_BOT_TOKEN and restart the process. Attempt={Attempt}, MaximumAttempts={MaximumAttempts}",
+                    BeanBotLog.DiscordTokenRejected(
+                        _logger,
                         attempt,
-                        _options.MaximumAttempts);
+                        _options.MaximumAttempts,
+                        exception);
                     throw;
                 }
                 catch (Discord.Net.HttpException exception)
                 {
                     if (attempt == _options.MaximumAttempts)
                     {
-                        Log.Fatal(
-                            exception,
-                            "Discord login failed after all startup attempts. Attempt={Attempt}, MaximumAttempts={MaximumAttempts}",
+                        BeanBotLog.DiscordLoginExhausted(
+                            _logger,
                             attempt,
-                            _options.MaximumAttempts);
+                            _options.MaximumAttempts,
+                            exception);
                         throw;
                     }
 
                     var retryDelay = _options.RetryDelay(attempt);
-                    Log.Warning(
-                        exception,
-                        "Discord login attempt failed; delaying before retry. Attempt={Attempt}, MaximumAttempts={MaximumAttempts}, RetryDelay={RetryDelay}",
+                    BeanBotLog.DiscordLoginRetrying(
+                        _logger,
                         attempt,
                         _options.MaximumAttempts,
-                        retryDelay);
+                        retryDelay,
+                        exception);
                     await _delay.DelayAsync(retryDelay, cancellationToken);
                 }
                 catch (Exception exception)
                 {
-                    Log.Fatal(
-                        exception,
-                        "Discord startup failed with a non-retryable login error. Attempt={Attempt}, MaximumAttempts={MaximumAttempts}",
+                    BeanBotLog.DiscordLoginFailed(
+                        _logger,
                         attempt,
-                        _options.MaximumAttempts);
+                        _options.MaximumAttempts,
+                        exception);
                     throw;
                 }
             }

--- a/BeanBot/Services/EditMessageEventServices.cs
+++ b/BeanBot/Services/EditMessageEventServices.cs
@@ -1,6 +1,7 @@
+using BeanBot.Util;
 using Discord;
 using Discord.WebSocket;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Buffers;
 using System.Linq;
@@ -13,10 +14,14 @@ namespace BeanBot.Services
         private const string EditWarning = "Do not edit your 8ball requests in my presence, mortal.";
         private static readonly SearchValues<char> CommandSeparators = SearchValues.Create(" \t\r\n");
         private readonly DiscordSocketClient _discordClient;
+        private readonly ILogger<EditMessageEventServices> _logger;
 
-        public EditMessageEventServices(DiscordSocketClient discordClient)
+        public EditMessageEventServices(
+            DiscordSocketClient discordClient,
+            ILogger<EditMessageEventServices> logger)
         {
             _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public async Task HandleUpdate(
@@ -41,7 +46,7 @@ namespace BeanBot.Services
 
             if (botResponse == null)
             {
-                Log.Debug("Could not find a cached fortune response for edited message {MessageId}", newMessage.Id);
+                BeanBotLog.FortuneResponseMissing(_logger, newMessage.Id);
                 return;
             }
 
@@ -82,7 +87,7 @@ namespace BeanBot.Services
                    string.Equals(command, "fortune", StringComparison.OrdinalIgnoreCase);
         }
 
-        private static async Task ReplaceResponseAsync(SocketUserMessage botResponse)
+        private async Task ReplaceResponseAsync(SocketUserMessage botResponse)
         {
             const int maxAttempts = 3;
             for (var attempt = 1; attempt <= maxAttempts; attempt++)
@@ -94,12 +99,12 @@ namespace BeanBot.Services
                 }
                 catch (Exception exception) when (attempt < maxAttempts)
                 {
-                    Log.Debug(exception, "Attempt {Attempt} to replace an edited fortune response failed", attempt);
+                    BeanBotLog.FortuneResponseReplaceAttemptFailed(_logger, attempt, exception);
                     await Task.Delay(TimeSpan.FromMilliseconds(100 * attempt));
                 }
                 catch (Exception exception)
                 {
-                    Log.Warning(exception, "Could not replace the response to edited fortune message {MessageId}", botResponse.Id);
+                    BeanBotLog.FortuneResponseReplaceFailed(_logger, botResponse.Id, exception);
                 }
             }
         }

--- a/BeanBot/Services/HealthCheckServer.cs
+++ b/BeanBot/Services/HealthCheckServer.cs
@@ -1,4 +1,5 @@
 using BeanBot.Configuration;
+using BeanBot.Util;
 
 using Discord.WebSocket;
 
@@ -46,6 +47,7 @@ namespace BeanBot.Services
         private readonly TimeSpan _shutdownTimeout;
         private readonly int _maximumConcurrentClients;
         private readonly BoundedClientRateLimiter _rateLimiter;
+        private readonly ILogger<HealthCheckServer> _logger;
         private WebApplication? _application;
         private int _boundPort;
         private int _disposed;
@@ -53,10 +55,12 @@ namespace BeanBot.Services
         public HealthCheckServer(
             HealthCheckOptions options,
             DiscordSocketClient discordClient,
-            DiscordConnectionHealth discordConnectionHealth)
+            DiscordConnectionHealth discordConnectionHealth,
+            ILogger<HealthCheckServer> logger)
             : this(
                 options,
                 CreateSnapshotFactory(discordClient, discordConnectionHealth),
+                logger,
                 DefaultRequestHeadersTimeout,
                 DefaultMaximumConcurrentClients,
                 DefaultMaximumTrackedRateLimitClients,
@@ -67,6 +71,7 @@ namespace BeanBot.Services
         internal HealthCheckServer(
             HealthCheckOptions options,
             Func<DiscordHealthSnapshot> createHealthSnapshot,
+            ILogger<HealthCheckServer> logger,
             TimeSpan? requestHeadersTimeout = null,
             int maximumConcurrentClients = DefaultMaximumConcurrentClients,
             int maximumTrackedRateLimitClients = DefaultMaximumTrackedRateLimitClients,
@@ -74,6 +79,7 @@ namespace BeanBot.Services
         {
             ArgumentNullException.ThrowIfNull(options);
             ArgumentNullException.ThrowIfNull(createHealthSnapshot);
+            ArgumentNullException.ThrowIfNull(logger);
             ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumConcurrentClients);
             ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumTrackedRateLimitClients);
 
@@ -84,6 +90,7 @@ namespace BeanBot.Services
 
             _options = options;
             _createHealthSnapshot = createHealthSnapshot;
+            _logger = logger;
             _requestHeadersTimeout = effectiveRequestHeadersTimeout;
             _shutdownTimeout = effectiveShutdownTimeout;
             _maximumConcurrentClients = maximumConcurrentClients;
@@ -151,8 +158,8 @@ namespace BeanBot.Services
                 }
             }
 
-            Log.Information(
-                "Health check endpoint listening on {BindAddress}:{Port}{Path} with a {RateLimitSeconds}s per-client poll limit",
+            BeanBotLog.HealthEndpointListening(
+                _logger,
                 _options.BindAddress,
                 BoundPort,
                 _options.Path,
@@ -162,8 +169,8 @@ namespace BeanBot.Services
                 && !_options.BindAddress.Equals(IPAddress.Loopback)
                 && !_options.BindAddress.Equals(IPAddress.IPv6Loopback))
             {
-                Log.Warning(
-                    "Health check endpoint is listening without a bearer token on {BindAddress}:{Port}{Path}",
+                BeanBotLog.HealthEndpointUnauthenticated(
+                    _logger,
                     _options.BindAddress,
                     BoundPort,
                     _options.Path);
@@ -195,8 +202,8 @@ namespace BeanBot.Services
                 }
                 catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
                 {
-                    Log.Warning(
-                        "Health check endpoint exceeded its {ShutdownTimeoutSeconds}s shutdown timeout; aborting remaining requests",
+                    BeanBotLog.HealthEndpointShutdownTimedOut(
+                        _logger,
                         _shutdownTimeout.TotalSeconds);
                 }
             }

--- a/BeanBot/Services/RoleReactService.cs
+++ b/BeanBot/Services/RoleReactService.cs
@@ -1,8 +1,9 @@
 using BeanBot.Entities;
 using BeanBot.Repository;
+using BeanBot.Util;
 using Discord;
 using Discord.WebSocket;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -25,24 +26,30 @@ namespace BeanBot.Services
         private readonly TimeSpan _shutdownDrainTimeout;
         private readonly TaskCompletionSource _disposeCompletion = new(
             TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly ILogger<RoleReactService> _logger;
         private volatile bool _cacheLoaded;
         private bool _stopping;
         private int _disposeStarted;
 
-        public RoleReactService(RoleReactRepository roleReactRepository, DiscordSocketClient? client = null)
-            : this(roleReactRepository, client, DefaultShutdownDrainTimeout)
+        public RoleReactService(
+            RoleReactRepository roleReactRepository,
+            ILogger<RoleReactService> logger,
+            DiscordSocketClient? client = null)
+            : this(roleReactRepository, client, DefaultShutdownDrainTimeout, logger)
         {
         }
 
         internal RoleReactService(
             RoleReactRepository roleReactRepository,
             DiscordSocketClient? client,
-            TimeSpan shutdownDrainTimeout)
+            TimeSpan shutdownDrainTimeout,
+            ILogger<RoleReactService> logger)
         {
             ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(shutdownDrainTimeout, TimeSpan.Zero);
             _roleReactRepository = roleReactRepository ?? throw new ArgumentNullException(nameof(roleReactRepository));
             _client = client;
             _shutdownDrainTimeout = shutdownDrainTimeout;
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public Task HandleReact(Cacheable<IUserMessage, ulong> message, Cacheable<IMessageChannel, ulong> channel, SocketReaction reaction)
@@ -144,7 +151,11 @@ namespace BeanBot.Services
             }
             catch (Exception exception)
             {
-                Log.Error(exception, "Failed to {Action} a reaction role for message {MessageId}", addRole ? "add" : "remove", message.Id);
+                BeanBotLog.ReactionRoleActionFailed(
+                    _logger,
+                    addRole ? "add" : "remove",
+                    message.Id,
+                    exception);
             }
         }
 
@@ -243,16 +254,12 @@ namespace BeanBot.Services
                     }
                     catch (TimeoutException)
                     {
-                        Log.Warning(
-                            "Timed out draining {InFlightReactionHandlerCount} reaction-role handler(s); leaving the cache lock for process exit",
-                            inFlightOperations.Length);
+                        BeanBotLog.ReactionRoleDrainTimedOut(_logger, inFlightOperations.Length);
                         return;
                     }
                     catch (Exception exception)
                     {
-                        Log.Warning(
-                            exception,
-                            "A reaction-role handler failed while shutdown was draining in-flight work");
+                        BeanBotLog.ReactionRoleShutdownOperationFailed(_logger, exception);
                     }
                 }
 

--- a/BeanBot/Util/BeanBotLog.cs
+++ b/BeanBot/Util/BeanBotLog.cs
@@ -1,0 +1,289 @@
+using Discord;
+
+using Microsoft.Extensions.Logging;
+
+using System.Net;
+
+namespace BeanBot.Util;
+
+internal static partial class BeanBotLog
+{
+    [LoggerMessage(Level = LogLevel.Information, Message = "Instantiating Command Handler")]
+    internal static partial void CommandHandlerCreated(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Installing Commands")]
+    internal static partial void CommandsInstalling(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Initializing New Member Handler")]
+    internal static partial void NewMemberHandlerInitializing(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Sent the welcome message to {UserId}")]
+    internal static partial void WelcomeMessageSent(ILogger logger, ulong userId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Could not send the welcome message to {UserId}")]
+    internal static partial void WelcomeMessageFailed(ILogger logger, ulong userId, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Initializing Daily Pun Posting Service")]
+    internal static partial void PunServiceInitializing(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Next pun scheduled for {NextLocal} Chicago ({NextUtc} UTC). Now: {NowLocal} Chicago")]
+    internal static partial void PunScheduled(ILogger logger, string nextLocal, string nextUtc, string nowLocal);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Shutting down pun service")]
+    internal static partial void PunServiceShuttingDown(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Error in PunHandler loop; retrying in 30s")]
+    internal static partial void PunLoopFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Posting daily pun at {LocalTime} Chicago")]
+    internal static partial void PunPosting(ILogger logger, DateTimeOffset localTime);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Could not find general channel with ID {ChannelId} to post daily pun")]
+    internal static partial void PunChannelMissing(ILogger logger, ulong channelId);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "No puns found in puns.csv")]
+    internal static partial void PunFileEmpty(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "puns.csv file not found; cannot post daily pun")]
+    internal static partial void PunFileMissing(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Error occurred while posting daily pun")]
+    internal static partial void PunPostingFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Instantiating React Handler")]
+    internal static partial void ReactHandlerCreated(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Instantiating Role Services")]
+    internal static partial void RoleServicesCreated(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Skipping Discord stop/logout and client disposal because a startup lifecycle operation is still running; process exit will reclaim it")]
+    internal static partial void DiscordStopSkipped(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "BeanBot cleanup failed after application startup did not complete")]
+    internal static partial void StartupCleanupFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Instantiating Command Services")]
+    internal static partial void CommandServicesCreated(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Skipping Discord {Operation} operation because the host shutdown deadline elapsed")]
+    internal static partial void DiscordShutdownOperationSkipped(ILogger logger, string operation);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Discord {Operation} operation failed after its shutdown wait ended")]
+    internal static partial void DiscordShutdownLateFailure(ILogger logger, string operation, Exception? exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Discord {Operation} operation did not complete during bounded shutdown")]
+    internal static partial void DiscordShutdownOperationFailed(ILogger logger, string operation, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "BeanBot Discord gateway reached Ready. LoginState={LoginState}, ConnectionState={ConnectionState}")]
+    internal static partial void DiscordReady(ILogger logger, LoginState loginState, ConnectionState connectionState);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Discord reached Ready, but the persisted outage recovery notification could not be processed")]
+    internal static partial void OutageRecoveryProcessingFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "BeanBot disconnected from Discord. LoginState={LoginState}, ConnectionState={ConnectionState}, MostRecentDisconnectReason={MostRecentDisconnectReason}")]
+    internal static partial void DiscordDisconnected(ILogger logger, string loginState, string connectionState, string? mostRecentDisconnectReason, Exception? exception = null);
+
+    [LoggerMessage(Level = LogLevel.Critical, Message = "An unhandled application exception occurred")]
+    internal static partial void UnhandledApplicationException(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Critical, Message = "An unhandled non-Exception error occurred: {Error}")]
+    internal static partial void UnhandledApplicationError(ILogger logger, object error);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "An unobserved task exception occurred")]
+    internal static partial void UnobservedTaskException(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Could not delete incomplete reaction-role message after setup failed")]
+    internal static partial void IncompleteReactionRoleCleanupFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Could not clean up the reaction-role setup messages")]
+    internal static partial void ReactionRoleCleanupFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Could not delete the source message for echo command {MessageId}")]
+    internal static partial void EchoSourceDeleteFailed(ILogger logger, ulong messageId, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "The meme API request failed")]
+    internal static partial void MemeApiFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "No usable puns were found in Resources/puns.csv")]
+    internal static partial void ModulePunFileEmpty(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Could not attach the invalid-question Gordon GIF")]
+    internal static partial void GordonAttachmentFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to download an image from {ImageUrl}")]
+    internal static partial void ImageDownloadFailed(ILogger logger, Uri imageUrl, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Reaction-role settings successfully created for message {MessageId}")]
+    internal static partial void ReactionRoleSettingsCreated(ILogger logger, string messageId);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Error inserting reaction-role settings into the database")]
+    internal static partial void ReactionRoleInsertFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Error retrieving recent reaction-role settings from the database")]
+    internal static partial void RecentReactionRoleReadFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Error retrieving reaction-role settings for message {MessageId}")]
+    internal static partial void ReactionRoleReadFailed(ILogger logger, ulong messageId, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Could not delete {MessageCount} setup message(s) using {DeleteMode}; continuing cleanup")]
+    internal static partial void MessageCleanupFailed(ILogger logger, int messageCount, string deleteMode, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Health check endpoint listening on {BindAddress}:{Port}{Path} with a {RateLimitSeconds}s per-client poll limit")]
+    internal static partial void HealthEndpointListening(ILogger logger, IPAddress bindAddress, int port, string path, int rateLimitSeconds);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Health check endpoint is listening without a bearer token on {BindAddress}:{Port}{Path}")]
+    internal static partial void HealthEndpointUnauthenticated(ILogger logger, IPAddress bindAddress, int port, string path);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Health check endpoint exceeded its {ShutdownTimeoutSeconds}s shutdown timeout; aborting remaining requests")]
+    internal static partial void HealthEndpointShutdownTimedOut(ILogger logger, double shutdownTimeoutSeconds);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Could not find a cached fortune response for edited message {MessageId}")]
+    internal static partial void FortuneResponseMissing(ILogger logger, ulong messageId);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Attempt {Attempt} to replace an edited fortune response failed")]
+    internal static partial void FortuneResponseReplaceAttemptFailed(ILogger logger, int attempt, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Could not replace the response to edited fortune message {MessageId}")]
+    internal static partial void FortuneResponseReplaceFailed(ILogger logger, ulong messageId, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to {Action} a reaction role for message {MessageId}")]
+    internal static partial void ReactionRoleActionFailed(ILogger logger, string action, ulong messageId, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Timed out draining {InFlightReactionHandlerCount} reaction-role handler(s); leaving the cache lock for process exit")]
+    internal static partial void ReactionRoleDrainTimedOut(ILogger logger, int inFlightReactionHandlerCount);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "A reaction-role handler failed while shutdown was draining in-flight work")]
+    internal static partial void ReactionRoleShutdownOperationFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Discord {Operation} operation failed after its startup wait ended")]
+    internal static partial void DiscordStartupLateFailure(ILogger logger, string operation, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Discord started, but the initial presence could not be set")]
+    internal static partial void DiscordPresenceFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Attempting Discord login. Attempt={Attempt}, MaximumAttempts={MaximumAttempts}")]
+    internal static partial void DiscordLoginAttempting(ILogger logger, int attempt, int maximumAttempts);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Discord login succeeded. Attempt={Attempt}, MaximumAttempts={MaximumAttempts}")]
+    internal static partial void DiscordLoginSucceeded(ILogger logger, int attempt, int maximumAttempts);
+
+    [LoggerMessage(Level = LogLevel.Critical, Message = "Discord rejected the configured bot token. Update BEANBOT_BOT_TOKEN and restart the process. Attempt={Attempt}, MaximumAttempts={MaximumAttempts}")]
+    internal static partial void DiscordTokenRejected(ILogger logger, int attempt, int maximumAttempts, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Critical, Message = "Discord login failed after all startup attempts. Attempt={Attempt}, MaximumAttempts={MaximumAttempts}")]
+    internal static partial void DiscordLoginExhausted(ILogger logger, int attempt, int maximumAttempts, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Discord login attempt failed; delaying before retry. Attempt={Attempt}, MaximumAttempts={MaximumAttempts}, RetryDelay={RetryDelay}")]
+    internal static partial void DiscordLoginRetrying(ILogger logger, int attempt, int maximumAttempts, TimeSpan retryDelay, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Critical, Message = "Discord startup failed with a non-retryable login error. Attempt={Attempt}, MaximumAttempts={MaximumAttempts}")]
+    internal static partial void DiscordLoginFailed(ILogger logger, int attempt, int maximumAttempts, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Attempting Discord outage recovery notification. DisconnectedAtUtc={DisconnectedAtUtc}, ProcessRestartRequested={ProcessRestartRequested}")]
+    internal static partial void OutageNotificationAttempting(ILogger logger, DateTimeOffset disconnectedAtUtc, bool processRestartRequested);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Discord outage recovery notification failed after {DeliveryAttempts} attempts; persisted outage retained. DisconnectedAtUtc={DisconnectedAtUtc}")]
+    internal static partial void OutageNotificationFailed(ILogger logger, int deliveryAttempts, DateTimeOffset disconnectedAtUtc);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Discord outage recovery notification delivered. DisconnectedAtUtc={DisconnectedAtUtc}")]
+    internal static partial void OutageNotificationDelivered(ILogger logger, DateTimeOffset disconnectedAtUtc);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Discord outage recovery notification delivery attempt failed. DeliveryAttempt={DeliveryAttempt}, MaximumDeliveryAttempts={MaximumDeliveryAttempts}")]
+    internal static partial void OutageNotificationDeliveryFailed(ILogger logger, int deliveryAttempt, int maximumDeliveryAttempts, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Discord outage manual recovery attempt persisted. DisconnectedAtUtc={DisconnectedAtUtc}")]
+    internal static partial void OutageManualRecoveryPersisted(ILogger logger, DateTimeOffset disconnectedAtUtc);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Discord outage process restart request persisted")]
+    internal static partial void OutageRestartPersisted(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Persisted Discord outage cleared")]
+    internal static partial void OutageCleared(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Persisted Discord outage loaded. DisconnectedAtUtc={DisconnectedAtUtc}, ManualRecoveryAttempted={ManualRecoveryAttempted}, ProcessRestartRequested={ProcessRestartRequested}")]
+    internal static partial void OutageLoaded(ILogger logger, DateTimeOffset disconnectedAtUtc, bool manualRecoveryAttempted, bool processRestartRequested);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Meaningful Discord outage persisted. DisconnectedAtUtc={DisconnectedAtUtc}, ManualRecoveryAttempted={ManualRecoveryAttempted}, ProcessRestartRequested={ProcessRestartRequested}")]
+    internal static partial void OutagePersisted(ILogger logger, DateTimeOffset disconnectedAtUtc, bool manualRecoveryAttempted, bool processRestartRequested);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Corrupted Discord outage state encountered and quarantined. QuarantinePath={QuarantinePath}")]
+    internal static partial void OutageQuarantined(ILogger logger, string quarantinePath, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Corrupted Discord outage state encountered but could not be quarantined. OutageFilePath={OutageFilePath}")]
+    internal static partial void OutageQuarantineFailed(ILogger logger, string outageFilePath, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Could not process Discord paginator reaction for message {MessageId}")]
+    internal static partial void PaginatorReactionFailed(ILogger logger, ulong messageId, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Could not remove expired paginator control from message {MessageId}")]
+    internal static partial void PaginatorControlRemoveFailed(ILogger logger, ulong messageId, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Discord paginator expiration failed for message {MessageId}")]
+    internal static partial void PaginatorExpirationFailed(ILogger logger, ulong messageId, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Could not remove paginator reaction from user {UserId}")]
+    internal static partial void PaginatorUserReactionRemoveFailed(ILogger logger, ulong userId, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Discord paginator shutdown exceeded {Timeout}; cleanup will finish in the background")]
+    internal static partial void PaginatorShutdownTimedOut(ILogger logger, TimeSpan timeout);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Discord paginator shutdown encountered a cleanup failure")]
+    internal static partial void PaginatorShutdownFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Deferred Discord paginator cleanup failed")]
+    internal static partial void PaginatorDeferredCleanupFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Discord gateway {Operation} operation failed after its recovery wait ended")]
+    internal static partial void DiscordRecoveryLateFailure(ILogger logger, string operation, Exception? exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Discord gateway recovery grace period started. LoginState={LoginState}, ConnectionState={ConnectionState}, GracePeriod={GracePeriod}, MostRecentDisconnectReason={MostRecentDisconnectReason}")]
+    internal static partial void DiscordRecoveryGraceStarted(ILogger logger, string loginState, string connectionState, TimeSpan gracePeriod, string? mostRecentDisconnectReason);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Discord gateway remained unhealthy for {UnhealthyDuration}; beginning one manual reconnect cycle. LoginState={LoginState}, ConnectionState={ConnectionState}, MostRecentDisconnectReason={MostRecentDisconnectReason}")]
+    internal static partial void DiscordManualRecoveryStarting(ILogger logger, TimeSpan unhealthyDuration, string loginState, string connectionState, string? mostRecentDisconnectReason);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Discord manual reconnect cycle failed. LoginState={LoginState}, ConnectionState={ConnectionState}, MostRecentDisconnectReason={MostRecentDisconnectReason}")]
+    internal static partial void DiscordManualRecoveryFailed(ILogger logger, string loginState, string connectionState, string? mostRecentDisconnectReason, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Discord manual reconnect succeeded after {UnhealthyDuration}. LoginState={LoginState}, ConnectionState={ConnectionState}")]
+    internal static partial void DiscordManualRecoverySucceeded(ILogger logger, TimeSpan unhealthyDuration, string loginState, string connectionState);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Discord manual reconnect failed to reach Ready after {UnhealthyDuration}. LoginState={LoginState}, ConnectionState={ConnectionState}, MostRecentDisconnectReason={MostRecentDisconnectReason}")]
+    internal static partial void DiscordManualRecoveryNotReady(ILogger logger, TimeSpan unhealthyDuration, string loginState, string connectionState, string? mostRecentDisconnectReason);
+
+    [LoggerMessage(Level = LogLevel.Critical, Message = "Discord gateway recovery was exhausted; exiting with code 1 so Docker can restart BeanBot")]
+    internal static partial void DiscordRecoveryExhausted(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Critical, Message = "Discord gateway recovery monitor failed unexpectedly")]
+    internal static partial void DiscordRecoveryMonitorFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Critical, Message = "Exiting with code 1 because the Discord gateway recovery monitor cannot continue safely")]
+    internal static partial void DiscordRecoveryMonitorExiting(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Could not persist the meaningful Discord outage before manual recovery. DisconnectedAtUtc={DisconnectedAtUtc}")]
+    internal static partial void DiscordOutagePersistBeforeRecoveryFailed(ILogger logger, DateTimeOffset disconnectedAtUtc, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Could not persist the Discord outage restart request before process exit")]
+    internal static partial void DiscordOutageRestartPersistFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Discord gateway recovered naturally after {UnhealthyDuration}; manual reconnect was not needed. LoginState={LoginState}, ConnectionState={ConnectionState}")]
+    internal static partial void DiscordNaturalRecovery(ILogger logger, TimeSpan unhealthyDuration, string loginState, string connectionState);
+
+    [LoggerMessage(Message = "{DiscordMessage}")]
+    internal static partial void DiscordMessage(ILogger logger, LogLevel level, string discordMessage, Exception? exception);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Discord log ({Severity}): {DiscordMessage}")]
+    internal static partial void DiscordMessageFallback(ILogger logger, LogSeverity severity, string discordMessage, Exception? exception);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Discord user {Username} ({UserId}) joined {Guild}")]
+    internal static partial void DiscordUserJoined(ILogger logger, string username, ulong userId, object guild);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Discord command {CommandName} was executed")]
+    internal static partial void DiscordCommandExecuted(ILogger logger, string commandName);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Discord command {CommandName} was rejected with {Error}: {Reason}")]
+    internal static partial void DiscordCommandRejected(ILogger logger, string commandName, object? error, string reason);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Discord command {CommandName} failed with {Error}: {Reason}")]
+    internal static partial void DiscordCommandFailed(ILogger logger, string commandName, object? error, string reason);
+}

--- a/BeanBot/Util/LogHandler.cs
+++ b/BeanBot/Util/LogHandler.cs
@@ -5,6 +5,7 @@ using Discord.WebSocket;
 using Microsoft.Extensions.Logging;
 
 using Serilog;
+using Serilog.Events;
 
 using System.Globalization;
 using System.IO;
@@ -36,6 +37,9 @@ namespace BeanBot.Util
 
             loggerConfiguration
                 .MinimumLevel.Verbose()
+                .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
+                .MinimumLevel.Override("Microsoft.Hosting.Lifetime", LogEventLevel.Information)
+                .MinimumLevel.Override("System", LogEventLevel.Warning)
                 .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
                 .WriteTo.Async(a => a.File(
                     Path.Combine(DirectorySetup.botBaseDirectory, "Logs", "BeanBotLogs.txt"),

--- a/BeanBot/Util/LogHandler.cs
+++ b/BeanBot/Util/LogHandler.cs
@@ -1,6 +1,9 @@
 ﻿using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
+
+using Microsoft.Extensions.Logging;
+
 using Serilog;
 
 using System.Globalization;
@@ -9,68 +12,97 @@ using System.Threading.Tasks;
 
 namespace BeanBot.Util
 {
-    public static class LogHandler
+    public sealed class LogHandler
     {
-        internal static void CreateLoggerConfiguration(IOwnerErrorNotifier ownerErrorNotifier)
+        private readonly ILogger<LogHandler> _logger;
+
+        public LogHandler(ILogger<LogHandler> logger)
         {
-            Log.Logger = new LoggerConfiguration()
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        internal static Serilog.ILogger CreateBootstrapLogger()
+            => new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
+                .CreateBootstrapLogger();
+
+        internal static void ConfigureLogger(
+            LoggerConfiguration loggerConfiguration,
+            IOwnerErrorNotifier ownerErrorNotifier)
+        {
+            ArgumentNullException.ThrowIfNull(loggerConfiguration);
+            ArgumentNullException.ThrowIfNull(ownerErrorNotifier);
+
+            loggerConfiguration
                 .MinimumLevel.Verbose()
                 .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
                 .WriteTo.Async(a => a.File(
                     Path.Combine(DirectorySetup.botBaseDirectory, "Logs", "BeanBotLogs.txt"),
                     formatProvider: CultureInfo.InvariantCulture,
                     rollingInterval: RollingInterval.Day))
-                .WriteTo.Sink(new DiscordOwnerErrorSink(ownerErrorNotifier))
-                .CreateLogger();
-            Log.Information("Logger Configuration complete");
+                .WriteTo.Sink(new DiscordOwnerErrorSink(ownerErrorNotifier));
         }
 
-        public static Task LogMessages(LogMessage messages)
+        public Task LogMessages(LogMessage messages)
         {
             var formattedMessage = string.IsNullOrWhiteSpace(messages.Source)
                 ? messages.Message ?? messages.ToString()
                 : $"Discord:\t{messages.Source}\t{messages.Message}";
 
-            switch (messages.Severity)
+            var severity = messages.Severity;
+            var logLevel = severity switch
             {
-                case LogSeverity.Critical:
-                    Log.Fatal(messages.Exception, "{DiscordMessage}", formattedMessage);
-                    break;
-                case LogSeverity.Error:
-                    Log.Error(messages.Exception, "{DiscordMessage}", formattedMessage);
-                    break;
-                case LogSeverity.Warning:
-                    Log.Warning(messages.Exception, "{DiscordMessage}", formattedMessage);
-                    break;
-                case LogSeverity.Info:
-                    Log.Information(messages.Exception, "{DiscordMessage}", formattedMessage);
-                    break;
-                case LogSeverity.Verbose:
-                    Log.Verbose(messages.Exception, "{DiscordMessage}", formattedMessage);
-                    break;
-                case LogSeverity.Debug:
-                    Log.Debug(messages.Exception, "{DiscordMessage}", formattedMessage);
-                    break;
-                default:
-                    Log.Information(messages.Exception, "Discord log ({Severity}): {DiscordMessage}", messages.Severity, formattedMessage);
-                    break;
+                LogSeverity.Critical => LogLevel.Critical,
+                LogSeverity.Error => LogLevel.Error,
+                LogSeverity.Warning => LogLevel.Warning,
+                LogSeverity.Info => LogLevel.Information,
+                LogSeverity.Verbose => LogLevel.Trace,
+                LogSeverity.Debug => LogLevel.Debug,
+                _ => LogLevel.None
+            };
+            if (logLevel == LogLevel.None)
+            {
+                if (_logger.IsEnabled(LogLevel.Information))
+                {
+                    BeanBotLog.DiscordMessageFallback(
+                        _logger,
+                        severity,
+                        formattedMessage,
+                        messages.Exception);
+                }
+            }
+            else
+            {
+                BeanBotLog.DiscordMessage(
+                    _logger,
+                    logLevel,
+                    formattedMessage,
+                    messages.Exception);
             }
 
             return Task.CompletedTask;
         }
 
-        public static Task LogNewMember(SocketGuildUser newUser)
+        public Task LogNewMember(SocketGuildUser newUser)
         {
-            Log.Information("Discord user {Username} ({UserId}) joined {Guild}", newUser.Username, newUser.Id, newUser.Guild);
+            BeanBotLog.DiscordUserJoined(
+                _logger,
+                newUser.Username,
+                newUser.Id,
+                newUser.Guild);
             return Task.CompletedTask;
         }
 
-        public static Task LogCommands(Optional<CommandInfo> command, ICommandContext context, IResult result)
+        public Task LogCommands(Optional<CommandInfo> command, ICommandContext context, IResult result)
         {
+            ArgumentNullException.ThrowIfNull(context);
+            ArgumentNullException.ThrowIfNull(result);
+
             var commandName = command.IsSpecified ? command.Value.Name : "Unspecified Command";
             if (result.IsSuccess)
             {
-                Log.Information("Discord command {CommandName} was executed", commandName);
+                BeanBotLog.DiscordCommandExecuted(_logger, commandName);
             }
             else
             {
@@ -82,21 +114,19 @@ namespace BeanBot.Util
                     result.Error == CommandError.UnmetPrecondition;
                 if (isExpectedUserError)
                 {
-                    Log.Warning(
-                        "Discord command {CommandName} was rejected with {Error}: {Reason}. Input: {Input}",
+                    BeanBotLog.DiscordCommandRejected(
+                        _logger,
                         commandName,
                         result.Error,
-                        result.ErrorReason,
-                        context.Message);
+                        result.ErrorReason);
                 }
                 else
                 {
-                    Log.Error(
-                        "Discord command {CommandName} failed with {Error}: {Reason}. Input: {Input}",
+                    BeanBotLog.DiscordCommandFailed(
+                        _logger,
                         commandName,
                         result.Error,
-                        result.ErrorReason,
-                        context.Message);
+                        result.ErrorReason);
                 }
             }
             return Task.CompletedTask;

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,12 +16,11 @@
     <PackageVersion Include="MongoDB.Driver" Version="2.30.0" />
     <PackageVersion Include="MongoDB.Driver.Core" Version="2.30.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="Serilog" Version="2.9.0" />
-    <PackageVersion Include="Serilog.Extensions.Logging" Version="3.1.0" />
-    <PackageVersion Include="Serilog.Settings.Configuration" Version="3.1.0" />
-    <PackageVersion Include="Serilog.Sinks.Async" Version="1.4.0" />
-    <PackageVersion Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageVersion Include="Serilog.Sinks.File" Version="4.0.0" />
+    <PackageVersion Include="Serilog" Version="4.3.0" />
+    <PackageVersion Include="Serilog.Extensions.Hosting" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
     <!-- Pin secure versions of vulnerable transitive MongoDB.Driver dependencies. -->
     <PackageVersion Include="SharpCompress" Version="0.50.0" />
     <PackageVersion Include="Snappier" Version="1.3.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,7 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Serilog" Version="4.3.0" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />


### PR DESCRIPTION
Closes #95

## Summary
- integrate Serilog with the Generic Host through Microsoft.Extensions.Logging
- inject category loggers into application services while preserving structured fields and severity
- preserve the bounded Discord owner-error sink and redact command message payloads
- modernize the coordinated Serilog package stack

## Verification
- Docker SDK restore, format, build, and 314 tests passed
- production Docker image build passed
- vulnerability scan passed
- workflow validation scripts passed
- exact ./scripts/verify.sh full is delegated to this draft PR because the host lacks the ASP.NET 10 targeting pack