### PR TITLE
Modernize low-risk NuGet dependencies

### DIFF
--- a/BeanBot/BeanBot.csproj
+++ b/BeanBot/BeanBot.csproj
@@ -25,12 +25,10 @@
     <PackageReference Include="Discord.Net.Commands" />
     <PackageReference Include="Discord.Net.Core" />
     <PackageReference Include="Discord.Net.Rest" />
-    <PackageReference Include="Discord.Net.Webhook" />
     <PackageReference Include="Discord.Net.WebSocket" />
     <PackageReference Include="LQ.MemeApiDotNetWrapper" />
     <PackageReference Include="MongoDB.Bson" />
     <PackageReference Include="MongoDB.Driver" />
-    <PackageReference Include="MongoDB.Driver.Core" />
     <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.Extensions.Hosting" />
     <PackageReference Include="Serilog.Extensions.Logging" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,23 +8,21 @@
     <PackageVersion Include="Discord.Net.Commands" Version="3.20.1" />
     <PackageVersion Include="Discord.Net.Core" Version="3.20.1" />
     <PackageVersion Include="Discord.Net.Rest" Version="3.20.1" />
-    <PackageVersion Include="Discord.Net.Webhook" Version="3.20.1" />
     <PackageVersion Include="Discord.Net.WebSocket" Version="3.20.1" />
     <PackageVersion Include="LQ.MemeApiDotNetWrapper" Version="1.5.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="MongoDB.Bson" Version="2.30.0" />
     <PackageVersion Include="MongoDB.Driver" Version="2.30.0" />
-    <PackageVersion Include="MongoDB.Driver.Core" Version="2.30.0" />
-    <PackageVersion Include="Serilog" Version="4.3.0" />
+    <PackageVersion Include="Serilog" Version="4.4.0" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="10.0.0" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
     <!-- Pin secure versions of vulnerable transitive MongoDB.Driver dependencies. -->
-    <PackageVersion Include="SharpCompress" Version="0.50.0" />
+    <PackageVersion Include="SharpCompress" Version="0.50.4" />
     <PackageVersion Include="Snappier" Version="1.3.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

- remove unused direct references to `Discord.Net.Webhook` and `MongoDB.Driver.Core`
- update Serilog from 4.3.0 to 4.4.0
- update the SharpCompress security pin from 0.50.0 to 0.50.4
- update xunit.runner.visualstudio from 3.1.4 to stable 3.1.5

This is the first focused dependency-modernization PR from #90. The breaking CsvHelper, test platform, and MongoDB driver migrations remain separate work.

## Dependency graph

- `MongoDB.Driver.Core` remains resolved transitively at 2.30.0 through `MongoDB.Driver`
- `Discord.Net.Webhook` is no longer present in the resolved graph
- Snappier remains pinned at 1.3.1
- no prerelease package was introduced

## Verification

- focused logging/health tests: 42 passed
- Release suite: 339 passed
- `./scripts/verify.sh fast`
- `./scripts/verify.sh full`
- no known vulnerable direct or transitive NuGet packages
- .NET 10 Docker image build passed
- independent verifier: PASS
- independent reviewer: CLEAN
- exact-head GitHub Actions run 148: passed
