### PR TITLE
Fix Mongo repository error semantics and cancellation

### DIFF
--- a/BeanBot.Tests/Repository/RoleReactRepositoryTests.cs
+++ b/BeanBot.Tests/Repository/RoleReactRepositoryTests.cs
@@ -1,0 +1,146 @@
+using BeanBot.Entities;
+using BeanBot.Repository;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Xunit;
+
+namespace BeanBot.Tests.Repository;
+
+public class RoleReactRepositoryTests
+{
+    [Fact]
+    public async Task GetRoleSetting_ReturnsMatchingSetting()
+    {
+        var expected = CreateRoleSettings("42");
+        var store = new FakeRoleSettingsStore
+        {
+            GetByMessageId = (messageId, _) =>
+            {
+                Assert.Equal("42", messageId);
+                return Task.FromResult<RoleSettings?>(expected);
+            }
+        };
+        var repository = CreateRepository(store);
+
+        var actual = await repository.GetRoleSetting(42UL);
+
+        Assert.Same(expected, actual);
+    }
+
+    [Fact]
+    public async Task GetRoleSetting_ReturnsNullWhenSettingDoesNotExist()
+    {
+        var repository = CreateRepository(new FakeRoleSettingsStore());
+
+        var actual = await repository.GetRoleSetting(42UL);
+
+        Assert.Null(actual);
+    }
+
+    [Fact]
+    public async Task GetRoleSetting_PropagatesInfrastructureFailure()
+    {
+        var expected = new InvalidOperationException("database unavailable");
+        var store = new FakeRoleSettingsStore
+        {
+            GetByMessageId = (_, _) => Task.FromException<RoleSettings?>(expected)
+        };
+        var repository = CreateRepository(store);
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => repository.GetRoleSetting(42UL));
+
+        Assert.Same(expected, actual);
+    }
+
+    [Fact]
+    public async Task GetRecentRoleSettings_PassesCancellationTokenToStore()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var store = new FakeRoleSettingsStore
+        {
+            GetRecent = async (_, cancellationToken) =>
+            {
+                Assert.Equal(cancellation.Token, cancellationToken);
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                return new List<RoleSettings>();
+            }
+        };
+        var repository = CreateRepository(store);
+        var read = repository.GetRecentRoleSettings(cancellation.Token);
+        cancellation.Cancel();
+
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => read);
+
+        Assert.Equal(cancellation.Token, exception.CancellationToken);
+    }
+
+    [Fact]
+    public async Task InsertNewRoleSettings_UpdatesLastAccessedAndPassesCancellationToken()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var settings = CreateRoleSettings("42");
+        var beforeInsert = DateTime.UtcNow;
+        var store = new FakeRoleSettingsStore
+        {
+            Insert = (actual, cancellationToken) =>
+            {
+                Assert.Same(settings, actual);
+                Assert.Equal(cancellation.Token, cancellationToken);
+                return Task.CompletedTask;
+            }
+        };
+        var repository = CreateRepository(store);
+
+        await repository.InsertNewRoleSettings(settings, cancellation.Token);
+
+        Assert.InRange(settings.lastAccessed, beforeInsert, DateTime.UtcNow);
+    }
+
+    [Fact]
+    public async Task InsertNewRoleSettings_PropagatesInfrastructureFailure()
+    {
+        var expected = new InvalidOperationException("database unavailable");
+        var store = new FakeRoleSettingsStore
+        {
+            Insert = (_, _) => Task.FromException(expected)
+        };
+        var repository = CreateRepository(store);
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => repository.InsertNewRoleSettings(CreateRoleSettings("42")));
+
+        Assert.Same(expected, actual);
+    }
+
+    private static RoleReactRepository CreateRepository(IRoleSettingsStore store)
+        => new(store, NullLogger<RoleReactRepository>.Instance);
+
+    private static RoleSettings CreateRoleSettings(string messageId)
+        => new(new List<RoleEmotePair>(), "1", "2", messageId);
+
+    private sealed class FakeRoleSettingsStore : IRoleSettingsStore
+    {
+        public Func<RoleSettings, CancellationToken, Task> Insert { get; set; }
+            = (_, _) => Task.CompletedTask;
+        public Func<DateTime, CancellationToken, Task<List<RoleSettings>>> GetRecent { get; set; }
+            = (_, _) => Task.FromResult(new List<RoleSettings>());
+        public Func<string, CancellationToken, Task<RoleSettings?>> GetByMessageId { get; set; }
+            = (_, _) => Task.FromResult<RoleSettings?>(null);
+
+        public Task InsertAsync(RoleSettings roleSettings, CancellationToken cancellationToken)
+            => Insert(roleSettings, cancellationToken);
+
+        public Task<List<RoleSettings>> GetRecentAsync(
+            DateTime oldestLastAccessed,
+            CancellationToken cancellationToken)
+            => GetRecent(oldestLastAccessed, cancellationToken);
+
+        public Task<RoleSettings?> GetByMessageIdAsync(
+            string messageId,
+            CancellationToken cancellationToken)
+            => GetByMessageId(messageId, cancellationToken);
+    }
+}

--- a/BeanBot.Tests/Services/RoleReactServiceTests.cs
+++ b/BeanBot.Tests/Services/RoleReactServiceTests.cs
@@ -1,7 +1,7 @@
+using BeanBot.Entities;
 using BeanBot.Repository;
 using BeanBot.Services;
 
-using MongoDB.Driver;
 using Microsoft.Extensions.Logging.Abstractions;
 
 using System.Reflection;
@@ -19,7 +19,7 @@ public class RoleReactServiceTests
         var cacheLock = GetCacheLock(service);
         var handlerCompletion = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
-        var handler = service.TrackHandlerAsync(() => handlerCompletion.Task);
+        var handler = service.TrackHandlerAsync(_ => handlerCompletion.Task);
 
         var firstDispose = service.DisposeAsync().AsTask();
         var secondDispose = service.DisposeAsync().AsTask();
@@ -42,7 +42,7 @@ public class RoleReactServiceTests
         var cacheLock = GetCacheLock(service);
         var handlerCompletion = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
-        var handler = service.TrackHandlerAsync(() => handlerCompletion.Task);
+        var handler = service.TrackHandlerAsync(_ => handlerCompletion.Task);
 
         await service.DisposeAsync();
 
@@ -52,16 +52,168 @@ public class RoleReactServiceTests
         await handler;
     }
 
-    private static RoleReactService CreateService(TimeSpan shutdownDrainTimeout)
+    [Fact]
+    public async Task GetCachedRoleSettingAsync_CachesSuccessfulFallbackLookup()
     {
-        var database = new MongoClient("mongodb://localhost:27017")
-            .GetDatabase("BeanBotNullableTests");
+        var expected = CreateRoleSettings("42");
+        var store = new FakeRoleSettingsStore
+        {
+            GetByMessageId = (messageId, _) =>
+            {
+                Assert.Equal("42", messageId);
+                return Task.FromResult<RoleSettings?>(expected);
+            }
+        };
+        await using var service = CreateService(TimeSpan.FromSeconds(1), store);
+
+        var first = await service.GetCachedRoleSettingAsync(42UL, CancellationToken.None);
+        var second = await service.GetCachedRoleSettingAsync(42UL, CancellationToken.None);
+
+        Assert.Same(expected, first);
+        Assert.Same(expected, second);
+        Assert.Equal(1, store.GetRecentCallCount);
+        Assert.Equal(1, store.GetByMessageIdCallCount);
+    }
+
+    [Fact]
+    public async Task GetCachedRoleSettingAsync_DoesNotCacheInfrastructureFailure()
+    {
+        var expected = CreateRoleSettings("42");
+        var failure = new InvalidOperationException("database unavailable");
+        var store = new FakeRoleSettingsStore();
+        store.GetByMessageId = (_, _) => store.GetByMessageIdCallCount == 1
+            ? Task.FromException<RoleSettings?>(failure)
+            : Task.FromResult<RoleSettings?>(expected);
+        await using var service = CreateService(TimeSpan.FromSeconds(1), store);
+
+        var actualFailure = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.GetCachedRoleSettingAsync(42UL, CancellationToken.None));
+        var recovered = await service.GetCachedRoleSettingAsync(42UL, CancellationToken.None);
+
+        Assert.Same(failure, actualFailure);
+        Assert.Same(expected, recovered);
+        Assert.Equal(2, store.GetByMessageIdCallCount);
+    }
+
+    [Fact]
+    public async Task GetCachedRoleSettingAsync_RetriesFailedInitialCacheLoad()
+    {
+        var expected = CreateRoleSettings("42");
+        var failure = new InvalidOperationException("database unavailable");
+        var store = new FakeRoleSettingsStore();
+        store.GetRecent = (_, _) => store.GetRecentCallCount == 1
+            ? Task.FromException<List<RoleSettings>>(failure)
+            : Task.FromResult(new List<RoleSettings> { expected });
+        await using var service = CreateService(TimeSpan.FromSeconds(1), store);
+
+        var actualFailure = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.GetCachedRoleSettingAsync(42UL, CancellationToken.None));
+        var recovered = await service.GetCachedRoleSettingAsync(42UL, CancellationToken.None);
+
+        Assert.Same(failure, actualFailure);
+        Assert.Same(expected, recovered);
+        Assert.Equal(2, store.GetRecentCallCount);
+        Assert.Equal(0, store.GetByMessageIdCallCount);
+    }
+
+    [Fact]
+    public async Task PersistRoleSettingsAsync_DoesNotCacheFailedInsert()
+    {
+        var settings = CreateRoleSettings("42");
+        var failure = new InvalidOperationException("database unavailable");
+        var store = new FakeRoleSettingsStore
+        {
+            Insert = (_, _) => Task.FromException(failure)
+        };
+        await using var service = CreateService(TimeSpan.FromSeconds(1), store);
+
+        var actualFailure = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.PersistRoleSettingsAsync(settings, CancellationToken.None));
+        var cached = await service.GetCachedRoleSettingAsync(42UL, CancellationToken.None);
+
+        Assert.Same(failure, actualFailure);
+        Assert.Null(cached);
+        Assert.Equal(1, store.GetByMessageIdCallCount);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_CancelsTrackedRepositoryWorkBeforeDrain()
+    {
+        var operationStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var store = new FakeRoleSettingsStore
+        {
+            GetRecent = async (_, cancellationToken) =>
+            {
+                operationStarted.SetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                return new List<RoleSettings>();
+            }
+        };
+        var service = CreateService(TimeSpan.FromSeconds(1), store);
+        var cacheLock = GetCacheLock(service);
+        var handler = service.TrackHandlerAsync(cancellationToken =>
+            service.GetCachedRoleSettingAsync(42UL, cancellationToken));
+        await operationStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        await service.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(1));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => handler);
+        Assert.Throws<ObjectDisposedException>(() => cacheLock.Wait(0));
+    }
+
+    [Fact]
+    public async Task TrackHandlerAsync_AfterShutdownDoesNotStartHandler()
+    {
+        var service = CreateService(TimeSpan.FromSeconds(1));
+        await service.DisposeAsync();
+        var started = false;
+
+        await service.TrackHandlerAsync(_ =>
+        {
+            started = true;
+            return Task.CompletedTask;
+        });
+
+        Assert.False(started);
+    }
+
+    [Fact]
+    public async Task TrackHandlerAsync_AfterApplicationStoppingDoesNotStartHandler()
+    {
+        using var applicationStopping = new CancellationTokenSource();
+        await using var service = CreateService(
+            TimeSpan.FromSeconds(1),
+            applicationStopping: applicationStopping.Token);
+        applicationStopping.Cancel();
+        var started = false;
+
+        await service.TrackHandlerAsync(_ =>
+        {
+            started = true;
+            return Task.CompletedTask;
+        });
+
+        Assert.False(started);
+    }
+
+    private static RoleReactService CreateService(
+        TimeSpan shutdownDrainTimeout,
+        FakeRoleSettingsStore? store = null,
+        CancellationToken applicationStopping = default)
+    {
         return new RoleReactService(
-            new RoleReactRepository(database, NullLogger<RoleReactRepository>.Instance),
+            new RoleReactRepository(
+                store ?? new FakeRoleSettingsStore(),
+                NullLogger<RoleReactRepository>.Instance),
             client: null,
             shutdownDrainTimeout,
-            NullLogger<RoleReactService>.Instance);
+            NullLogger<RoleReactService>.Instance,
+            applicationStopping);
     }
+
+    private static RoleSettings CreateRoleSettings(string messageId)
+        => new(new List<RoleEmotePair>(), "1", "2", messageId);
 
     private static SemaphoreSlim GetCacheLock(RoleReactService service)
     {
@@ -69,5 +221,37 @@ public class RoleReactServiceTests
             "_cacheLock",
             BindingFlags.Instance | BindingFlags.NonPublic);
         return Assert.IsType<SemaphoreSlim>(cacheLockField?.GetValue(service));
+    }
+
+    private sealed class FakeRoleSettingsStore : IRoleSettingsStore
+    {
+        public Func<RoleSettings, CancellationToken, Task> Insert { get; set; }
+            = (_, _) => Task.CompletedTask;
+        public Func<DateTime, CancellationToken, Task<List<RoleSettings>>> GetRecent { get; set; }
+            = (_, _) => Task.FromResult(new List<RoleSettings>());
+        public Func<string, CancellationToken, Task<RoleSettings?>> GetByMessageId { get; set; }
+            = (_, _) => Task.FromResult<RoleSettings?>(null);
+
+        public int GetRecentCallCount { get; private set; }
+        public int GetByMessageIdCallCount { get; private set; }
+
+        public Task InsertAsync(RoleSettings roleSettings, CancellationToken cancellationToken)
+            => Insert(roleSettings, cancellationToken);
+
+        public Task<List<RoleSettings>> GetRecentAsync(
+            DateTime oldestLastAccessed,
+            CancellationToken cancellationToken)
+        {
+            GetRecentCallCount++;
+            return GetRecent(oldestLastAccessed, cancellationToken);
+        }
+
+        public Task<RoleSettings?> GetByMessageIdAsync(
+            string messageId,
+            CancellationToken cancellationToken)
+        {
+            GetByMessageIdCallCount++;
+            return GetByMessageId(messageId, cancellationToken);
+        }
     }
 }

--- a/BeanBot.Tests/Util/LogHandlerTests.cs
+++ b/BeanBot.Tests/Util/LogHandlerTests.cs
@@ -78,7 +78,7 @@ public class LogHandlerTests
         var logger = loggerFactory.CreateLogger<LogHandlerTests>();
         var exception = new InvalidOperationException("failed");
 
-        BeanBotLog.ReactionRoleReadFailed(logger, 42UL, exception);
+        BeanBotLog.ReactionRoleActionFailed(logger, "add", 42UL, exception);
 
         var logEvent = Assert.Single(sink.Events);
         Assert.Equal(LogEventLevel.Error, logEvent.Level);
@@ -132,10 +132,10 @@ public class LogHandlerTests
         var logger = loggerFactory.CreateLogger<LogHandlerTests>();
 
         BeanBotLog.DiscordPresenceFailed(logger, new InvalidOperationException("handled"));
-        BeanBotLog.ReactionRoleReadFailed(logger, 42UL, new InvalidOperationException("failed"));
+        BeanBotLog.ReactionRoleActionFailed(logger, "add", 42UL, new InvalidOperationException("failed"));
 
         var alert = Assert.Single(notifier.Alerts);
-        Assert.Contains("Error retrieving reaction-role settings for message 42", alert);
+        Assert.Contains("Failed to \"add\" a reaction role for message 42", alert);
         Assert.DoesNotContain("Discord started", alert);
     }
 

--- a/BeanBot/Repository/RoleReactRepository.cs
+++ b/BeanBot/Repository/RoleReactRepository.cs
@@ -1,72 +1,107 @@
-﻿using BeanBot.Entities;
+using BeanBot.Entities;
 using BeanBot.Util;
-using Discord;
+
 using Microsoft.Extensions.Logging;
+
 using MongoDB.Driver;
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace BeanBot.Repository
 {
-    public class RoleReactRepository
+    internal interface IRoleSettingsStore
+    {
+        Task InsertAsync(RoleSettings roleSettings, CancellationToken cancellationToken);
+        Task<List<RoleSettings>> GetRecentAsync(DateTime oldestLastAccessed, CancellationToken cancellationToken);
+        Task<RoleSettings?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken);
+    }
+
+    internal sealed class MongoRoleSettingsStore : IRoleSettingsStore
     {
         private readonly IMongoCollection<RoleSettings> _roleSettings;
+
+        public MongoRoleSettingsStore(IMongoDatabase database)
+        {
+            _roleSettings = (database ?? throw new ArgumentNullException(nameof(database)))
+                .GetCollection<RoleSettings>("roleSettings");
+        }
+
+        public Task InsertAsync(RoleSettings roleSettings, CancellationToken cancellationToken)
+            => _roleSettings.InsertOneAsync(roleSettings, cancellationToken: cancellationToken);
+
+        public async Task<List<RoleSettings>> GetRecentAsync(
+            DateTime oldestLastAccessed,
+            CancellationToken cancellationToken)
+        {
+            var filter = Builders<RoleSettings>.Filter.Where(
+                result => result.lastAccessed >= oldestLastAccessed);
+            using var results = await _roleSettings.FindAsync(
+                filter,
+                cancellationToken: cancellationToken);
+            return await results.ToListAsync(cancellationToken);
+        }
+
+        public async Task<RoleSettings?> GetByMessageIdAsync(
+            string messageId,
+            CancellationToken cancellationToken)
+        {
+            var filter = Builders<RoleSettings>.Filter.Where(
+                document => document.messageId == messageId);
+            return await _roleSettings.Find(filter).FirstOrDefaultAsync(cancellationToken);
+        }
+    }
+
+    public sealed class RoleReactRepository
+    {
+        private readonly IRoleSettingsStore _roleSettingsStore;
         private readonly ILogger<RoleReactRepository> _logger;
 
         public RoleReactRepository(
             IMongoDatabase database,
             ILogger<RoleReactRepository> logger)
+            : this(new MongoRoleSettingsStore(database), logger)
         {
+        }
+
+        internal RoleReactRepository(
+            IRoleSettingsStore roleSettingsStore,
+            ILogger<RoleReactRepository> logger)
+        {
+            _roleSettingsStore = roleSettingsStore ?? throw new ArgumentNullException(nameof(roleSettingsStore));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _roleSettings = (database ?? throw new ArgumentNullException(nameof(database)))
-                .GetCollection<RoleSettings>("roleSettings");
         }
 
-        public async Task InsertNewRoleSettings(RoleSettings roleSettings)
+        public async Task InsertNewRoleSettings(
+            RoleSettings roleSettings,
+            CancellationToken cancellationToken = default)
         {
-            try
-            {
-                roleSettings.lastAccessed = DateTime.UtcNow;
-                await _roleSettings.InsertOneAsync(roleSettings);
-                BeanBotLog.ReactionRoleSettingsCreated(_logger, roleSettings.messageId);
-            }
-            catch (Exception e)
-            {
-                BeanBotLog.ReactionRoleInsertFailed(_logger, e);
-                throw;
-            }
+            cancellationToken.ThrowIfCancellationRequested();
+            roleSettings.lastAccessed = DateTime.UtcNow;
+            await _roleSettingsStore.InsertAsync(roleSettings, cancellationToken);
+            BeanBotLog.ReactionRoleSettingsCreated(_logger, roleSettings.messageId);
         }
 
-        public async Task<List<RoleSettings>> GetRecentRoleSettings()
+        public Task<List<RoleSettings>> GetRecentRoleSettings(
+            CancellationToken cancellationToken = default)
         {
-            try
-            {
-                var filterByLastAccessedDate = Builders<RoleSettings>.Filter.Where(result => result.lastAccessed >= DateTime.UtcNow.AddDays(-30));
-                var results = await _roleSettings.FindAsync<RoleSettings>(filterByLastAccessedDate);
-                return await results.ToListAsync();
-            }
-            catch (Exception e)
-            {
-                BeanBotLog.RecentReactionRoleReadFailed(_logger, e);
-                throw;
-            }
+            cancellationToken.ThrowIfCancellationRequested();
+            return _roleSettingsStore.GetRecentAsync(
+                DateTime.UtcNow.AddDays(-30),
+                cancellationToken);
         }
 
-        public async Task<RoleSettings?> GetRoleSetting(IUserMessage message)
+        public Task<RoleSettings?> GetRoleSetting(
+            ulong messageId,
+            CancellationToken cancellationToken = default)
         {
-            try
-            {
-                var messageId = message.Id.ToString(CultureInfo.InvariantCulture);
-                var filterByMessageId = Builders<RoleSettings>.Filter.Where(doc => doc.messageId == messageId);
-                return await _roleSettings.Find(filterByMessageId).FirstOrDefaultAsync();
-            }
-            catch (Exception e)
-            {
-                BeanBotLog.ReactionRoleReadFailed(_logger, message.Id, e);
-                return null;
-            }
+            cancellationToken.ThrowIfCancellationRequested();
+            return _roleSettingsStore.GetByMessageIdAsync(
+                messageId.ToString(CultureInfo.InvariantCulture),
+                cancellationToken);
         }
     }
 }

--- a/BeanBot/Services/RoleReactService.cs
+++ b/BeanBot/Services/RoleReactService.cs
@@ -3,6 +3,7 @@ using BeanBot.Repository;
 using BeanBot.Util;
 using Discord;
 using Discord.WebSocket;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
@@ -27,15 +28,24 @@ namespace BeanBot.Services
         private readonly TaskCompletionSource _disposeCompletion = new(
             TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly ILogger<RoleReactService> _logger;
+        private readonly CancellationTokenSource _shutdownCancellation;
+        private readonly CancellationToken _shutdownToken;
         private volatile bool _cacheLoaded;
         private bool _stopping;
         private int _disposeStarted;
 
         public RoleReactService(
             RoleReactRepository roleReactRepository,
+            IHostApplicationLifetime applicationLifetime,
             ILogger<RoleReactService> logger,
             DiscordSocketClient? client = null)
-            : this(roleReactRepository, client, DefaultShutdownDrainTimeout, logger)
+            : this(
+                roleReactRepository,
+                client,
+                DefaultShutdownDrainTimeout,
+                logger,
+                (applicationLifetime ?? throw new ArgumentNullException(nameof(applicationLifetime)))
+                    .ApplicationStopping)
         {
         }
 
@@ -43,41 +53,56 @@ namespace BeanBot.Services
             RoleReactRepository roleReactRepository,
             DiscordSocketClient? client,
             TimeSpan shutdownDrainTimeout,
-            ILogger<RoleReactService> logger)
+            ILogger<RoleReactService> logger,
+            CancellationToken applicationStopping)
         {
             ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(shutdownDrainTimeout, TimeSpan.Zero);
             _roleReactRepository = roleReactRepository ?? throw new ArgumentNullException(nameof(roleReactRepository));
             _client = client;
             _shutdownDrainTimeout = shutdownDrainTimeout;
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _shutdownCancellation = CancellationTokenSource.CreateLinkedTokenSource(applicationStopping);
+            _shutdownToken = _shutdownCancellation.Token;
         }
 
         public Task HandleReact(Cacheable<IUserMessage, ulong> message, Cacheable<IMessageChannel, ulong> channel, SocketReaction reaction)
-            => TrackHandlerAsync(() => HandleReactionAsync(message, channel, reaction, addRole: true));
+            => TrackHandlerAsync(cancellationToken =>
+                HandleReactionAsync(message, channel, reaction, addRole: true, cancellationToken));
 
         public Task HandleRemoveReact(Cacheable<IUserMessage, ulong> message, Cacheable<IMessageChannel, ulong> channel, SocketReaction reaction)
-            => TrackHandlerAsync(() => HandleReactionAsync(message, channel, reaction, addRole: false));
+            => TrackHandlerAsync(cancellationToken =>
+                HandleReactionAsync(message, channel, reaction, addRole: false, cancellationToken));
 
-        internal Task TrackHandlerAsync(Func<Task> beginOperation)
+        internal Task TrackHandlerAsync(Func<CancellationToken, Task> beginOperation)
+            => TrackOperationAsync(beginOperation, skipWhenStopping: true);
+
+        private Task TrackRequiredOperationAsync(Func<CancellationToken, Task> beginOperation)
+            => TrackOperationAsync(beginOperation, skipWhenStopping: false);
+
+        private Task TrackOperationAsync(
+            Func<CancellationToken, Task> beginOperation,
+            bool skipWhenStopping)
         {
             ArgumentNullException.ThrowIfNull(beginOperation);
 
             Task operation;
             lock (_operationSync)
             {
-                if (_stopping)
+                if (_stopping || _shutdownToken.IsCancellationRequested)
                 {
-                    return Task.CompletedTask;
+                    return skipWhenStopping
+                        ? Task.CompletedTask
+                        : Task.FromCanceled(_shutdownToken);
                 }
 
-                operation = beginOperation();
+                operation = beginOperation(_shutdownToken);
                 _inFlightOperations.Add(operation);
             }
 
-            return ObserveHandlerAsync(operation);
+            return ObserveOperationAsync(operation);
         }
 
-        private async Task ObserveHandlerAsync(Task operation)
+        private async Task ObserveOperationAsync(Task operation)
         {
             try
             {
@@ -96,7 +121,8 @@ namespace BeanBot.Services
             Cacheable<IUserMessage, ulong> message,
             Cacheable<IMessageChannel, ulong> channel,
             SocketReaction reaction,
-            bool addRole)
+            bool addRole,
+            CancellationToken cancellationToken)
         {
             try
             {
@@ -123,7 +149,7 @@ namespace BeanBot.Services
                     return;
                 }
 
-                var roleSetting = await GetCachedRoleSettingAsync(message.Id, cachedMessage);
+                var roleSetting = await GetCachedRoleSettingAsync(message.Id, cancellationToken);
                 var pair = roleSetting?.roleEmotePair?
                     .FirstOrDefault(candidate =>
                         candidate.emojiId == customEmote.Id.ToString(CultureInfo.InvariantCulture));
@@ -149,6 +175,10 @@ namespace BeanBot.Services
                     await user.RemoveRoleAsync(role);
                 }
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (Exception exception)
             {
                 BeanBotLog.ReactionRoleActionFailed(
@@ -159,16 +189,18 @@ namespace BeanBot.Services
             }
         }
 
-        private async Task<RoleSettings?> GetCachedRoleSettingAsync(ulong messageId, IUserMessage message)
+        internal async Task<RoleSettings?> GetCachedRoleSettingAsync(
+            ulong messageId,
+            CancellationToken cancellationToken)
         {
-            await EnsureCacheLoadedAsync();
+            await EnsureCacheLoadedAsync(cancellationToken);
             var messageIdText = messageId.ToString(CultureInfo.InvariantCulture);
             if (_roleSettings.TryGetValue(messageIdText, out var cached))
             {
                 return cached;
             }
 
-            var roleSetting = await _roleReactRepository.GetRoleSetting(message);
+            var roleSetting = await _roleReactRepository.GetRoleSetting(messageId, cancellationToken);
             if (roleSetting != null && !string.IsNullOrWhiteSpace(roleSetting.messageId))
             {
                 _roleSettings[roleSetting.messageId] = roleSetting;
@@ -177,14 +209,14 @@ namespace BeanBot.Services
             return roleSetting;
         }
 
-        private async Task EnsureCacheLoadedAsync()
+        private async Task EnsureCacheLoadedAsync(CancellationToken cancellationToken)
         {
             if (_cacheLoaded)
             {
                 return;
             }
 
-            await _cacheLock.WaitAsync();
+            await _cacheLock.WaitAsync(cancellationToken);
             try
             {
                 if (_cacheLoaded)
@@ -192,7 +224,7 @@ namespace BeanBot.Services
                     return;
                 }
 
-                foreach (var setting in await _roleReactRepository.GetRecentRoleSettings())
+                foreach (var setting in await _roleReactRepository.GetRecentRoleSettings(cancellationToken))
                 {
                     if (!string.IsNullOrWhiteSpace(setting.messageId))
                     {
@@ -207,7 +239,26 @@ namespace BeanBot.Services
             }
         }
 
-        public async Task SaveRoleSettings(List<RoleEmotePair> roleEmotePair, IMessage messageToListen)
+        public Task SaveRoleSettings(
+            List<RoleEmotePair> roleEmotePair,
+            IMessage messageToListen,
+            CancellationToken cancellationToken = default)
+            => TrackRequiredOperationAsync(async shutdownToken =>
+            {
+                using var operationCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                    shutdownToken,
+                    cancellationToken);
+                operationCancellation.Token.ThrowIfCancellationRequested();
+                await SaveRoleSettingsCoreAsync(
+                    roleEmotePair,
+                    messageToListen,
+                    operationCancellation.Token);
+            });
+
+        private async Task SaveRoleSettingsCoreAsync(
+            List<RoleEmotePair> roleEmotePair,
+            IMessage messageToListen,
+            CancellationToken cancellationToken)
         {
             if (messageToListen.Channel is not SocketTextChannel textChannel)
             {
@@ -219,7 +270,14 @@ namespace BeanBot.Services
                 textChannel.Guild.Id.ToString(CultureInfo.InvariantCulture),
                 messageToListen.Channel.Id.ToString(CultureInfo.InvariantCulture),
                 messageToListen.Id.ToString(CultureInfo.InvariantCulture));
-            await _roleReactRepository.InsertNewRoleSettings(settings);
+            await PersistRoleSettingsAsync(settings, cancellationToken);
+        }
+
+        internal async Task PersistRoleSettingsAsync(
+            RoleSettings settings,
+            CancellationToken cancellationToken)
+        {
+            await _roleReactRepository.InsertNewRoleSettings(settings, cancellationToken);
             _roleSettings[settings.messageId] = settings;
         }
 
@@ -239,6 +297,8 @@ namespace BeanBot.Services
 
             try
             {
+                _shutdownCancellation.Cancel();
+
                 Task[] inFlightOperations;
                 lock (_operationSync)
                 {
@@ -257,6 +317,9 @@ namespace BeanBot.Services
                         BeanBotLog.ReactionRoleDrainTimedOut(_logger, inFlightOperations.Length);
                         return;
                     }
+                    catch (OperationCanceledException) when (_shutdownToken.IsCancellationRequested)
+                    {
+                    }
                     catch (Exception exception)
                     {
                         BeanBotLog.ReactionRoleShutdownOperationFailed(_logger, exception);
@@ -264,6 +327,7 @@ namespace BeanBot.Services
                 }
 
                 _cacheLock.Dispose();
+                _shutdownCancellation.Dispose();
                 GC.SuppressFinalize(this);
             }
             finally

--- a/BeanBot/Util/BeanBotLog.cs
+++ b/BeanBot/Util/BeanBotLog.cs
@@ -116,15 +116,6 @@ internal static partial class BeanBotLog
     [LoggerMessage(Level = LogLevel.Information, Message = "Reaction-role settings successfully created for message {MessageId}")]
     internal static partial void ReactionRoleSettingsCreated(ILogger logger, string messageId);
 
-    [LoggerMessage(Level = LogLevel.Error, Message = "Error inserting reaction-role settings into the database")]
-    internal static partial void ReactionRoleInsertFailed(ILogger logger, Exception exception);
-
-    [LoggerMessage(Level = LogLevel.Error, Message = "Error retrieving recent reaction-role settings from the database")]
-    internal static partial void RecentReactionRoleReadFailed(ILogger logger, Exception exception);
-
-    [LoggerMessage(Level = LogLevel.Error, Message = "Error retrieving reaction-role settings for message {MessageId}")]
-    internal static partial void ReactionRoleReadFailed(ILogger logger, ulong messageId, Exception exception);
-
     [LoggerMessage(Level = LogLevel.Warning, Message = "Could not delete {MessageCount} setup message(s) using {DeleteMode}; continuing cleanup")]
     internal static partial void MessageCleanupFailed(ILogger logger, int messageCount, string deleteMode, Exception exception);
 
@@ -149,10 +140,10 @@ internal static partial class BeanBotLog
     [LoggerMessage(Level = LogLevel.Error, Message = "Failed to {Action} a reaction role for message {MessageId}")]
     internal static partial void ReactionRoleActionFailed(ILogger logger, string action, ulong messageId, Exception exception);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Timed out draining {InFlightReactionHandlerCount} reaction-role handler(s); leaving the cache lock for process exit")]
-    internal static partial void ReactionRoleDrainTimedOut(ILogger logger, int inFlightReactionHandlerCount);
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Timed out draining {InFlightReactionOperationCount} reaction-role operation(s); leaving the cache lock for process exit")]
+    internal static partial void ReactionRoleDrainTimedOut(ILogger logger, int inFlightReactionOperationCount);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "A reaction-role handler failed while shutdown was draining in-flight work")]
+    [LoggerMessage(Level = LogLevel.Warning, Message = "A reaction-role operation failed while shutdown was draining in-flight work")]
     internal static partial void ReactionRoleShutdownOperationFailed(ILogger logger, Exception exception);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Discord {Operation} operation failed after its startup wait ended")]


### PR DESCRIPTION
Closes #91

## Summary
- distinguish missing reaction-role settings from Mongo failures
- pass cancellation through repository calls and cancel in-flight repository work during host shutdown
- preserve cache consistency across failed reads and writes
- add focused repository, cache, and shutdown tests

## Verification
- containerized formatting/analyzers: passed
- Release build: passed
- full test suite: 331 passed
- transitive vulnerability scan: passed
- production Docker build: passed

Draft pending exact-head GitHub Actions verification and independent verifier/reviewer gates.