### PR TITLE
Strengthen application boundary integration tests

### DIFF
--- a/BeanBot.Tests/BeanBot.Tests.csproj
+++ b/BeanBot.Tests/BeanBot.Tests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Testcontainers.MongoDb" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/BeanBot.Tests/Integration/BeanBotHostIntegrationTests.cs
+++ b/BeanBot.Tests/Integration/BeanBotHostIntegrationTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
 using System.Net;
+using System.Net.Sockets;
 
 using Xunit;
 
@@ -47,7 +48,8 @@ public class BeanBotHostIntegrationTests
         await using var testHost = CreateHost(runtime, CreateValidConfiguration());
 
         await testHost.Host.StartAsync().WaitAsync(TimeSpan.FromSeconds(5));
-        using var client = CreateHealthClient(runtime.HealthPort);
+        var healthPort = runtime.HealthPort;
+        using var client = CreateHealthClient(healthPort);
 
         using var unhealthyResponse = await client.GetAsync("/healthz");
         runtime.SetHealthSnapshot(HealthySnapshot);
@@ -55,6 +57,7 @@ public class BeanBotHostIntegrationTests
         using var healthyResponse = await client.GetAsync("/healthz");
 
         await testHost.Host.StopAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        await AssertListenerStoppedAsync(healthPort);
 
         Assert.Equal(HttpStatusCode.ServiceUnavailable, unhealthyResponse.StatusCode);
         Assert.Equal(HttpStatusCode.OK, healthyResponse.StatusCode);
@@ -190,6 +193,15 @@ public class BeanBotHostIntegrationTests
         {
             BaseAddress = new Uri($"http://127.0.0.1:{port}")
         };
+
+    private static async Task AssertListenerStoppedAsync(int port)
+    {
+        using var client = new TcpClient();
+        await Assert.ThrowsAsync<SocketException>(
+            () => client
+                .ConnectAsync(IPAddress.Loopback, port)
+                .WaitAsync(TimeSpan.FromSeconds(2)));
+    }
 
     private static DiscordStartupService CreateStartupService(
         IDiscordStartupLifecycle lifecycle,

--- a/BeanBot.Tests/Integration/BeanBotHostIntegrationTests.cs
+++ b/BeanBot.Tests/Integration/BeanBotHostIntegrationTests.cs
@@ -21,6 +21,8 @@ namespace BeanBot.Tests.Integration;
 
 public class BeanBotHostIntegrationTests
 {
+    private static readonly TimeSpan HealthPollInterval = TimeSpan.FromMilliseconds(1);
+
     private static readonly DiscordHealthSnapshot UnhealthySnapshot = new(
         false,
         "Discord gateway has not reached the Ready state yet.",
@@ -53,7 +55,7 @@ public class BeanBotHostIntegrationTests
 
         using var unhealthyResponse = await client.GetAsync("/healthz");
         runtime.SetHealthSnapshot(HealthySnapshot);
-        await Task.Delay(TimeSpan.FromMilliseconds(20));
+        await Task.Delay(HealthPollInterval + TimeSpan.FromMilliseconds(1));
         using var healthyResponse = await client.GetAsync("/healthz");
 
         await testHost.Host.StopAsync().WaitAsync(TimeSpan.FromSeconds(5));
@@ -266,7 +268,7 @@ public class BeanBotHostIntegrationTests
                     IPAddress.Loopback,
                     0,
                     null,
-                    TimeSpan.FromMilliseconds(1))
+                    HealthPollInterval)
                 : HealthCheckOptions.Disabled;
             _healthServer = new HealthCheckServer(
                 options,

--- a/BeanBot.Tests/Integration/BeanBotHostIntegrationTests.cs
+++ b/BeanBot.Tests/Integration/BeanBotHostIntegrationTests.cs
@@ -1,0 +1,386 @@
+using BeanBot.Configuration;
+using BeanBot.Hosting;
+using BeanBot.Services;
+
+using Discord.WebSocket;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using System.Net;
+
+using Xunit;
+
+namespace BeanBot.Tests.Integration;
+
+public class BeanBotHostIntegrationTests
+{
+    private static readonly DiscordHealthSnapshot UnhealthySnapshot = new(
+        false,
+        "Discord gateway has not reached the Ready state yet.",
+        "LoggedOut",
+        "Disconnected",
+        null,
+        null,
+        null,
+        null);
+
+    private static readonly DiscordHealthSnapshot HealthySnapshot = new(
+        true,
+        "BeanBot is connected to Discord.",
+        "LoggedIn",
+        "Connected",
+        new DateTimeOffset(2026, 8, 19, 12, 0, 0, TimeSpan.Zero),
+        null,
+        null,
+        null);
+
+    [Fact]
+    public async Task ValidConfiguration_StartsHealthTransitionsAndShutsDownInOrder()
+    {
+        var runtime = new RecordingRuntime(healthEnabled: true);
+        await using var testHost = CreateHost(runtime, CreateValidConfiguration());
+
+        await testHost.Host.StartAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        using var client = CreateHealthClient(runtime.HealthPort);
+
+        using var unhealthyResponse = await client.GetAsync("/healthz");
+        runtime.SetHealthSnapshot(HealthySnapshot);
+        await Task.Delay(TimeSpan.FromMilliseconds(20));
+        using var healthyResponse = await client.GetAsync("/healthz");
+
+        await testHost.Host.StopAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, unhealthyResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, healthyResponse.StatusCode);
+        Assert.Equal(0, runtime.HealthPort);
+        Assert.Equal(
+            new[]
+            {
+                "subscribe-events",
+                "start-health",
+                "start-discord",
+                "start-recovery",
+                "start-commands",
+                "start-event-background",
+                "stop-event-command",
+                "stop-recovery",
+                "unsubscribe-events",
+                "stop-background",
+                "flush-alerts",
+                "stop-discord",
+                "dispose-discord",
+                "flush-alerts"
+            },
+            runtime.Calls);
+    }
+
+    [Fact]
+    public async Task InvalidConfiguration_FailsBeforeRuntimeStartupWithoutExposingValues()
+    {
+        const string testToken = "integration-token-must-not-appear";
+        const string malformedChannelId = "invalid-channel-must-not-appear";
+        var configuration = CreateValidConfiguration();
+        configuration[BeanBotConfiguration.BotTokenVariable] = testToken;
+        configuration[BeanBotConfiguration.GeneralChannelVariable] = malformedChannelId;
+        var runtime = new RecordingRuntime(healthEnabled: false);
+        await using var testHost = CreateHost(runtime, configuration);
+
+        var exception = await Assert.ThrowsAsync<OptionsValidationException>(
+            () => testHost.Host.StartAsync());
+
+        Assert.Contains(BeanBotConfiguration.GeneralChannelVariable, exception.Message);
+        Assert.DoesNotContain(testToken, exception.Message);
+        Assert.DoesNotContain(malformedChannelId, exception.Message);
+        Assert.Empty(runtime.Calls);
+    }
+
+    [Fact]
+    public async Task DiscordRetryExhaustion_FailsHostStartupAndCleansUpOnce()
+    {
+        var finalFailure = CreateHttpException(HttpStatusCode.BadGateway);
+        var lifecycle = new QueueStartupLifecycle(
+            CreateHttpException(HttpStatusCode.ServiceUnavailable),
+            CreateHttpException(HttpStatusCode.TooManyRequests),
+            finalFailure);
+        var delay = new RecordingDelay();
+        var startupService = CreateStartupService(lifecycle, delay);
+        var runtime = new RecordingRuntime(healthEnabled: false)
+        {
+            StartDiscord = startupService.StartAsync
+        };
+        await using var testHost = CreateHost(runtime, CreateValidConfiguration());
+
+        var exception = await Assert.ThrowsAsync<Discord.Net.HttpException>(
+            () => testHost.Host.StartAsync());
+
+        Assert.Same(finalFailure, exception);
+        Assert.Equal(3, lifecycle.LoginCount);
+        Assert.Equal(0, lifecycle.StartCount);
+        Assert.Equal(
+            new[] { TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(15) },
+            delay.RequestedDelays);
+        Assert.Equal(1, runtime.Calls.Count(call => call == "unsubscribe-events"));
+        Assert.Equal(1, runtime.Calls.Count(call => call == "stop-background"));
+        Assert.Equal(1, runtime.Calls.Count(call => call == "dispose-discord"));
+    }
+
+    [Fact]
+    public async Task StopApplicationDuringDiscordRetry_CancelsStartupAndCleansUpOnce()
+    {
+        var lifecycle = new QueueStartupLifecycle(
+            CreateHttpException(HttpStatusCode.ServiceUnavailable));
+        var delay = new BlockingDelay();
+        var startupService = CreateStartupService(lifecycle, delay);
+        var runtime = new RecordingRuntime(healthEnabled: false)
+        {
+            StartDiscord = startupService.StartAsync
+        };
+        await using var testHost = CreateHost(runtime, CreateValidConfiguration());
+
+        var startup = testHost.Host.StartAsync();
+        await delay.Requested.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        testHost.Host.Services.GetRequiredService<IHostApplicationLifetime>().StopApplication();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => startup.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.Equal(1, lifecycle.LoginCount);
+        Assert.Equal(0, lifecycle.StartCount);
+        Assert.Equal(1, runtime.Calls.Count(call => call == "unsubscribe-events"));
+        Assert.Equal(1, runtime.Calls.Count(call => call == "stop-background"));
+        Assert.Equal(1, runtime.Calls.Count(call => call == "dispose-discord"));
+    }
+
+    private static TestHostScope CreateHost(
+        RecordingRuntime runtime,
+        IReadOnlyDictionary<string, string?> configurationValues)
+    {
+        var builder = Host.CreateApplicationBuilder();
+        builder.Logging.ClearProviders();
+        builder.Configuration.Sources.Clear();
+        builder.Configuration.AddInMemoryCollection(configurationValues);
+        builder.Configuration.AddBeanBotConfiguration(Array.Empty<string>());
+        builder.Services.AddBeanBot(builder.Configuration);
+        builder.Services.Replace(ServiceDescriptor.Singleton<IBeanBotRuntime>(runtime));
+
+        var host = builder.Build();
+        return new TestHostScope(
+            host,
+            host.Services.GetRequiredService<DiscordSocketClient>(),
+            runtime);
+    }
+
+    private static Dictionary<string, string?> CreateValidConfiguration()
+        => new()
+        {
+            [BeanBotConfiguration.BotTokenVariable] = "integration-test-token",
+            [BeanBotConfiguration.MongoConnectionVariable] = "mongodb://127.0.0.1:27017",
+            [BeanBotConfiguration.GeneralChannelVariable] = "123456789",
+            [BeanBotConfiguration.HatoeteUrlVariable] = "https://example.test/hatoete.png",
+            [BeanBotConfiguration.YoshimaruUrlVariable] = "https://example.test/yoshimaru.png"
+        };
+
+    private static HttpClient CreateHealthClient(int port)
+        => new(new SocketsHttpHandler { UseProxy = false })
+        {
+            BaseAddress = new Uri($"http://127.0.0.1:{port}")
+        };
+
+    private static DiscordStartupService CreateStartupService(
+        IDiscordStartupLifecycle lifecycle,
+        IDiscordStartupDelay delay)
+        => new(
+            lifecycle,
+            NullLogger<DiscordStartupService>.Instance,
+            DiscordStartupOptions.Default,
+            delay);
+
+    private static Discord.Net.HttpException CreateHttpException(HttpStatusCode statusCode)
+        => new(statusCode, null, null, "Test Discord failure", null);
+
+    private sealed class TestHostScope : IAsyncDisposable
+    {
+        private readonly DiscordSocketClient _discordClient;
+        private readonly RecordingRuntime _runtime;
+
+        public TestHostScope(
+            IHost host,
+            DiscordSocketClient discordClient,
+            RecordingRuntime runtime)
+        {
+            Host = host;
+            _discordClient = discordClient;
+            _runtime = runtime;
+        }
+
+        public IHost Host { get; }
+
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                if (Host is IAsyncDisposable asyncDisposableHost)
+                {
+                    await asyncDisposableHost.DisposeAsync();
+                }
+                else
+                {
+                    Host.Dispose();
+                }
+            }
+            finally
+            {
+                await _runtime.DisposeAsync();
+                _discordClient.Dispose();
+            }
+        }
+    }
+
+    private sealed class RecordingRuntime : IBeanBotRuntime, IAsyncDisposable
+    {
+        private readonly HealthCheckServer _healthServer;
+        private DiscordHealthSnapshot _healthSnapshot = UnhealthySnapshot;
+
+        public RecordingRuntime(bool healthEnabled)
+        {
+            var options = healthEnabled
+                ? new HealthCheckOptions(
+                    true,
+                    IPAddress.Loopback,
+                    0,
+                    null,
+                    TimeSpan.FromMilliseconds(1))
+                : HealthCheckOptions.Disabled;
+            _healthServer = new HealthCheckServer(
+                options,
+                () => Volatile.Read(ref _healthSnapshot),
+                NullLogger<HealthCheckServer>.Instance);
+        }
+
+        public List<string> Calls { get; } = new();
+        public Func<CancellationToken, Task>? StartDiscord { get; init; }
+        public bool HasUnfinishedDiscordStartupOperation => false;
+        public int HealthPort => _healthServer.BoundPort;
+
+        public void SetHealthSnapshot(DiscordHealthSnapshot snapshot)
+            => Volatile.Write(ref _healthSnapshot, snapshot);
+
+        public void SubscribeApplicationEvents() => Calls.Add("subscribe-events");
+
+        public async Task StartHealthServerAsync(CancellationToken cancellationToken)
+        {
+            Calls.Add("start-health");
+            await _healthServer.StartAsync(cancellationToken);
+        }
+
+        public Task StartDiscordAsync(CancellationToken cancellationToken)
+        {
+            Calls.Add("start-discord");
+            return StartDiscord?.Invoke(cancellationToken) ?? Task.CompletedTask;
+        }
+
+        public void StartGatewayRecovery() => Calls.Add("start-recovery");
+
+        public Task StartCommandServicesAsync()
+        {
+            Calls.Add("start-commands");
+            return Task.CompletedTask;
+        }
+
+        public void StartEventAndBackgroundServices() => Calls.Add("start-event-background");
+        public void StopEventAndCommandServices() => Calls.Add("stop-event-command");
+
+        public Task StopGatewayRecoveryAsync()
+        {
+            Calls.Add("stop-recovery");
+            return Task.CompletedTask;
+        }
+
+        public void UnsubscribeApplicationEvents() => Calls.Add("unsubscribe-events");
+
+        public async Task StopBackgroundServicesAsync(CancellationToken cancellationToken)
+        {
+            Calls.Add("stop-background");
+            await _healthServer.StopAsync(cancellationToken);
+        }
+
+        public Task FlushOwnerAlertsAsync()
+        {
+            Calls.Add("flush-alerts");
+            return Task.CompletedTask;
+        }
+
+        public Task StopDiscordAsync(CancellationToken cancellationToken)
+        {
+            Calls.Add("stop-discord");
+            return Task.CompletedTask;
+        }
+
+        public void DisposeDiscordClient() => Calls.Add("dispose-discord");
+
+        public ValueTask DisposeAsync() => _healthServer.DisposeAsync();
+    }
+
+    private sealed class QueueStartupLifecycle : IDiscordStartupLifecycle
+    {
+        private readonly Queue<Exception?> _loginFailures;
+
+        public QueueStartupLifecycle(params Exception?[] loginFailures)
+        {
+            _loginFailures = new Queue<Exception?>(loginFailures);
+        }
+
+        public int LoginCount { get; private set; }
+        public int StartCount { get; private set; }
+
+        public Task LoginAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            LoginCount++;
+            var failure = _loginFailures.Count > 0 ? _loginFailures.Dequeue() : null;
+            return failure is null ? Task.CompletedTask : Task.FromException(failure);
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            StartCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task SetPresenceAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingDelay : IDiscordStartupDelay
+    {
+        public List<TimeSpan> RequestedDelays { get; } = new();
+
+        public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            RequestedDelays.Add(delay);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class BlockingDelay : IDiscordStartupDelay
+    {
+        public TaskCompletionSource Requested { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+        {
+            Requested.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        }
+    }
+}

--- a/BeanBot.Tests/Integration/MongoRoleReactRepositoryIntegrationTests.cs
+++ b/BeanBot.Tests/Integration/MongoRoleReactRepositoryIntegrationTests.cs
@@ -1,0 +1,139 @@
+using BeanBot.Entities;
+using BeanBot.Repository;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using MongoDB.Driver;
+
+using System.Net;
+using System.Net.Sockets;
+
+using Testcontainers.MongoDb;
+
+using Xunit;
+
+namespace BeanBot.Tests.Integration;
+
+public sealed class MongoRoleReactRepositoryIntegrationTests
+    : IClassFixture<MongoDbIntegrationFixture>
+{
+    private static readonly TimeSpan OperationTimeout = TimeSpan.FromSeconds(10);
+    private readonly MongoDbIntegrationFixture _fixture;
+
+    public MongoRoleReactRepositoryIntegrationTests(MongoDbIntegrationFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task InsertAndRead_PersistsRoleSettingsAcrossRepositoryInstances()
+    {
+        var databaseName = CreateDatabaseName();
+        var firstClient = new MongoClient(_fixture.ConnectionString);
+        var firstRepository = CreateRepository(firstClient.GetDatabase(databaseName));
+        var settings = new RoleSettings(
+            new List<RoleEmotePair> { new("123", "456") },
+            "789",
+            "101112",
+            "131415");
+
+        try
+        {
+            using var cancellation = new CancellationTokenSource(OperationTimeout);
+            await firstRepository.InsertNewRoleSettings(settings, cancellation.Token);
+
+            var secondClient = new MongoClient(_fixture.ConnectionString);
+            var secondRepository = CreateRepository(secondClient.GetDatabase(databaseName));
+            var persisted = await secondRepository.GetRoleSetting(131415UL, cancellation.Token);
+
+            Assert.NotNull(persisted);
+            Assert.Equal("789", persisted.GuildId);
+            Assert.Equal("101112", persisted.ChannelId);
+            Assert.Equal("131415", persisted.MessageId);
+            var pair = Assert.Single(persisted.RoleEmotePairs);
+            Assert.Equal("123", pair.RoleId);
+            Assert.Equal("456", pair.EmojiId);
+            Assert.Equal(DateTimeKind.Utc, persisted.LastAccessedUtc.Kind);
+            Assert.NotEqual(default, persisted.LastAccessedUtc);
+        }
+        finally
+        {
+            await DropDatabaseAsync(firstClient, databaseName);
+        }
+    }
+
+    [Fact]
+    public async Task GetRoleSetting_ReturnsNullWhenMongoCollectionHasNoMatch()
+    {
+        var databaseName = CreateDatabaseName();
+        var client = new MongoClient(_fixture.ConnectionString);
+        var repository = CreateRepository(client.GetDatabase(databaseName));
+
+        try
+        {
+            using var cancellation = new CancellationTokenSource(OperationTimeout);
+            var persisted = await repository.GetRoleSetting(42UL, cancellation.Token);
+
+            Assert.Null(persisted);
+        }
+        finally
+        {
+            await DropDatabaseAsync(client, databaseName);
+        }
+    }
+
+    [Fact]
+    public async Task GetRoleSetting_PropagatesBoundedMongoInfrastructureFailure()
+    {
+        using var nonMongoEndpoint = new TcpListener(IPAddress.Loopback, 0);
+        nonMongoEndpoint.Start();
+        var endpoint = (IPEndPoint)nonMongoEndpoint.LocalEndpoint;
+        var settings = MongoClientSettings.FromConnectionString(
+            $"mongodb://127.0.0.1:{endpoint.Port}");
+        settings.ConnectTimeout = TimeSpan.FromMilliseconds(250);
+        settings.SocketTimeout = TimeSpan.FromMilliseconds(250);
+        settings.ServerSelectionTimeout = TimeSpan.FromSeconds(1);
+        var repository = CreateRepository(
+            new MongoClient(settings).GetDatabase(CreateDatabaseName()));
+
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var exception = await Assert.ThrowsAsync<TimeoutException>(
+            () => repository.GetRoleSetting(42UL, cancellation.Token));
+
+        Assert.Contains("selecting a server", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static RoleReactRepository CreateRepository(IMongoDatabase database)
+        => new(database, NullLogger<RoleReactRepository>.Instance);
+
+    private static string CreateDatabaseName()
+        => $"BeanBotIntegration_{Guid.NewGuid():N}";
+
+    private static async Task DropDatabaseAsync(MongoClient client, string databaseName)
+    {
+        using var cancellation = new CancellationTokenSource(OperationTimeout);
+        await client.DropDatabaseAsync(databaseName, cancellation.Token);
+    }
+}
+
+public sealed class MongoDbIntegrationFixture : IAsyncLifetime
+{
+    private static readonly TimeSpan StartupTimeout = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(30);
+    private const string MongoImage =
+        "mongo:8.2.12-noble@sha256:dc23b0dde2221277b581dd76933f39f8a765fee9dbd99b9deb19184c063c061f";
+    private readonly MongoDbContainer _container = new MongoDbBuilder(MongoImage).Build();
+
+    public string ConnectionString => _container.GetConnectionString();
+
+    public async Task InitializeAsync()
+    {
+        using var cancellation = new CancellationTokenSource(StartupTimeout);
+        await _container.StartAsync(cancellation.Token);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _container.DisposeAsync().AsTask().WaitAsync(ShutdownTimeout);
+    }
+}

--- a/BeanBot.Tests/Integration/OutageRecoveryRestartIntegrationTests.cs
+++ b/BeanBot.Tests/Integration/OutageRecoveryRestartIntegrationTests.cs
@@ -1,0 +1,105 @@
+using BeanBot.Services;
+using BeanBot.Util;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Xunit;
+
+namespace BeanBot.Tests.Integration;
+
+public sealed class OutageRecoveryRestartIntegrationTests : IDisposable
+{
+    private readonly string _temporaryDirectory = Path.Combine(
+        Path.GetTempPath(),
+        $"beanbot-outage-restart-tests-{Guid.NewGuid():N}");
+
+    public OutageRecoveryRestartIntegrationTests()
+        => Directory.CreateDirectory(_temporaryDirectory);
+
+    [Fact]
+    public async Task PersistedOutage_SurvivesRestartsAndClearsOnlyAfterSuccessfulNotification()
+    {
+        var disconnectedAtUtc = new DateTimeOffset(2026, 8, 19, 7, 42, 15, TimeSpan.Zero);
+        using (var writer = CreateStore())
+        {
+            await writer.OpenAsync(disconnectedAtUtc, "Gateway timed out");
+            await writer.MarkManualRecoveryAttemptedAsync(disconnectedAtUtc, "Manual reconnect failed");
+            await writer.MarkProcessRestartRequestedAsync(disconnectedAtUtc, "Ready timeout");
+        }
+
+        var outagePath = Path.Combine(_temporaryDirectory, DiscordOutageStore.OutageFileName);
+        var failedDelivery = new RecordingDelivery(alwaysFail: true);
+        using (var restartedStore = CreateStore())
+        using (var failedNotifier = CreateNotifier(restartedStore, failedDelivery))
+        {
+            await failedNotifier.NotifyIfOutageRecoveredAsync(disconnectedAtUtc.AddMinutes(10));
+
+            var retainedOutage = await restartedStore.ReadAsync();
+            Assert.NotNull(retainedOutage);
+            Assert.True(retainedOutage.ManualRecoveryAttempted);
+            Assert.True(retainedOutage.ProcessRestartRequested);
+            Assert.Equal("Ready timeout", retainedOutage.MostRecentDisconnectReason);
+            Assert.True(File.Exists(outagePath));
+            Assert.Equal(
+                DiscordOutageRecoveryNotifier.MaximumDeliveryAttempts,
+                failedDelivery.AttemptCount);
+        }
+
+        var successfulDelivery = new RecordingDelivery();
+        using (var recoveredStore = CreateStore())
+        using (var successfulNotifier = CreateNotifier(recoveredStore, successfulDelivery))
+        {
+            await successfulNotifier.NotifyIfOutageRecoveredAsync(disconnectedAtUtc.AddMinutes(12));
+
+            var message = Assert.Single(successfulDelivery.Messages);
+            Assert.Contains("Container restart requested: yes", message);
+            Assert.Contains("persisted across a requested process/container restart", message);
+            Assert.Null(await recoveredStore.ReadAsync());
+            Assert.False(File.Exists(outagePath));
+        }
+    }
+
+    private DiscordOutageStore CreateStore()
+        => new(_temporaryDirectory, NullLogger<DiscordOutageStore>.Instance);
+
+    private static DiscordOutageRecoveryNotifier CreateNotifier(
+        IDiscordOutageStore store,
+        RecordingDelivery delivery)
+        => new(
+            store,
+            delivery,
+            NullLogger<DiscordOutageRecoveryNotifier>.Instance,
+            _ => TimeSpan.Zero,
+            TimeSpan.FromSeconds(1));
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_temporaryDirectory))
+        {
+            Directory.Delete(_temporaryDirectory, recursive: true);
+        }
+    }
+
+    private sealed class RecordingDelivery : IOwnerAlertDelivery
+    {
+        private readonly bool _alwaysFail;
+
+        public RecordingDelivery(bool alwaysFail = false) => _alwaysFail = alwaysFail;
+
+        public List<string> Messages { get; } = new();
+        public int AttemptCount { get; private set; }
+
+        public Task DeliverAsync(string alert, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            AttemptCount++;
+            if (_alwaysFail)
+            {
+                throw new InvalidOperationException("Discord REST unavailable");
+            }
+
+            Messages.Add(alert);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,6 +21,7 @@
     <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageVersion Include="Testcontainers.MongoDb" Version="4.14.0" />
     <!-- Pin secure versions of vulnerable transitive MongoDB.Driver dependencies. -->
     <PackageVersion Include="SharpCompress" Version="0.50.0" />
     <PackageVersion Include="Snappier" Version="1.3.1" />

--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ If you bind the endpoint to anything other than `127.0.0.1`, set `BEANBOT_HEALTH
 
 ## Local Development
 
-Install a stable .NET 10 SDK. The repository's `global.json` accepts SDK 10.0.100 or
-newer .NET 10 patches and feature bands while excluding preview and other major SDKs.
-Then restore, build, and run the test suite from the repo root:
+Install a stable .NET 10 SDK and Docker. The repository's `global.json` accepts SDK
+10.0.100 or newer .NET 10 patches and feature bands while excluding preview and
+other major SDKs. The integration suite automatically starts an isolated MongoDB
+container; it does not use `BEANBOT_MONGO_CONNECTION_STRING` or require a manually
+managed test database. Then restore, build, and run the test suite from the repo root:
 
 ```powershell
 dotnet restore BeanBot.sln

--- a/docs/codex-development-loop.md
+++ b/docs/codex-development-loop.md
@@ -36,11 +36,12 @@ The script keeps the .NET CLI home and NuGet package cache in the repository's i
 
 The gates have these dependencies:
 
-- Configuration, script orchestration, build, test, and diff checks are deterministic local checks once dependencies are restored.
+- Configuration, script orchestration, build, test, and diff checks are deterministic local checks once dependencies and the pinned MongoDB integration image are available.
 - Restore and vulnerable-package checks require NuGet/network availability.
-- The Docker gate requires a working Docker daemon and registry/network access when base layers are absent.
+- Tests require a working Docker daemon because the integration suite automatically starts an isolated, ephemeral MongoDB container. Registry/network access is required when its pinned image is absent.
+- The full-only Docker image gate also requires registry/network access when base layers are absent.
 - GitHub evaluates Actions syntax/triggers and supplies exact-head required-check evidence.
-- Real Discord, production MongoDB, deployment health, and post-deployment behavior remain manual. Tests must not connect to them.
+- Real Discord, production MongoDB, deployment health, and post-deployment behavior remain manual. Tests must not connect to production services or credentials.
 
 Formatting and warning-level analyzer conventions are mandatory gates backed by the repository's `.editorconfig`. No coverage threshold is imposed.
 


### PR DESCRIPTION
Closes #94

## Summary
- exercise the real Generic Host, Options validation, hosted application lifecycle, and Kestrel health endpoint around bounded Discord fakes
- cover Discord retry exhaustion and startup cancellation through the composed host cleanup path
- verify persisted outage state survives fresh store instances and clears only after successful recovery notification
- cover the production MongoDB repository boundary with a digest-pinned ephemeral container:
  - persist and read role settings through fresh Mongo clients and repository instances
  - return `null` for a missing message ID
  - propagate a bounded driver failure from a deliberately unusable endpoint
- isolate Mongo tests with unique databases and automatic cleanup; no production credentials or manually managed service is used
- document Docker-backed integration-test prerequisites and clarify the health rate-limit test timing

## Verification
- focused Mongo integration tests: 3 passed
- verification orchestration tests: passed
- `./scripts/verify.sh fast`: 347 passed, 0 failed, 0 skipped
- `./scripts/verify.sh full`: 347 passed, no known vulnerable direct/transitive packages, production Docker image built successfully
- Release build: passed with 0 warnings
- exact-head GitHub Actions build on `e99326f`: passed in 1m28s