### PR TITLE
Adopt develop-first agent branching policy

### DIFF
--- a/.agents/skills/beanbot-implement/SKILL.md
+++ b/.agents/skills/beanbot-implement/SKILL.md
@@ -6,13 +6,13 @@ description: Implement an approved BeanBot plan as the main-thread sole writer a
 # Implement an approved BeanBot plan
 
 1. Require the approved plan and acceptance criteria. Read applicable `AGENTS.md` and inspect repository reality before following the plan. Stop if they materially conflict.
-2. Confirm a clean dedicated branch from current `origin/master`. Implement the smallest complete change without unrelated refactoring.
+2. Select the correct base branch before writing code. For ordinary features, refactors, chores, and bug fixes, confirm a clean dedicated branch from current `origin/develop`. Use `origin/master` only for an explicitly justified production hotfix or release/promotion task. Never implement directly on `develop` or `master`.
 3. Add meaningful behavioral and failure-path tests. Preserve existing architecture, reliability rules, validation, authentication, and failure handling.
 4. Run the narrowest relevant checks first and repair failures. Then run `./scripts/verify.sh fast` and, before PR completion, `./scripts/verify.sh full` when its dependencies are available.
-5. Give a fresh Verifier the complete original goal, approved plan, acceptance criteria, base branch, and full diff. Correct every actionable finding and request fresh verification.
+5. Give a fresh Verifier the complete original goal, approved plan, acceptance criteria, base branch, intended PR target, and full diff. Correct every actionable finding and request fresh verification.
 6. Request a fresh independent Reviewer only after `Result: PASS`. Correct consequential review findings, rerun verification, and request review again.
-7. Prepare, commit, push, and open or update the PR only when required gates pass. If local infrastructure alone blocks a required gate, use a draft PR for exact-head CI evidence, then return that evidence to a fresh Verifier.
-8. Mark the PR ready only after Verifier PASS, Reviewer CLEAN, and required exact-head CI succeeds. Never merge or enable auto-merge without explicit instruction.
+7. Prepare, commit, push, and open or update the PR only when required gates pass. Ordinary work targets `develop`. Release promotion uses an intentional `develop` → `master` PR. An emergency hotfix may target `master`, but its completion criteria must include merging or backporting the same fix into `develop`. If local infrastructure alone blocks a required gate, use a draft PR for exact-head CI evidence, then return that evidence to a fresh Verifier.
+8. Mark the PR ready only after Verifier PASS, Reviewer CLEAN, and required exact-head CI succeeds. Never merge or enable auto-merge without explicit instruction. Do not create a GitHub Release merely because ordinary development was merged; follow the repository's intentional release trigger/versioning workflow.
 
 Keep the repair loop bounded: stop after two reasonable attempts at the same materially unchanged failure, or sooner for an environmental failure, unavailable Discord/GitHub/NuGet/Docker infrastructure, conflicting requirements, missing tools or permissions, repository/plan conflict, required test weakening, or unrelated redesign. Report the failing command, evidence, attempts, and safe next action.
 

--- a/.agents/skills/beanbot-plan/SKILL.md
+++ b/.agents/skills/beanbot-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: beanbot-plan
-description: Create an implementation-ready, read-only plan for a BeanBot change. Use when a BeanBot goal needs current behavior, affected files, reliability constraints, acceptance criteria, and a concrete test plan established before implementation.
+description: Create an implementation-ready, read-only plan for a BeanBot change. Use when a BeanBot goal needs current behavior, affected files, reliability constraints, acceptance criteria, branch strategy, and a concrete test plan established before implementation.
 ---
 
 # Plan a BeanBot change
@@ -8,15 +8,17 @@ description: Create an implementation-ready, read-only plan for a BeanBot change
 1. Read every applicable `AGENTS.md` before analyzing the request.
 2. Inspect the current code, tests, configuration, Docker behavior, CI, and documentation relevant to the goal. Treat the repository as authoritative.
 3. Confirm current behavior and distinguish evidence from assumptions. Identify affected files, compatibility risks, and any unresolved decision that would materially change the implementation.
-4. Produce a bounded, implementation-ready plan with these sections:
+4. Determine the branch strategy. Ordinary features, refactors, chores, and bug fixes should be based on `develop` and target `develop`. Use `master` only for an explicitly justified production hotfix or release/promotion task; hotfix plans must include merging or backporting the fix into `develop`.
+5. Produce a bounded, implementation-ready plan with these sections:
    - Confirmed current behavior
    - Requested behavior
    - Relevant files/components
+   - Branch strategy and intended PR target
    - Reliability/security constraints
    - Implementation plan
    - Test plan
    - Acceptance criteria
    - Risks/assumptions
-5. Stop after returning the plan. If a material decision remains unresolved, state it and request direction.
+6. Stop after returning the plan. If a material decision remains unresolved, state it and request direction.
 
 Do not edit files, commit, push, open a pull request, or begin implementation.

--- a/.agents/skills/beanbot-review/SKILL.md
+++ b/.agents/skills/beanbot-review/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: beanbot-review
-description: Independently review a fully verified BeanBot diff for consequential correctness, reliability, security, test, and deployment risks. Use only after a fresh Verifier has returned PASS and the reviewer must report findings or CLEAN without editing files.
+description: Independently review a fully verified BeanBot diff for consequential correctness, reliability, security, test, deployment, and branch-policy risks. Use only after a fresh Verifier has returned PASS and the reviewer must report findings or CLEAN without editing files.
 ---
 
 # Review a verified BeanBot change independently
 
-Require the original goal, approved plan, acceptance criteria, base branch, complete diff, and fresh Verifier PASS evidence.
+Require the original goal, approved plan, acceptance criteria, base branch, intended PR target, complete diff, and fresh Verifier PASS evidence.
 
-1. Read applicable `AGENTS.md`, especially `Code Review Rules`.
+1. Read applicable `AGENTS.md`, especially `Working Rules`, `Pull Request and Release Flow`, and `Code Review Rules`.
 2. Inspect the complete diff and relevant surrounding code. Do not trust summaries as evidence.
-3. Prioritize correctness, Discord lifecycle races, persistence semantics, health truthfulness, security, MongoDB/cache consistency, Docker compatibility, and meaningful test gaps. Avoid style-only comments unless they conceal a real defect.
-4. For each finding, provide severity, file/behavior, evidence, impact, and expected correction.
-5. List residual risks and intentionally manual checks. Return `Result: CLEAN` when no consequential finding remains.
-6. Do not edit files, repair findings, commit, push, or open a PR.
+3. Confirm the branch/PR target follows policy: ordinary work is based on and targets `develop`; `master` is reserved for intentional release promotion or an explicitly justified production hotfix. A hotfix targeting `master` must also include a merge/backport path into `develop`.
+4. Prioritize correctness, Discord lifecycle races, persistence semantics, health truthfulness, security, MongoDB/cache consistency, Docker compatibility, meaningful test gaps, and accidental release/workflow regressions. Avoid style-only comments unless they conceal a real defect.
+5. For each finding, provide severity, file/behavior, evidence, impact, and expected correction.
+6. List residual risks and intentionally manual checks. Return `Result: CLEAN` when no consequential finding remains.
+7. Do not edit files, repair findings, commit, push, open a PR, merge, or create a release.
 
 Review only after verification passes. A correction invalidates prior verification and review; require fresh verification before reviewing again.

--- a/.agents/skills/beanbot-verify/SKILL.md
+++ b/.agents/skills/beanbot-verify/SKILL.md
@@ -1,19 +1,20 @@
 ---
 name: beanbot-verify
-description: Independently verify a completed BeanBot diff against its approved plan and acceptance criteria. Use after implementation or corrections when a fresh verifier must inspect the diff, run all required gates, detect workspace mutations, and return PASS or FAIL without editing source files.
+description: Independently verify a completed BeanBot diff against its approved plan and acceptance criteria. Use after implementation or corrections when a fresh verifier must inspect the diff, run all required gates, validate branch/PR policy, detect workspace mutations, and return PASS or FAIL without editing source files.
 ---
 
 # Verify a BeanBot change independently
 
-Require the original goal, approved plan, acceptance criteria, base branch, and complete diff. Read applicable `AGENTS.md`; inspect the diff instead of trusting the Implementer's summary.
+Require the original goal, approved plan, acceptance criteria, base branch, intended PR target, and complete diff. Read applicable `AGENTS.md`; inspect the diff instead of trusting the Implementer's summary.
 
 1. Capture `git status --porcelain=v1 --untracked-files=all` before running commands. Record tracked and non-ignored files.
-2. Map every acceptance criterion to concrete evidence.
-3. Run relevant focused tests, then every applicable deterministic repository gate. Normally run `./scripts/verify.sh fast` and `./scripts/verify.sh full`; a required failed or skipped gate means FAIL.
-4. Confirm local commands match CI, and inspect Docker/configuration implications where applicable.
-5. Check the diff and workspace for secrets, generated junk, weakened tests, and unexpected files.
-6. Capture the same status baseline afterward and confirm it is unchanged. Ignored `bin`, `obj`, test-result, package, or Docker output is allowed.
-7. Do not edit or repair implementation files. Do not commit, push, or open a PR.
+2. Confirm the branch strategy follows repository policy. Ordinary features, refactors, chores, and bug fixes must be based on and target `develop`. `master` is acceptable only for an intentional release/promotion or explicitly justified production hotfix; hotfix acceptance criteria must include merging/backporting the same fix into `develop`.
+3. Map every acceptance criterion to concrete evidence.
+4. Run relevant focused tests, then every applicable deterministic repository gate. Normally run `./scripts/verify.sh fast` and `./scripts/verify.sh full`; a required failed or skipped gate means FAIL.
+5. Confirm local commands match CI, and inspect Docker/configuration and release-workflow implications where applicable. Flag any change that would cause routine development merges to create unintended GitHub Releases.
+6. Check the diff and workspace for secrets, generated junk, weakened tests, and unexpected files.
+7. Capture the same status baseline afterward and confirm it is unchanged. Ignored `bin`, `obj`, test-result, package, or Docker output is allowed.
+8. Do not edit or repair implementation files. Do not commit, push, open a PR, merge, or create a release.
 
 Return exactly this structure:
 
@@ -22,6 +23,9 @@ Result: PASS | FAIL
 
 Acceptance criteria:
 - criterion -> pass/fail with evidence
+
+Branch policy:
+- base branch / PR target -> pass/fail with evidence
 
 Commands run:
 - command -> result

--- a/.github/workflows/dotnetaction.yml
+++ b/.github/workflows/dotnetaction.yml
@@ -3,10 +3,12 @@ name: .NET Core Master and Deploy Checks
 on:
   push:
     branches:
+      - develop
       - master
       - deploy
   pull_request:
     branches:
+      - develop
       - master
       - deploy
   release:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,9 @@
 
 ## Working Rules
 
-- Perform coding work on a dedicated branch created from the latest `origin/master`; never implement directly on `master`.
+- For ordinary coding work, create a dedicated branch from the latest `origin/develop`; never implement directly on `develop` or `master`. Ordinary feature, refactor, chore, and bug-fix PRs target `develop`.
+- Treat `master` as the production/release branch. Promote tested changes from `develop` to `master` through an intentional release/promotion PR rather than using `master` as the day-to-day integration branch.
+- Critical production hotfixes may branch from the latest `origin/master` and target `master` when waiting for normal promotion is unsafe. After the hotfix lands, ensure the same fix is merged or backported into `develop` before ordinary development continues.
 - Inspect current behavior, tests, configuration, Docker, CI, and documentation before editing. Implement the smallest complete change and avoid unrelated refactors.
 - Keep code human-readable and human-reviewable. Prefer self-documenting method and variable names.
 - Do not weaken tests, assertions, validation, authentication, rate limiting, or failure handling to obtain green output.
@@ -29,6 +31,13 @@
 - The Implementer corrects Verifier or Reviewer findings, reruns focused checks, and requests fresh verification. Review begins only after verification passes.
 - Stop after two reasonable attempts at the same materially unchanged failure, or sooner for unavailable infrastructure, conflicting requirements, missing permissions/tools, architectural conflict, or a fix that would require weakened tests or unrelated redesign. Report the command, evidence, attempts, and safest next action.
 - Never commit ordinary transient plans, verification reports, or review results.
+
+## Pull Request and Release Flow
+
+- Ordinary work: `feature|fix|chore/...` → `develop`.
+- Release promotion: `develop` → `master` through an intentional PR after required verification.
+- Emergency hotfix: branch from `master` → `master`, then merge/backport the fix into `develop`.
+- Do not create a GitHub Release merely because routine development was merged. Release creation should be tied to the repository's intentional release trigger/versioning workflow.
 
 ## Code Review Rules
 

--- a/docs/codex-development-loop.md
+++ b/docs/codex-development-loop.md
@@ -6,11 +6,17 @@ BeanBot uses repository-scoped Codex skills and custom agents to separate planni
 
 1. Invoke `$beanbot-plan` or the `beanbot_planner` custom agent with the user goal. It inspects the repository read-only and returns current behavior, a bounded plan, tests, acceptance criteria, and risks.
 2. After the user approves the plan, invoke `$beanbot-implement` in the main thread. The main thread is the sole writer and implements the smallest complete change.
-3. Hand the original goal, approved plan, acceptance criteria, base branch, and complete diff to a fresh `beanbot_verifier`. It may create ignored build output but must not edit source files. `Result: FAIL` returns findings to the main thread.
+3. Hand the original goal, approved plan, acceptance criteria, base branch, intended PR target, and complete diff to a fresh `beanbot_verifier`. It may create ignored build output but must not edit source files. `Result: FAIL` returns findings to the main thread.
 4. After `Result: PASS`, hand the same context, diff, and verifier evidence to a fresh `beanbot_reviewer`. Findings return to the main thread; every correction requires fresh verification before review runs again. `Result: CLEAN` completes independent review.
-5. Required exact-head GitHub CI must pass before the PR is marked ready. A human decides whether to merge; the workflow never merges or enables auto-merge.
+5. Required exact-head GitHub CI for the intended PR target must pass before the PR is marked ready. A human decides whether to merge; the workflow never merges or enables auto-merge.
 
 Plans, handoffs, verification evidence, and review results are transient conversation artifacts. Do not commit routine `PLAN.md`, `VERIFICATION.md`, or review-result files.
+
+## Branch and pull request model
+
+Ordinary feature, fix, refactor, and chore branches start from the current `origin/develop` and target `develop`. Tested changes reach the production/release branch through an intentional `develop` to `master` promotion PR; `master` is not the day-to-day integration branch. An emergency production hotfix may start from and target `master`, but the same fix must then be merged or backported into `develop` before ordinary development continues.
+
+Repository verification CI runs for pull requests targeting `develop`, `master`, or `deploy`, and for pushes to those branches. The separate automated release workflow remains limited to pushes to `master`, so ordinary `develop` activity does not create a GitHub Release. See `AGENTS.md` for the authoritative shared branch and release policy.
 
 ## Verification interfaces
 
@@ -24,7 +30,7 @@ Run commands from any directory; each script resolves the repository root itself
 
 `fast` is the normal implementation loop. It tests the verifier's orchestration and failure propagation, validates Codex/CI configuration, restores the solution, verifies `.editorconfig` formatting and warning-level analyzers without another restore, builds Release, runs Release tests without a second build, and checks committed, staged, and unstaged diffs for whitespace errors.
 
-`full` runs every fast gate once, then requests a machine-readable report for direct and transitive NuGet dependencies across the complete solution, fails explicitly if that report contains a known vulnerability, and builds the Docker image. The internal `build-test` mode gives the master-only release workflow the same orchestration self-test, validation, restore, Release build, Release test, and diff gates without duplicating full-only Docker and vulnerability work.
+`full` runs every fast gate once, then requests a machine-readable report for direct and transitive NuGet dependencies across the complete solution, fails explicitly if that report contains a known vulnerability, and builds the Docker image. The internal `build-test` mode gives the release workflow, which currently runs only for pushes to `master`, the same orchestration self-test, validation, restore, Release build, Release test, and diff gates without duplicating full-only Docker and vulnerability work.
 
 The script keeps the .NET CLI home and NuGet package cache in the repository's ignored `.dotnet-home` and `.dotnet` directories unless the caller explicitly supplies `DOTNET_CLI_HOME` or `NUGET_PACKAGES`.
 
@@ -46,4 +52,4 @@ If only local infrastructure is unavailable, open a draft PR to obtain exact-hea
 
 ## Automation boundaries
 
-Skills and custom-agent files guide active Codex sessions; they do not create a persistent autonomous daemon. Repository rules can guide Codex review, but cannot enable an external GitHub review setting. GitHub Actions performs shared verification and the existing master-only release action. PR creation/readiness and deployment checks are user- or agent-triggered, merging remains human-controlled, and no automatic merge is configured.
+Skills and custom-agent files guide active Codex sessions; they do not create a persistent autonomous daemon. Repository rules can guide Codex review, but cannot enable an external GitHub review setting. GitHub Actions performs shared verification for `develop`, `master`, and `deploy`; a separate release action remains limited to `master`. PR creation/readiness and deployment checks are user- or agent-triggered, merging remains human-controlled, and no automatic merge is configured.


### PR DESCRIPTION
## Summary

Implements the repository-guidance portion of #110.

- makes `develop` the normal integration base and PR target
- reserves `master` for intentional release promotion and emergency production hotfixes
- requires hotfixes to be merged/backported into `develop`
- updates all BeanBot agent skills to plan, implement, verify, and review against the new branch model
- tells agents not to create releases as a side effect of ordinary development merges

## Branch setup

The existing `develop` branch was 145 commits behind `master`. It was safely fast-forwarded to the current `master` before this branch was created.

## Files changed

- `AGENTS.md`
- `.agents/skills/beanbot-plan/SKILL.md`
- `.agents/skills/beanbot-implement/SKILL.md`
- `.agents/skills/beanbot-verify/SKILL.md`
- `.agents/skills/beanbot-review/SKILL.md`

## Verification

Documentation/agent-policy-only change; no application runtime code changed.

## Follow-up

Issue #110 remains open for the release-workflow change itself, especially replacing the current release-on-every-`master`-push behavior with an intentional tag/manual release trigger.