### PR TITLE
Modernize persistence models without changing MongoDB schema

### DIFF
--- a/BeanBot.Tests/Entities/RoleSettingsTests.cs
+++ b/BeanBot.Tests/Entities/RoleSettingsTests.cs
@@ -167,7 +167,6 @@ public class RoleSettingsTests
         var pair = pairs.EnumerateArray().Single();
         Assert.Equal("role", pair.GetProperty("roleId").GetString());
         Assert.Equal("emoji", pair.GetProperty("emojiId").GetString());
-        Assert.Contains(Environment.NewLine, json, StringComparison.Ordinal);
     }
 
     private static BsonDocument CreateLegacyDocument(ObjectId id, DateTime lastAccessedUtc)

--- a/BeanBot.Tests/Entities/RoleSettingsTests.cs
+++ b/BeanBot.Tests/Entities/RoleSettingsTests.cs
@@ -1,8 +1,9 @@
 using BeanBot.Entities;
 
 using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
 
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
 
 using Xunit;
 
@@ -11,37 +12,182 @@ namespace BeanBot.Tests.Entities;
 public class RoleSettingsTests
 {
     [Fact]
-    public void ParameterlessInstance_HasSafeCollectionAndStringDefaults()
+    public void ParameterlessInstances_HaveSafeCollectionAndStringDefaults()
     {
         var settings = new RoleSettings();
+        var pair = new RoleEmotePair();
 
-        Assert.Empty(settings.roleEmotePair);
-        Assert.Empty(settings.guildId);
-        Assert.Empty(settings.channelId);
-        Assert.Empty(settings.messageId);
+        Assert.Empty(settings.RoleEmotePairs);
+        Assert.Empty(settings.GuildId);
+        Assert.Empty(settings.ChannelId);
+        Assert.Empty(settings.MessageId);
+        Assert.Empty(pair.RoleId);
+        Assert.Empty(pair.EmojiId);
     }
 
     [Fact]
-    public void Serialization_PreservesExistingPersistedMemberNames()
+    public void Constructor_CopiesRoleEmotePairs()
+    {
+        var pairs = new List<RoleEmotePair> { new("role", "emoji") };
+        var settings = new RoleSettings(pairs, "guild", "channel", "message");
+
+        pairs.Clear();
+
+        var pair = Assert.Single(settings.RoleEmotePairs);
+        Assert.Equal("role", pair.RoleId);
+        Assert.Equal("emoji", pair.EmojiId);
+    }
+
+    [Fact]
+    public void Constructor_RejectsNullCollection()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => new RoleSettings(null!, "guild", "channel", "message"));
+    }
+
+    [Fact]
+    public void LegacyBson_DeserializesIntoModernProperties()
+    {
+        var id = ObjectId.GenerateNewId();
+        var lastAccessedUtc = new DateTime(2026, 8, 18, 12, 34, 56, DateTimeKind.Utc);
+        var legacyDocument = CreateLegacyDocument(id, lastAccessedUtc);
+
+        var settings = BsonSerializer.Deserialize<RoleSettings>(legacyDocument);
+
+        Assert.Equal(id, settings.Id);
+        Assert.Equal("guild", settings.GuildId);
+        Assert.Equal("channel", settings.ChannelId);
+        Assert.Equal("message", settings.MessageId);
+        Assert.Equal(lastAccessedUtc, settings.LastAccessedUtc);
+        Assert.Equal(DateTimeKind.Utc, settings.LastAccessedUtc.Kind);
+        var pair = Assert.Single(settings.RoleEmotePairs);
+        Assert.Equal("role", pair.RoleId);
+        Assert.Equal("emoji", pair.EmojiId);
+    }
+
+    [Fact]
+    public void LegacyBson_MissingMembersRetainSafeDefaults()
+    {
+        var settings = BsonSerializer.Deserialize<RoleSettings>(
+            new BsonDocument("_id", ObjectId.GenerateNewId()));
+
+        Assert.Empty(settings.RoleEmotePairs);
+        Assert.Empty(settings.GuildId);
+        Assert.Empty(settings.ChannelId);
+        Assert.Empty(settings.MessageId);
+    }
+
+    [Fact]
+    public void LegacyBson_ExplicitNullMembersNormalizeToSafeDefaults()
+    {
+        var settings = BsonSerializer.Deserialize<RoleSettings>(
+            new BsonDocument
+            {
+                { "_id", ObjectId.GenerateNewId() },
+                { "roleEmotePair", BsonNull.Value },
+                { "guildId", BsonNull.Value },
+                { "channelId", BsonNull.Value },
+                { "messageId", BsonNull.Value }
+            });
+
+        Assert.Empty(settings.RoleEmotePairs);
+        Assert.Empty(settings.GuildId);
+        Assert.Empty(settings.ChannelId);
+        Assert.Empty(settings.MessageId);
+    }
+
+    [Fact]
+    public void LegacyBson_ExplicitNullPairMembersNormalizeToSafeDefaults()
+    {
+        var pair = BsonSerializer.Deserialize<RoleEmotePair>(
+            new BsonDocument
+            {
+                { "roleId", BsonNull.Value },
+                { "emojiId", BsonNull.Value }
+            });
+
+        Assert.Empty(pair.RoleId);
+        Assert.Empty(pair.EmojiId);
+    }
+
+    [Fact]
+    public void BsonSerialization_PreservesExistingDocumentShapeAndTypes()
+    {
+        var id = ObjectId.GenerateNewId();
+        var lastAccessedUtc = new DateTime(2026, 8, 18, 12, 34, 56, DateTimeKind.Utc);
+        var settings = BsonSerializer.Deserialize<RoleSettings>(
+            CreateLegacyDocument(id, lastAccessedUtc));
+
+        var bson = settings.ToBsonDocument();
+
+        Assert.Equal(
+            ["_id", "roleEmotePair", "guildId", "channelId", "messageId", "lastAccessed"],
+            bson.Names);
+        Assert.Equal(BsonType.ObjectId, bson["_id"].BsonType);
+        Assert.Equal(BsonType.Array, bson["roleEmotePair"].BsonType);
+        Assert.Equal(BsonType.String, bson["guildId"].BsonType);
+        Assert.Equal(BsonType.String, bson["channelId"].BsonType);
+        Assert.Equal(BsonType.String, bson["messageId"].BsonType);
+        Assert.Equal(BsonType.DateTime, bson["lastAccessed"].BsonType);
+
+        var pair = bson["roleEmotePair"].AsBsonArray.Single().AsBsonDocument;
+        Assert.Equal(["roleId", "emojiId"], pair.Names);
+        Assert.Equal(BsonType.String, pair["roleId"].BsonType);
+        Assert.Equal(BsonType.String, pair["emojiId"].BsonType);
+        Assert.Equal(lastAccessedUtc, bson["lastAccessed"].ToUniversalTime());
+        Assert.DoesNotContain("RoleEmotePairs", bson.Names);
+        Assert.DoesNotContain("LastAccessedUtc", bson.Names);
+    }
+
+    [Fact]
+    public void ToString_PreservesExistingJsonMemberNames()
     {
         var settings = new RoleSettings(
             new List<RoleEmotePair> { new("role", "emoji") },
             "guild",
             "channel",
-            "message");
+            "message")
+        {
+            LastAccessedUtc = new DateTime(2026, 8, 18, 12, 34, 56, DateTimeKind.Utc)
+        };
 
-        var bson = settings.ToBsonDocument();
-        var json = JObject.Parse(settings.ToString());
+        var json = settings.ToString();
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
 
-        Assert.True(bson.Contains("_id"));
-        Assert.True(bson.Contains("roleEmotePair"));
-        Assert.True(bson.Contains("guildId"));
-        Assert.True(bson.Contains("channelId"));
-        Assert.True(bson.Contains("messageId"));
-        Assert.True(bson.Contains("lastAccessed"));
-        Assert.NotNull(json["roleEmotePair"]);
-        Assert.NotNull(json["guildId"]);
-        Assert.NotNull(json["channelId"]);
-        Assert.NotNull(json["messageId"]);
+        Assert.True(root.TryGetProperty("id", out _));
+        Assert.True(root.TryGetProperty("roleEmotePair", out var pairs));
+        Assert.True(root.TryGetProperty("guildId", out _));
+        Assert.True(root.TryGetProperty("channelId", out _));
+        Assert.True(root.TryGetProperty("messageId", out _));
+        Assert.True(root.TryGetProperty("lastAccessed", out _));
+        Assert.False(root.TryGetProperty("RoleEmotePairs", out _));
+        Assert.False(root.TryGetProperty("LastAccessedUtc", out _));
+
+        var pair = pairs.EnumerateArray().Single();
+        Assert.Equal("role", pair.GetProperty("roleId").GetString());
+        Assert.Equal("emoji", pair.GetProperty("emojiId").GetString());
+        Assert.Contains(Environment.NewLine, json, StringComparison.Ordinal);
     }
+
+    private static BsonDocument CreateLegacyDocument(ObjectId id, DateTime lastAccessedUtc)
+        => new()
+        {
+            { "_id", id },
+            {
+                "roleEmotePair",
+                new BsonArray
+                {
+                    new BsonDocument
+                    {
+                        { "roleId", "role" },
+                        { "emojiId", "emoji" }
+                    }
+                }
+            },
+            { "guildId", "guild" },
+            { "channelId", "channel" },
+            { "messageId", "message" },
+            { "lastAccessed", new BsonDateTime(lastAccessedUtc) }
+        };
 }

--- a/BeanBot.Tests/Repository/RoleReactRepositoryTests.cs
+++ b/BeanBot.Tests/Repository/RoleReactRepositoryTests.cs
@@ -78,6 +78,29 @@ public class RoleReactRepositoryTests
     }
 
     [Fact]
+    public async Task GetRecentRoleSettings_UsesThirtyDayUtcCutoff()
+    {
+        DateTime? observedCutoff = null;
+        var beforeRead = DateTime.UtcNow.AddDays(-30);
+        var store = new FakeRoleSettingsStore
+        {
+            GetRecent = (oldestLastAccessedUtc, _) =>
+            {
+                observedCutoff = oldestLastAccessedUtc;
+                return Task.FromResult(new List<RoleSettings>());
+            }
+        };
+        var repository = CreateRepository(store);
+
+        await repository.GetRecentRoleSettings();
+        var afterRead = DateTime.UtcNow.AddDays(-30);
+
+        var cutoff = Assert.IsType<DateTime>(observedCutoff);
+        Assert.Equal(DateTimeKind.Utc, cutoff.Kind);
+        Assert.InRange(cutoff, beforeRead, afterRead);
+    }
+
+    [Fact]
     public async Task InsertNewRoleSettings_UpdatesLastAccessedAndPassesCancellationToken()
     {
         using var cancellation = new CancellationTokenSource();
@@ -96,7 +119,8 @@ public class RoleReactRepositoryTests
 
         await repository.InsertNewRoleSettings(settings, cancellation.Token);
 
-        Assert.InRange(settings.lastAccessed, beforeInsert, DateTime.UtcNow);
+        Assert.Equal(DateTimeKind.Utc, settings.LastAccessedUtc.Kind);
+        Assert.InRange(settings.LastAccessedUtc, beforeInsert, DateTime.UtcNow);
     }
 
     [Fact]
@@ -134,9 +158,9 @@ public class RoleReactRepositoryTests
             => Insert(roleSettings, cancellationToken);
 
         public Task<List<RoleSettings>> GetRecentAsync(
-            DateTime oldestLastAccessed,
+            DateTime oldestLastAccessedUtc,
             CancellationToken cancellationToken)
-            => GetRecent(oldestLastAccessed, cancellationToken);
+            => GetRecent(oldestLastAccessedUtc, cancellationToken);
 
         public Task<RoleSettings?> GetByMessageIdAsync(
             string messageId,

--- a/BeanBot.Tests/Services/RoleReactServiceTests.cs
+++ b/BeanBot.Tests/Services/RoleReactServiceTests.cs
@@ -239,11 +239,11 @@ public class RoleReactServiceTests
             => Insert(roleSettings, cancellationToken);
 
         public Task<List<RoleSettings>> GetRecentAsync(
-            DateTime oldestLastAccessed,
+            DateTime oldestLastAccessedUtc,
             CancellationToken cancellationToken)
         {
             GetRecentCallCount++;
-            return GetRecent(oldestLastAccessed, cancellationToken);
+            return GetRecent(oldestLastAccessedUtc, cancellationToken);
         }
 
         public Task<RoleSettings?> GetByMessageIdAsync(

--- a/BeanBot/BeanBot.csproj
+++ b/BeanBot/BeanBot.csproj
@@ -31,7 +31,6 @@
     <PackageReference Include="MongoDB.Bson" />
     <PackageReference Include="MongoDB.Driver" />
     <PackageReference Include="MongoDB.Driver.Core" />
-    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.Extensions.Hosting" />
     <PackageReference Include="Serilog.Extensions.Logging" />

--- a/BeanBot/Entities/RoleEmotePair.cs
+++ b/BeanBot/Entities/RoleEmotePair.cs
@@ -1,18 +1,37 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using MongoDB.Bson.Serialization.Attributes;
+
+using System;
+using System.Text.Json.Serialization;
 
 namespace BeanBot.Entities
 {
     public class RoleEmotePair
     {
-        public string roleId { get; set; }
-        public string emojiId { get; set; }
+        private string _roleId = string.Empty;
+        private string _emojiId = string.Empty;
+
+        [BsonElement("roleId")]
+        [JsonPropertyName("roleId")]
+        public string RoleId
+        {
+            get => _roleId;
+            init => _roleId = value ?? string.Empty;
+        }
+
+        [BsonElement("emojiId")]
+        [JsonPropertyName("emojiId")]
+        public string EmojiId
+        {
+            get => _emojiId;
+            init => _emojiId = value ?? string.Empty;
+        }
+
+        public RoleEmotePair() { }
 
         public RoleEmotePair(string roleId, string emojiId)
         {
-            this.roleId = roleId;
-            this.emojiId = emojiId;
+            RoleId = roleId ?? throw new ArgumentNullException(nameof(roleId));
+            EmojiId = emojiId ?? throw new ArgumentNullException(nameof(emojiId));
         }
     }
 }

--- a/BeanBot/Entities/RoleSettings.cs
+++ b/BeanBot/Entities/RoleSettings.cs
@@ -1,36 +1,82 @@
 ﻿using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Reflection;
-using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace BeanBot.Entities
 {
     public class RoleSettings
     {
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            WriteIndented = true
+        };
+        private List<RoleEmotePair> _roleEmotePairs = new();
+        private string _guildId = string.Empty;
+        private string _channelId = string.Empty;
+        private string _messageId = string.Empty;
+
         [BsonId]
-        public ObjectId id { get; set; }
-        public List<RoleEmotePair> roleEmotePair { get; set; } = new();
-        public string guildId { get; set; } = string.Empty;
-        public string channelId { get; set; } = string.Empty;
-        public string messageId { get; set; } = string.Empty;
-        public DateTime lastAccessed { get; set; }
+        [JsonPropertyName("id")]
+        public ObjectId Id { get; init; }
+
+        [BsonElement("roleEmotePair")]
+        [JsonPropertyName("roleEmotePair")]
+        public List<RoleEmotePair> RoleEmotePairs
+        {
+            get => _roleEmotePairs;
+            init => _roleEmotePairs = value ?? new List<RoleEmotePair>();
+        }
+
+        [BsonElement("guildId")]
+        [JsonPropertyName("guildId")]
+        public string GuildId
+        {
+            get => _guildId;
+            init => _guildId = value ?? string.Empty;
+        }
+
+        [BsonElement("channelId")]
+        [JsonPropertyName("channelId")]
+        public string ChannelId
+        {
+            get => _channelId;
+            init => _channelId = value ?? string.Empty;
+        }
+
+        [BsonElement("messageId")]
+        [JsonPropertyName("messageId")]
+        public string MessageId
+        {
+            get => _messageId;
+            init => _messageId = value ?? string.Empty;
+        }
+
+        [BsonElement("lastAccessed")]
+        [BsonDateTimeOptions(Kind = DateTimeKind.Utc)]
+        [JsonPropertyName("lastAccessed")]
+        public DateTime LastAccessedUtc { get; internal set; }
 
         public RoleSettings() { }
 
-        public RoleSettings(List<RoleEmotePair> roleEmotePair, string guildId, string channelId, string messageId)
+        public RoleSettings(
+            List<RoleEmotePair> roleEmotePairs,
+            string guildId,
+            string channelId,
+            string messageId)
         {
-            this.roleEmotePair = roleEmotePair;
-            this.guildId = guildId;
-            this.channelId = channelId;
-            this.messageId = messageId;
+            RoleEmotePairs = new List<RoleEmotePair>(
+                roleEmotePairs ?? throw new ArgumentNullException(nameof(roleEmotePairs)));
+            GuildId = guildId ?? throw new ArgumentNullException(nameof(guildId));
+            ChannelId = channelId ?? throw new ArgumentNullException(nameof(channelId));
+            MessageId = messageId ?? throw new ArgumentNullException(nameof(messageId));
         }
 
         public override string ToString()
         {
-            return JsonConvert.SerializeObject(this, Formatting.Indented);
+            return JsonSerializer.Serialize(this, JsonOptions);
         }
     }
 }

--- a/BeanBot/Modules/AdministrativeModule.cs
+++ b/BeanBot/Modules/AdministrativeModule.cs
@@ -90,8 +90,8 @@ namespace BeanBot.Modules
                     }
 
                     if (roleEmotePairs.Any(pair =>
-                        pair.roleId == role.Id.ToString(CultureInfo.InvariantCulture)
-                        || pair.emojiId == emote.Id.ToString(CultureInfo.InvariantCulture)))
+                        pair.RoleId == role.Id.ToString(CultureInfo.InvariantCulture)
+                        || pair.EmojiId == emote.Id.ToString(CultureInfo.InvariantCulture)))
                     {
                         messagesInInteraction.Add(await ReplyAsync("That role or emote is already being configured. Please start again."));
                         return;
@@ -134,8 +134,8 @@ namespace BeanBot.Modules
             foreach (var pair in pairs)
             {
                 var emote = Context.Guild.Emotes.First(candidate =>
-                    candidate.Id.ToString(CultureInfo.InvariantCulture) == pair.emojiId);
-                roleEmbed.AddField(emote.ToString(), $"<@&{pair.roleId}>", inline: true);
+                    candidate.Id.ToString(CultureInfo.InvariantCulture) == pair.EmojiId);
+                roleEmbed.AddField(emote.ToString(), $"<@&{pair.RoleId}>", inline: true);
             }
 
             roleEmbed.WithFooter(footer => footer.Text = $"Role Group: {roleGroupLabel}");
@@ -148,7 +148,7 @@ namespace BeanBot.Modules
             foreach (var pair in pairs)
             {
                 var emote = Context.Guild.Emotes.First(candidate =>
-                    candidate.Id.ToString(CultureInfo.InvariantCulture) == pair.emojiId);
+                    candidate.Id.ToString(CultureInfo.InvariantCulture) == pair.EmojiId);
                 await messageToListen.AddReactionAsync(emote);
                 await Task.Delay(TimeSpan.FromMilliseconds(250));
             }

--- a/BeanBot/Repository/RoleReactRepository.cs
+++ b/BeanBot/Repository/RoleReactRepository.cs
@@ -16,7 +16,7 @@ namespace BeanBot.Repository
     internal interface IRoleSettingsStore
     {
         Task InsertAsync(RoleSettings roleSettings, CancellationToken cancellationToken);
-        Task<List<RoleSettings>> GetRecentAsync(DateTime oldestLastAccessed, CancellationToken cancellationToken);
+        Task<List<RoleSettings>> GetRecentAsync(DateTime oldestLastAccessedUtc, CancellationToken cancellationToken);
         Task<RoleSettings?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken);
     }
 
@@ -34,11 +34,11 @@ namespace BeanBot.Repository
             => _roleSettings.InsertOneAsync(roleSettings, cancellationToken: cancellationToken);
 
         public async Task<List<RoleSettings>> GetRecentAsync(
-            DateTime oldestLastAccessed,
+            DateTime oldestLastAccessedUtc,
             CancellationToken cancellationToken)
         {
             var filter = Builders<RoleSettings>.Filter.Where(
-                result => result.lastAccessed >= oldestLastAccessed);
+                result => result.LastAccessedUtc >= oldestLastAccessedUtc);
             using var results = await _roleSettings.FindAsync(
                 filter,
                 cancellationToken: cancellationToken);
@@ -50,7 +50,7 @@ namespace BeanBot.Repository
             CancellationToken cancellationToken)
         {
             var filter = Builders<RoleSettings>.Filter.Where(
-                document => document.messageId == messageId);
+                document => document.MessageId == messageId);
             return await _roleSettings.Find(filter).FirstOrDefaultAsync(cancellationToken);
         }
     }
@@ -80,9 +80,9 @@ namespace BeanBot.Repository
             CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            roleSettings.lastAccessed = DateTime.UtcNow;
+            roleSettings.LastAccessedUtc = DateTime.UtcNow;
             await _roleSettingsStore.InsertAsync(roleSettings, cancellationToken);
-            BeanBotLog.ReactionRoleSettingsCreated(_logger, roleSettings.messageId);
+            BeanBotLog.ReactionRoleSettingsCreated(_logger, roleSettings.MessageId);
         }
 
         public Task<List<RoleSettings>> GetRecentRoleSettings(

--- a/BeanBot/Services/RoleReactService.cs
+++ b/BeanBot/Services/RoleReactService.cs
@@ -150,10 +150,10 @@ namespace BeanBot.Services
                 }
 
                 var roleSetting = await GetCachedRoleSettingAsync(message.Id, cancellationToken);
-                var pair = roleSetting?.roleEmotePair?
+                var pair = roleSetting?.RoleEmotePairs?
                     .FirstOrDefault(candidate =>
-                        candidate.emojiId == customEmote.Id.ToString(CultureInfo.InvariantCulture));
-                if (pair == null || !ulong.TryParse(pair.roleId, out var roleId))
+                        candidate.EmojiId == customEmote.Id.ToString(CultureInfo.InvariantCulture));
+                if (pair == null || !ulong.TryParse(pair.RoleId, out var roleId))
                 {
                     return;
                 }
@@ -201,9 +201,9 @@ namespace BeanBot.Services
             }
 
             var roleSetting = await _roleReactRepository.GetRoleSetting(messageId, cancellationToken);
-            if (roleSetting != null && !string.IsNullOrWhiteSpace(roleSetting.messageId))
+            if (roleSetting != null && !string.IsNullOrWhiteSpace(roleSetting.MessageId))
             {
-                _roleSettings[roleSetting.messageId] = roleSetting;
+                _roleSettings[roleSetting.MessageId] = roleSetting;
             }
 
             return roleSetting;
@@ -226,9 +226,9 @@ namespace BeanBot.Services
 
                 foreach (var setting in await _roleReactRepository.GetRecentRoleSettings(cancellationToken))
                 {
-                    if (!string.IsNullOrWhiteSpace(setting.messageId))
+                    if (!string.IsNullOrWhiteSpace(setting.MessageId))
                     {
-                        _roleSettings[setting.messageId] = setting;
+                        _roleSettings[setting.MessageId] = setting;
                     }
                 }
                 _cacheLoaded = true;
@@ -278,7 +278,7 @@ namespace BeanBot.Services
             CancellationToken cancellationToken)
         {
             await _roleReactRepository.InsertNewRoleSettings(settings, cancellationToken);
-            _roleSettings[settings.messageId] = settings;
+            _roleSettings[settings.MessageId] = settings;
         }
 
         public void Dispose()

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,6 @@
     <PackageVersion Include="MongoDB.Bson" Version="2.30.0" />
     <PackageVersion Include="MongoDB.Driver" Version="2.30.0" />
     <PackageVersion Include="MongoDB.Driver.Core" Version="2.30.0" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Serilog" Version="4.3.0" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="10.0.0" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />


### PR DESCRIPTION
## Summary

- rename `RoleSettings` and `RoleEmotePair` members to idiomatic PascalCase properties
- preserve the existing MongoDB field names and BSON value types with explicit mappings
- make UTC semantics, collection defaults, and null normalization explicit
- replace the model's Newtonsoft.Json usage with System.Text.Json while retaining legacy diagnostic JSON names
- remove BeanBot's direct Newtonsoft.Json package declaration

## Why

The Mongo-backed models exposed lowercase mutable members whose naming and null/time semantics were unclear. Renaming those members without explicit serialization mappings would silently change the persisted schema, and property initializers alone would not protect against legacy BSON documents containing explicit null values.

## Impact

Existing `roleSettings` documents remain readable and newly written documents retain `_id`, `roleEmotePair`, `roleId`, `emojiId`, `guildId`, `channelId`, `messageId`, and `lastAccessed` with their established BSON types. Invalid explicit-null values normalize to safe defaults, and reaction-role persistence-before-cache behavior is unchanged. No data migration is required.

## Validation

- focused entity/repository/service/module tests: 36 passed
- `./scripts/verify.sh fast`: passed, 339 tests
- `./scripts/verify.sh full`: passed, including formatting/analyzers, Release build/tests, vulnerability scan, and .NET 10 Docker image
- independent verifier: PASS
- independent reviewer: CLEAN

Closes #92