### PR TITLE
Apply modern C# style conventions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,15 @@ trim_trailing_whitespace = true
 indent_size = 4
 
 csharp_using_directive_placement = outside_namespace:suggestion
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+# IDE0005 warning severity requires XML documentation generation during compiler builds.
+# scripts/verify.sh enforces it explicitly without changing BeanBot's published artifacts.
+
+csharp_style_namespace_declarations = file_scoped:warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
+dotnet_style_prefer_collection_expression = when_types_exactly_match:warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
 
 csharp_style_var_for_built_in_types = false:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion

--- a/BeanBot.Tests/Configuration/BeanBotConfigurationTests.cs
+++ b/BeanBot.Tests/Configuration/BeanBotConfigurationTests.cs
@@ -1,15 +1,11 @@
+using System.Net;
 using BeanBot.Configuration;
 using BeanBot.Hosting;
-
 using Discord.WebSocket;
-
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
-
-using System.Net;
-
 using Xunit;
 
 namespace BeanBot.Tests.Configuration;

--- a/BeanBot.Tests/Entities/RoleSettingsTests.cs
+++ b/BeanBot.Tests/Entities/RoleSettingsTests.cs
@@ -1,10 +1,7 @@
+using System.Text.Json;
 using BeanBot.Entities;
-
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
-
-using System.Text.Json;
-
 using Xunit;
 
 namespace BeanBot.Tests.Entities;
@@ -143,7 +140,7 @@ public class RoleSettingsTests
     public void ToString_PreservesExistingJsonMemberNames()
     {
         var settings = new RoleSettings(
-            new List<RoleEmotePair> { new("role", "emoji") },
+            [new("role", "emoji")],
             "guild",
             "channel",
             "message")

--- a/BeanBot.Tests/Hosting/BeanBotApplicationTests.cs
+++ b/BeanBot.Tests/Hosting/BeanBotApplicationTests.cs
@@ -91,7 +91,7 @@ public class BeanBotApplicationTests
 
     private sealed class RecordingRuntime : IBeanBotRuntime
     {
-        public List<string> Calls { get; } = new();
+        public List<string> Calls { get; } = [];
         public string? FailingOperation { get; init; }
         public bool HasUnfinishedDiscordStartupOperation { get; init; }
 

--- a/BeanBot.Tests/Integration/BeanBotHostIntegrationTests.cs
+++ b/BeanBot.Tests/Integration/BeanBotHostIntegrationTests.cs
@@ -1,9 +1,9 @@
+using System.Net;
+using System.Net.Sockets;
 using BeanBot.Configuration;
 using BeanBot.Hosting;
 using BeanBot.Services;
-
 using Discord.WebSocket;
-
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -11,10 +11,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
-
-using System.Net;
-using System.Net.Sockets;
-
 using Xunit;
 
 namespace BeanBot.Tests.Integration;
@@ -276,7 +272,7 @@ public class BeanBotHostIntegrationTests
                 NullLogger<HealthCheckServer>.Instance);
         }
 
-        public List<string> Calls { get; } = new();
+        public List<string> Calls { get; } = [];
         public Func<CancellationToken, Task>? StartDiscord { get; init; }
         public bool HasUnfinishedDiscordStartupOperation => false;
         public int HealthPort => _healthServer.BoundPort;
@@ -376,7 +372,7 @@ public class BeanBotHostIntegrationTests
 
     private sealed class RecordingDelay : IDiscordStartupDelay
     {
-        public List<TimeSpan> RequestedDelays { get; } = new();
+        public List<TimeSpan> RequestedDelays { get; } = [];
 
         public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
         {

--- a/BeanBot.Tests/Integration/MongoRoleReactRepositoryIntegrationTests.cs
+++ b/BeanBot.Tests/Integration/MongoRoleReactRepositoryIntegrationTests.cs
@@ -1,15 +1,10 @@
-using BeanBot.Entities;
-using BeanBot.Repository;
-
-using Microsoft.Extensions.Logging.Abstractions;
-
-using MongoDB.Driver;
-
 using System.Net;
 using System.Net.Sockets;
-
+using BeanBot.Entities;
+using BeanBot.Repository;
+using Microsoft.Extensions.Logging.Abstractions;
+using MongoDB.Driver;
 using Testcontainers.MongoDb;
-
 using Xunit;
 
 namespace BeanBot.Tests.Integration;
@@ -32,7 +27,7 @@ public sealed class MongoRoleReactRepositoryIntegrationTests
         var firstClient = new MongoClient(_fixture.ConnectionString);
         var firstRepository = CreateRepository(firstClient.GetDatabase(databaseName));
         var settings = new RoleSettings(
-            new List<RoleEmotePair> { new("123", "456") },
+            [new("123", "456")],
             "789",
             "101112",
             "131415");

--- a/BeanBot.Tests/Integration/OutageRecoveryRestartIntegrationTests.cs
+++ b/BeanBot.Tests/Integration/OutageRecoveryRestartIntegrationTests.cs
@@ -86,7 +86,7 @@ public sealed class OutageRecoveryRestartIntegrationTests : IDisposable
 
         public RecordingDelivery(bool alwaysFail = false) => _alwaysFail = alwaysFail;
 
-        public List<string> Messages { get; } = new();
+        public List<string> Messages { get; } = [];
         public int AttemptCount { get; private set; }
 
         public Task DeliverAsync(string alert, CancellationToken cancellationToken)

--- a/BeanBot.Tests/Repository/RoleReactRepositoryTests.cs
+++ b/BeanBot.Tests/Repository/RoleReactRepositoryTests.cs
@@ -64,7 +64,7 @@ public class RoleReactRepositoryTests
             {
                 Assert.Equal(cancellation.Token, cancellationToken);
                 await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
-                return new List<RoleSettings>();
+                return [];
             }
         };
         var repository = CreateRepository(store);
@@ -143,7 +143,7 @@ public class RoleReactRepositoryTests
         => new(store, NullLogger<RoleReactRepository>.Instance);
 
     private static RoleSettings CreateRoleSettings(string messageId)
-        => new(new List<RoleEmotePair>(), "1", "2", messageId);
+        => new([], "1", "2", messageId);
 
     private sealed class FakeRoleSettingsStore : IRoleSettingsStore
     {

--- a/BeanBot.Tests/Services/BoundedClientRateLimiterTests.cs
+++ b/BeanBot.Tests/Services/BoundedClientRateLimiterTests.cs
@@ -100,7 +100,7 @@ public class BoundedClientRateLimiterTests
 
     private sealed class ManualClock
     {
-        private DateTimeOffset _utcNow = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        private DateTimeOffset _utcNow = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
         public DateTimeOffset GetUtcNow() => _utcNow;
 

--- a/BeanBot.Tests/Services/DiscordGatewayRecoveryServiceTests.cs
+++ b/BeanBot.Tests/Services/DiscordGatewayRecoveryServiceTests.cs
@@ -1,8 +1,6 @@
+using System.Collections.Concurrent;
 using BeanBot.Services;
 using Microsoft.Extensions.Logging.Abstractions;
-
-using System.Collections.Concurrent;
-
 using Xunit;
 
 namespace BeanBot.Tests.Services;
@@ -147,7 +145,7 @@ public class DiscordGatewayRecoveryServiceTests
     private sealed class FakeOutageStore : IDiscordOutageStore
     {
         public DiscordOutage? CurrentOutage { get; private set; }
-        public List<string> StateTransitions { get; } = new();
+        public List<string> StateTransitions { get; } = [];
 
         public Task<DiscordOutage?> ReadAsync(CancellationToken cancellationToken = default)
             => Task.FromResult(CurrentOutage);

--- a/BeanBot.Tests/Services/DiscordOutageRecoveryNotifierTests.cs
+++ b/BeanBot.Tests/Services/DiscordOutageRecoveryNotifierTests.cs
@@ -133,7 +133,7 @@ public class DiscordOutageRecoveryNotifierTests
     {
         private readonly bool _alwaysFail;
         public RecordingDelivery(bool alwaysFail = false) => _alwaysFail = alwaysFail;
-        public List<string> Messages { get; } = new();
+        public List<string> Messages { get; } = [];
         public int AttemptCount { get; private set; }
 
         public Task DeliverAsync(string alert, CancellationToken cancellationToken)

--- a/BeanBot.Tests/Services/DiscordPaginatorServiceTests.cs
+++ b/BeanBot.Tests/Services/DiscordPaginatorServiceTests.cs
@@ -1,15 +1,9 @@
+using System.Diagnostics;
+using System.Reflection;
 using BeanBot.Services;
-
 using Discord;
 using Discord.WebSocket;
 using Microsoft.Extensions.Logging.Abstractions;
-
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
-
 using Xunit;
 
 namespace BeanBot.Tests.Services;
@@ -264,8 +258,8 @@ public class DiscordPaginatorServiceTests
 
     public class ReactionRemovalMessageProxy : DispatchProxy
     {
-        public List<ulong> RemovedUserIds { get; } = new();
-        public List<IEmote> RemovedEmotes { get; } = new();
+        public List<ulong> RemovedUserIds { get; } = [];
+        public List<IEmote> RemovedEmotes { get; } = [];
 
         protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
         {

--- a/BeanBot.Tests/Services/DiscordStartupServiceTests.cs
+++ b/BeanBot.Tests/Services/DiscordStartupServiceTests.cs
@@ -1,9 +1,6 @@
-using BeanBot.Services;
-
-using Microsoft.Extensions.Logging.Abstractions;
-
 using System.Net;
-
+using BeanBot.Services;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace BeanBot.Tests.Services;
@@ -327,7 +324,7 @@ public class DiscordStartupServiceTests
 
     private sealed class RecordingDelay : IDiscordStartupDelay
     {
-        public List<TimeSpan> RequestedDelays { get; } = new();
+        public List<TimeSpan> RequestedDelays { get; } = [];
 
         public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
         {

--- a/BeanBot.Tests/Services/HealthCheckServerTests.cs
+++ b/BeanBot.Tests/Services/HealthCheckServerTests.cs
@@ -1,18 +1,15 @@
-using BeanBot.Configuration;
-using BeanBot.Services;
-
+using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Sockets;
-using System.Collections.Concurrent;
 using System.Text;
 using System.Text.Json;
-
+using BeanBot.Configuration;
+using BeanBot.Services;
+using Microsoft.Extensions.Logging.Abstractions;
 using Serilog;
 using Serilog.Core;
 using Serilog.Events;
-using Microsoft.Extensions.Logging.Abstractions;
-
 using Xunit;
 
 namespace BeanBot.Tests.Services;

--- a/BeanBot.Tests/Services/RoleReactServiceTests.cs
+++ b/BeanBot.Tests/Services/RoleReactServiceTests.cs
@@ -1,11 +1,8 @@
+using System.Reflection;
 using BeanBot.Entities;
 using BeanBot.Repository;
 using BeanBot.Services;
-
 using Microsoft.Extensions.Logging.Abstractions;
-
-using System.Reflection;
-
 using Xunit;
 
 namespace BeanBot.Tests.Services;
@@ -147,7 +144,7 @@ public class RoleReactServiceTests
             {
                 operationStarted.SetResult();
                 await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
-                return new List<RoleSettings>();
+                return [];
             }
         };
         var service = CreateService(TimeSpan.FromSeconds(1), store);
@@ -213,7 +210,7 @@ public class RoleReactServiceTests
     }
 
     private static RoleSettings CreateRoleSettings(string messageId)
-        => new(new List<RoleEmotePair>(), "1", "2", messageId);
+        => new([], "1", "2", messageId);
 
     private static SemaphoreSlim GetCacheLock(RoleReactService service)
     {

--- a/BeanBot.Tests/Util/DiscordOwnerErrorSinkTests.cs
+++ b/BeanBot.Tests/Util/DiscordOwnerErrorSinkTests.cs
@@ -1,8 +1,8 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
 using BeanBot.Util;
 using Serilog.Events;
 using Serilog.Parsing;
-using System.Collections.Concurrent;
-using System.Diagnostics;
 using Xunit;
 
 namespace BeanBot.Tests.Util;
@@ -111,7 +111,7 @@ public class DiscordOwnerErrorSinkTests
         LogEventLevel level,
         string message,
         Exception? exception = null)
-        => new LogEvent(
+        => new(
             DateTimeOffset.UtcNow,
             level,
             exception,
@@ -120,7 +120,7 @@ public class DiscordOwnerErrorSinkTests
 
     private sealed class CapturingNotifier : IOwnerErrorNotifier
     {
-        public List<string> Alerts { get; } = new();
+        public List<string> Alerts { get; } = [];
         public void Enqueue(string alert) => Alerts.Add(alert);
     }
 
@@ -133,8 +133,8 @@ public class DiscordOwnerErrorSinkTests
             _shouldFail = shouldFail;
         }
 
-        public ConcurrentDictionary<string, int> Attempts { get; } = new();
-        public ConcurrentBag<string> DeliveredAlerts { get; } = new();
+        public ConcurrentDictionary<string, int> Attempts { get; } = [];
+        public ConcurrentBag<string> DeliveredAlerts { get; } = [];
         public TaskCompletionSource FirstAttempted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
         public TaskCompletionSource LaterAlertDelivered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 

--- a/BeanBot.Tests/Util/LogHandlerTests.cs
+++ b/BeanBot.Tests/Util/LogHandlerTests.cs
@@ -175,7 +175,7 @@ public class LogHandlerTests
 
     private sealed class RecordingLogger<T> : ILogger<T>
     {
-        public List<LogEntry> Entries { get; } = new();
+        public List<LogEntry> Entries { get; } = [];
 
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
 
@@ -218,13 +218,13 @@ public class LogHandlerTests
 
     private sealed class CapturingSerilogSink : ILogEventSink
     {
-        public List<LogEvent> Events { get; } = new();
+        public List<LogEvent> Events { get; } = [];
         public void Emit(LogEvent logEvent) => Events.Add(logEvent);
     }
 
     private sealed class CapturingNotifier : IOwnerErrorNotifier
     {
-        public List<string> Alerts { get; } = new();
+        public List<string> Alerts { get; } = [];
         public void Enqueue(string alert) => Alerts.Add(alert);
     }
 }

--- a/BeanBot/Attributes/RequireGuildAttribute.cs
+++ b/BeanBot/Attributes/RequireGuildAttribute.cs
@@ -1,24 +1,21 @@
-﻿using System;
-using System.Threading.Tasks;
-using Discord.Commands;
+﻿using Discord.Commands;
 using Discord.WebSocket;
 
 
-namespace BeanBot.Attributes
+namespace BeanBot.Attributes;
+
+public class RequireGuildAttribute : PreconditionAttribute
 {
-    public class RequireGuildAttribute : PreconditionAttribute
+    // Override the CheckPermissions method
+    public override Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, CommandInfo command, IServiceProvider services)
     {
-        // Override the CheckPermissions method
-        public override Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, CommandInfo command, IServiceProvider services)
+        // Check if this user is a Guild User
+        if (context.User is SocketGuildUser)
         {
-            // Check if this user is a Guild User
-            if (context.User is SocketGuildUser)
-            {
-                // Since no async work is done, the result has to be wrapped with `Task.FromResult` to avoid compiler errors
-                return Task.FromResult(PreconditionResult.FromSuccess());
-            }
-            else
-                return Task.FromResult(PreconditionResult.FromError("You must be in a guild to run this command."));
+            // Since no async work is done, the result has to be wrapped with `Task.FromResult` to avoid compiler errors
+            return Task.FromResult(PreconditionResult.FromSuccess());
         }
+        else
+            return Task.FromResult(PreconditionResult.FromError("You must be in a guild to run this command."));
     }
 }

--- a/BeanBot/Configuration/BeanBotConfiguration.cs
+++ b/BeanBot/Configuration/BeanBotConfiguration.cs
@@ -1,172 +1,165 @@
 using Microsoft.Extensions.Configuration;
-
 using Serilog;
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+namespace BeanBot.Configuration;
 
-namespace BeanBot.Configuration
+internal static class BeanBotConfiguration
 {
-    internal static class BeanBotConfiguration
+    internal const string BotTokenVariable = "BEANBOT_BOT_TOKEN";
+    internal const string MongoConnectionVariable = "BEANBOT_MONGO_CONNECTION_STRING";
+    internal const string GeneralChannelVariable = "BEANBOT_GENERAL_CHANNEL_ID";
+    internal const string HatoeteUrlVariable = "BEANBOT_HATOETE_URL";
+    internal const string YoshimaruUrlVariable = "BEANBOT_YOSHIMARU_URL";
+    internal const string HealthCheckPortVariable = "BEANBOT_HEALTHCHECK_PORT";
+    internal const string HealthCheckBindAddressVariable = "BEANBOT_HEALTHCHECK_BIND_ADDRESS";
+    internal const string HealthCheckBearerTokenVariable = "BEANBOT_HEALTHCHECK_BEARER_TOKEN";
+    internal const string HealthCheckRateLimitVariable = "BEANBOT_HEALTHCHECK_RATE_LIMIT_SECONDS";
+
+    private static readonly ConfigurationKey[] RequiredKeys =
+    [
+        new(BotTokenVariable, "botToken", "BotToken"),
+        new(MongoConnectionVariable, "mongoConnectionString", "MongoConnectionString"),
+        new(GeneralChannelVariable, "generalChannelId", "GeneralChannelId"),
+        new(HatoeteUrlVariable, "hatoeteUrl", "HatoeteUrl"),
+        new(YoshimaruUrlVariable, "yoshimaruUrl", "YoshimaruUrl")
+    ];
+
+    private static readonly ConfigurationKey HealthCheckPort =
+        new(HealthCheckPortVariable, "healthCheckPort", "HealthCheck:Port");
+
+    private static readonly ConfigurationKey[] HealthCheckKeys =
+    [
+        new(HealthCheckBindAddressVariable, "healthCheckBindAddress", "HealthCheck:BindAddress"),
+        new(HealthCheckBearerTokenVariable, "healthCheckBearerToken", "HealthCheck:BearerToken"),
+        new(HealthCheckRateLimitVariable, "healthCheckRateLimitSeconds", "HealthCheck:RateLimitSeconds")
+    ];
+
+    internal static ConfigurationManager AddBeanBotConfiguration(
+        this ConfigurationManager configuration,
+        IEnumerable<string>? dotEnvCandidatePaths = null)
     {
-        internal const string BotTokenVariable = "BEANBOT_BOT_TOKEN";
-        internal const string MongoConnectionVariable = "BEANBOT_MONGO_CONNECTION_STRING";
-        internal const string GeneralChannelVariable = "BEANBOT_GENERAL_CHANNEL_ID";
-        internal const string HatoeteUrlVariable = "BEANBOT_HATOETE_URL";
-        internal const string YoshimaruUrlVariable = "BEANBOT_YOSHIMARU_URL";
-        internal const string HealthCheckPortVariable = "BEANBOT_HEALTHCHECK_PORT";
-        internal const string HealthCheckBindAddressVariable = "BEANBOT_HEALTHCHECK_BIND_ADDRESS";
-        internal const string HealthCheckBearerTokenVariable = "BEANBOT_HEALTHCHECK_BEARER_TOKEN";
-        internal const string HealthCheckRateLimitVariable = "BEANBOT_HEALTHCHECK_RATE_LIMIT_SECONDS";
+        ArgumentNullException.ThrowIfNull(configuration);
 
-        private static readonly ConfigurationKey[] RequiredKeys =
+        AddDotEnvDefaults(configuration, dotEnvCandidatePaths ?? DefaultDotEnvCandidatePaths());
+
+        var normalizedValues = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var key in RequiredKeys)
         {
-            new(BotTokenVariable, "botToken", "BotToken"),
-            new(MongoConnectionVariable, "mongoConnectionString", "MongoConnectionString"),
-            new(GeneralChannelVariable, "generalChannelId", "GeneralChannelId"),
-            new(HatoeteUrlVariable, "hatoeteUrl", "HatoeteUrl"),
-            new(YoshimaruUrlVariable, "yoshimaruUrl", "YoshimaruUrl")
-        };
+            AddNormalizedValue(configuration, normalizedValues, key);
+        }
 
-        private static readonly ConfigurationKey HealthCheckPort =
-            new(HealthCheckPortVariable, "healthCheckPort", "HealthCheck:Port");
-
-        private static readonly ConfigurationKey[] HealthCheckKeys =
+        var healthCheckPort = GetCompatibilityValue(configuration, HealthCheckPort);
+        if (healthCheckPort is not null)
         {
-            new(HealthCheckBindAddressVariable, "healthCheckBindAddress", "HealthCheck:BindAddress"),
-            new(HealthCheckBearerTokenVariable, "healthCheckBearerToken", "HealthCheck:BearerToken"),
-            new(HealthCheckRateLimitVariable, "healthCheckRateLimitSeconds", "HealthCheck:RateLimitSeconds")
-        };
+            normalizedValues[SectionKey(HealthCheckPort.OptionPath)] = healthCheckPort;
+        }
 
-        internal static ConfigurationManager AddBeanBotConfiguration(
-            this ConfigurationManager configuration,
-            IEnumerable<string>? dotEnvCandidatePaths = null)
+        if (!string.IsNullOrWhiteSpace(healthCheckPort))
         {
-            ArgumentNullException.ThrowIfNull(configuration);
-
-            AddDotEnvDefaults(configuration, dotEnvCandidatePaths ?? DefaultDotEnvCandidatePaths());
-
-            var normalizedValues = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
-            foreach (var key in RequiredKeys)
+            foreach (var key in HealthCheckKeys)
             {
                 AddNormalizedValue(configuration, normalizedValues, key);
             }
-
-            var healthCheckPort = GetCompatibilityValue(configuration, HealthCheckPort);
-            if (healthCheckPort is not null)
-            {
-                normalizedValues[SectionKey(HealthCheckPort.OptionPath)] = healthCheckPort;
-            }
-
-            if (!string.IsNullOrWhiteSpace(healthCheckPort))
-            {
-                foreach (var key in HealthCheckKeys)
-                {
-                    AddNormalizedValue(configuration, normalizedValues, key);
-                }
-            }
-
-            configuration.AddInMemoryCollection(normalizedValues);
-            return configuration;
         }
 
-        private static void AddDotEnvDefaults(
-            ConfigurationManager configuration,
-            IEnumerable<string> candidatePaths)
-        {
-            foreach (var candidatePath in candidatePaths.Distinct(StringComparer.OrdinalIgnoreCase))
-            {
-                if (!File.Exists(candidatePath))
-                {
-                    continue;
-                }
-
-                var defaults = ParseDotEnv(File.ReadLines(candidatePath))
-                    .Where(pair => configuration[pair.Key] is null)
-                    .ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.OrdinalIgnoreCase);
-
-                configuration.AddInMemoryCollection(defaults!);
-                Log.Information("Loaded configuration defaults from {DotEnvPath}", candidatePath);
-                return;
-            }
-        }
-
-        private static Dictionary<string, string> ParseDotEnv(IEnumerable<string> lines)
-        {
-            var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var rawLine in lines)
-            {
-                var line = rawLine.Trim();
-                if (string.IsNullOrWhiteSpace(line) || line.StartsWith('#'))
-                {
-                    continue;
-                }
-
-                if (line.StartsWith("export ", StringComparison.OrdinalIgnoreCase))
-                {
-                    line = line.Substring("export ".Length).Trim();
-                }
-
-                var separatorIndex = line.IndexOf('=');
-                if (separatorIndex <= 0)
-                {
-                    continue;
-                }
-
-                var key = line.Substring(0, separatorIndex).Trim();
-                var value = line.Substring(separatorIndex + 1).Trim();
-                if (!string.IsNullOrWhiteSpace(key))
-                {
-                    values.TryAdd(key, TrimMatchingQuotes(value));
-                }
-            }
-
-            return values;
-        }
-
-        private static void AddNormalizedValue(
-            IConfiguration configuration,
-            Dictionary<string, string?> normalizedValues,
-            ConfigurationKey key)
-        {
-            var value = GetCompatibilityValue(configuration, key);
-            if (value is not null)
-            {
-                normalizedValues[SectionKey(key.OptionPath)] = value;
-            }
-        }
-
-        private static string? GetCompatibilityValue(IConfiguration configuration, ConfigurationKey key)
-            => configuration[key.CanonicalName] ?? configuration[key.LegacyName];
-
-        private static IEnumerable<string> DefaultDotEnvCandidatePaths()
-        {
-            yield return Path.Combine(Directory.GetCurrentDirectory(), ".env");
-            yield return Path.Combine(AppContext.BaseDirectory, ".env");
-        }
-
-        private static string SectionKey(string optionPath)
-            => $"{BeanBotSettings.SectionName}:{optionPath}";
-
-        private static string TrimMatchingQuotes(string value)
-        {
-            if (value.Length < 2)
-            {
-                return value;
-            }
-
-            var hasMatchingDoubleQuotes = value[0] == '"' && value[^1] == '"';
-            var hasMatchingSingleQuotes = value[0] == '\'' && value[^1] == '\'';
-            return hasMatchingDoubleQuotes || hasMatchingSingleQuotes
-                ? value.Substring(1, value.Length - 2)
-                : value;
-        }
-
-        private sealed record ConfigurationKey(
-            string CanonicalName,
-            string LegacyName,
-            string OptionPath);
+        configuration.AddInMemoryCollection(normalizedValues);
+        return configuration;
     }
+
+    private static void AddDotEnvDefaults(
+        ConfigurationManager configuration,
+        IEnumerable<string> candidatePaths)
+    {
+        foreach (var candidatePath in candidatePaths.Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            if (!File.Exists(candidatePath))
+            {
+                continue;
+            }
+
+            var defaults = ParseDotEnv(File.ReadLines(candidatePath))
+                .Where(pair => configuration[pair.Key] is null)
+                .ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.OrdinalIgnoreCase);
+
+            configuration.AddInMemoryCollection(defaults!);
+            Log.Information("Loaded configuration defaults from {DotEnvPath}", candidatePath);
+            return;
+        }
+    }
+
+    private static Dictionary<string, string> ParseDotEnv(IEnumerable<string> lines)
+    {
+        var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.Trim();
+            if (string.IsNullOrWhiteSpace(line) || line.StartsWith('#'))
+            {
+                continue;
+            }
+
+            if (line.StartsWith("export ", StringComparison.OrdinalIgnoreCase))
+            {
+                line = line.Substring("export ".Length).Trim();
+            }
+
+            var separatorIndex = line.IndexOf('=');
+            if (separatorIndex <= 0)
+            {
+                continue;
+            }
+
+            var key = line.Substring(0, separatorIndex).Trim();
+            var value = line.Substring(separatorIndex + 1).Trim();
+            if (!string.IsNullOrWhiteSpace(key))
+            {
+                values.TryAdd(key, TrimMatchingQuotes(value));
+            }
+        }
+
+        return values;
+    }
+
+    private static void AddNormalizedValue(
+        IConfiguration configuration,
+        Dictionary<string, string?> normalizedValues,
+        ConfigurationKey key)
+    {
+        var value = GetCompatibilityValue(configuration, key);
+        if (value is not null)
+        {
+            normalizedValues[SectionKey(key.OptionPath)] = value;
+        }
+    }
+
+    private static string? GetCompatibilityValue(IConfiguration configuration, ConfigurationKey key)
+        => configuration[key.CanonicalName] ?? configuration[key.LegacyName];
+
+    private static IEnumerable<string> DefaultDotEnvCandidatePaths()
+    {
+        yield return Path.Combine(Directory.GetCurrentDirectory(), ".env");
+        yield return Path.Combine(AppContext.BaseDirectory, ".env");
+    }
+
+    private static string SectionKey(string optionPath)
+        => $"{BeanBotSettings.SectionName}:{optionPath}";
+
+    private static string TrimMatchingQuotes(string value)
+    {
+        if (value.Length < 2)
+        {
+            return value;
+        }
+
+        var hasMatchingDoubleQuotes = value[0] == '"' && value[^1] == '"';
+        var hasMatchingSingleQuotes = value[0] == '\'' && value[^1] == '\'';
+        return hasMatchingDoubleQuotes || hasMatchingSingleQuotes
+            ? value.Substring(1, value.Length - 2)
+            : value;
+    }
+
+    private sealed record ConfigurationKey(
+        string CanonicalName,
+        string LegacyName,
+        string OptionPath);
 }

--- a/BeanBot/Configuration/BeanBotOptions.cs
+++ b/BeanBot/Configuration/BeanBotOptions.cs
@@ -1,62 +1,60 @@
-using System;
 using System.Net;
 
-namespace BeanBot.Configuration
+namespace BeanBot.Configuration;
+
+public sealed class BeanBotOptions
 {
-    public sealed class BeanBotOptions
+    public BeanBotOptions(
+        string botToken,
+        string mongoConnectionString,
+        ulong generalChannelId,
+        Uri hatoeteImageUrl,
+        Uri yoshimaruImageUrl,
+        HealthCheckOptions healthCheck)
     {
-        public BeanBotOptions(
-            string botToken,
-            string mongoConnectionString,
-            ulong generalChannelId,
-            Uri hatoeteImageUrl,
-            Uri yoshimaruImageUrl,
-            HealthCheckOptions healthCheck)
-        {
-            BotToken = botToken;
-            MongoConnectionString = mongoConnectionString;
-            GeneralChannelId = generalChannelId;
-            HatoeteImageUrl = hatoeteImageUrl;
-            YoshimaruImageUrl = yoshimaruImageUrl;
-            HealthCheck = healthCheck;
-        }
-
-        public string BotToken { get; }
-        public string MongoConnectionString { get; }
-        public ulong GeneralChannelId { get; }
-        public Uri HatoeteImageUrl { get; }
-        public Uri YoshimaruImageUrl { get; }
-        public HealthCheckOptions HealthCheck { get; }
+        BotToken = botToken;
+        MongoConnectionString = mongoConnectionString;
+        GeneralChannelId = generalChannelId;
+        HatoeteImageUrl = hatoeteImageUrl;
+        YoshimaruImageUrl = yoshimaruImageUrl;
+        HealthCheck = healthCheck;
     }
 
-    public sealed class HealthCheckOptions
+    public string BotToken { get; }
+    public string MongoConnectionString { get; }
+    public ulong GeneralChannelId { get; }
+    public Uri HatoeteImageUrl { get; }
+    public Uri YoshimaruImageUrl { get; }
+    public HealthCheckOptions HealthCheck { get; }
+}
+
+public sealed class HealthCheckOptions
+{
+    public HealthCheckOptions(
+        bool enabled,
+        IPAddress bindAddress,
+        int port,
+        string? bearerToken,
+        TimeSpan minimumPollInterval)
     {
-        public HealthCheckOptions(
-            bool enabled,
-            IPAddress bindAddress,
-            int port,
-            string? bearerToken,
-            TimeSpan minimumPollInterval)
-        {
-            Enabled = enabled;
-            BindAddress = bindAddress;
-            Port = port;
-            BearerToken = bearerToken;
-            MinimumPollInterval = minimumPollInterval;
-        }
-
-        public bool Enabled { get; }
-        public IPAddress BindAddress { get; }
-        public int Port { get; }
-        public string Path { get; } = "/healthz";
-        public string? BearerToken { get; }
-        public TimeSpan MinimumPollInterval { get; }
-
-        public static HealthCheckOptions Disabled { get; } = new HealthCheckOptions(
-            false,
-            IPAddress.Loopback,
-            0,
-            null,
-            TimeSpan.FromSeconds(90));
+        Enabled = enabled;
+        BindAddress = bindAddress;
+        Port = port;
+        BearerToken = bearerToken;
+        MinimumPollInterval = minimumPollInterval;
     }
+
+    public bool Enabled { get; }
+    public IPAddress BindAddress { get; }
+    public int Port { get; }
+    public string Path { get; } = "/healthz";
+    public string? BearerToken { get; }
+    public TimeSpan MinimumPollInterval { get; }
+
+    public static HealthCheckOptions Disabled { get; } = new HealthCheckOptions(
+        false,
+        IPAddress.Loopback,
+        0,
+        null,
+        TimeSpan.FromSeconds(90));
 }

--- a/BeanBot/Configuration/BeanBotOptionsFactory.cs
+++ b/BeanBot/Configuration/BeanBotOptionsFactory.cs
@@ -1,46 +1,44 @@
-using System;
 using System.Globalization;
 using System.Net;
 
-namespace BeanBot.Configuration
+namespace BeanBot.Configuration;
+
+internal static class BeanBotOptionsFactory
 {
-    internal static class BeanBotOptionsFactory
+    internal static BeanBotOptions Create(BeanBotSettings settings)
     {
-        internal static BeanBotOptions Create(BeanBotSettings settings)
-        {
-            ArgumentNullException.ThrowIfNull(settings);
+        ArgumentNullException.ThrowIfNull(settings);
 
-            return new BeanBotOptions(
-                settings.BotToken!,
-                settings.MongoConnectionString!,
-                ulong.Parse(settings.GeneralChannelId!, NumberStyles.None, CultureInfo.InvariantCulture),
-                new Uri(settings.HatoeteUrl!, UriKind.Absolute),
-                new Uri(settings.YoshimaruUrl!, UriKind.Absolute),
-                CreateHealthCheckOptions(settings.HealthCheck));
+        return new BeanBotOptions(
+            settings.BotToken!,
+            settings.MongoConnectionString!,
+            ulong.Parse(settings.GeneralChannelId!, NumberStyles.None, CultureInfo.InvariantCulture),
+            new Uri(settings.HatoeteUrl!, UriKind.Absolute),
+            new Uri(settings.YoshimaruUrl!, UriKind.Absolute),
+            CreateHealthCheckOptions(settings.HealthCheck));
+    }
+
+    private static HealthCheckOptions CreateHealthCheckOptions(BeanBotHealthCheckSettings settings)
+    {
+        if (string.IsNullOrWhiteSpace(settings.Port))
+        {
+            return HealthCheckOptions.Disabled;
         }
 
-        private static HealthCheckOptions CreateHealthCheckOptions(BeanBotHealthCheckSettings settings)
-        {
-            if (string.IsNullOrWhiteSpace(settings.Port))
-            {
-                return HealthCheckOptions.Disabled;
-            }
+        var bindAddress = string.IsNullOrWhiteSpace(settings.BindAddress)
+            ? IPAddress.Any
+            : IPAddress.Parse(settings.BindAddress);
+        var port = int.Parse(settings.Port, NumberStyles.None, CultureInfo.InvariantCulture);
+        var rateLimitSeconds = string.IsNullOrWhiteSpace(settings.RateLimitSeconds)
+            ? 90
+            : int.Parse(settings.RateLimitSeconds, NumberStyles.None, CultureInfo.InvariantCulture);
+        var minimumPollInterval = TimeSpan.FromSeconds(rateLimitSeconds);
 
-            var bindAddress = string.IsNullOrWhiteSpace(settings.BindAddress)
-                ? IPAddress.Any
-                : IPAddress.Parse(settings.BindAddress);
-            var port = int.Parse(settings.Port, NumberStyles.None, CultureInfo.InvariantCulture);
-            var rateLimitSeconds = string.IsNullOrWhiteSpace(settings.RateLimitSeconds)
-                ? 90
-                : int.Parse(settings.RateLimitSeconds, NumberStyles.None, CultureInfo.InvariantCulture);
-            var minimumPollInterval = TimeSpan.FromSeconds(rateLimitSeconds);
-
-            return new HealthCheckOptions(
-                true,
-                bindAddress,
-                port,
-                settings.BearerToken,
-                minimumPollInterval);
-        }
+        return new HealthCheckOptions(
+            true,
+            bindAddress,
+            port,
+            settings.BearerToken,
+            minimumPollInterval);
     }
 }

--- a/BeanBot/Configuration/BeanBotSettings.cs
+++ b/BeanBot/Configuration/BeanBotSettings.cs
@@ -1,22 +1,21 @@
-namespace BeanBot.Configuration
+namespace BeanBot.Configuration;
+
+internal sealed class BeanBotSettings
 {
-    internal sealed class BeanBotSettings
-    {
-        internal const string SectionName = "BeanBot";
+    internal const string SectionName = "BeanBot";
 
-        public string? BotToken { get; set; }
-        public string? MongoConnectionString { get; set; }
-        public string? GeneralChannelId { get; set; }
-        public string? HatoeteUrl { get; set; }
-        public string? YoshimaruUrl { get; set; }
-        public BeanBotHealthCheckSettings HealthCheck { get; set; } = new BeanBotHealthCheckSettings();
-    }
+    public string? BotToken { get; set; }
+    public string? MongoConnectionString { get; set; }
+    public string? GeneralChannelId { get; set; }
+    public string? HatoeteUrl { get; set; }
+    public string? YoshimaruUrl { get; set; }
+    public BeanBotHealthCheckSettings HealthCheck { get; set; } = new BeanBotHealthCheckSettings();
+}
 
-    internal sealed class BeanBotHealthCheckSettings
-    {
-        public string? Port { get; set; }
-        public string? BindAddress { get; set; }
-        public string? BearerToken { get; set; }
-        public string? RateLimitSeconds { get; set; }
-    }
+internal sealed class BeanBotHealthCheckSettings
+{
+    public string? Port { get; set; }
+    public string? BindAddress { get; set; }
+    public string? BearerToken { get; set; }
+    public string? RateLimitSeconds { get; set; }
 }

--- a/BeanBot/Configuration/BeanBotSettingsValidator.cs
+++ b/BeanBot/Configuration/BeanBotSettingsValidator.cs
@@ -1,132 +1,128 @@
-using Microsoft.Extensions.Options;
-
-using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Net;
+using Microsoft.Extensions.Options;
 
-namespace BeanBot.Configuration
+namespace BeanBot.Configuration;
+
+internal sealed class BeanBotSettingsValidator : IValidateOptions<BeanBotSettings>
 {
-    internal sealed class BeanBotSettingsValidator : IValidateOptions<BeanBotSettings>
+    public ValidateOptionsResult Validate(string? name, BeanBotSettings settings)
     {
-        public ValidateOptionsResult Validate(string? name, BeanBotSettings settings)
+        ArgumentNullException.ThrowIfNull(settings);
+
+        var failures = new List<string>();
+        Require(settings.BotToken, BeanBotConfiguration.BotTokenVariable, "botToken", failures);
+        Require(
+            settings.MongoConnectionString,
+            BeanBotConfiguration.MongoConnectionVariable,
+            "mongoConnectionString",
+            failures);
+
+        if (string.IsNullOrWhiteSpace(settings.GeneralChannelId))
         {
-            ArgumentNullException.ThrowIfNull(settings);
+            failures.Add(Missing(BeanBotConfiguration.GeneralChannelVariable, "generalChannelId"));
+        }
+        else if (!ulong.TryParse(
+            settings.GeneralChannelId,
+            NumberStyles.None,
+            CultureInfo.InvariantCulture,
+            out _))
+        {
+            failures.Add(
+                $"Invalid value for {BeanBotConfiguration.GeneralChannelVariable}. " +
+                "Expected a Discord snowflake ID.");
+        }
 
-            var failures = new List<string>();
-            Require(settings.BotToken, BeanBotConfiguration.BotTokenVariable, "botToken", failures);
-            Require(
-                settings.MongoConnectionString,
-                BeanBotConfiguration.MongoConnectionVariable,
-                "mongoConnectionString",
-                failures);
+        ValidateHttpUri(
+            settings.HatoeteUrl,
+            BeanBotConfiguration.HatoeteUrlVariable,
+            "hatoeteUrl",
+            failures);
+        ValidateHttpUri(
+            settings.YoshimaruUrl,
+            BeanBotConfiguration.YoshimaruUrlVariable,
+            "yoshimaruUrl",
+            failures);
 
-            if (string.IsNullOrWhiteSpace(settings.GeneralChannelId))
-            {
-                failures.Add(Missing(BeanBotConfiguration.GeneralChannelVariable, "generalChannelId"));
-            }
-            else if (!ulong.TryParse(
-                settings.GeneralChannelId,
+        ValidateHealthCheck(settings.HealthCheck, failures);
+
+        return failures.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+
+    private static void ValidateHealthCheck(
+        BeanBotHealthCheckSettings settings,
+        List<string> failures)
+    {
+        if (string.IsNullOrWhiteSpace(settings.Port))
+        {
+            return;
+        }
+
+        if (!int.TryParse(settings.Port, NumberStyles.None, CultureInfo.InvariantCulture, out var port) ||
+            port < IPEndPoint.MinPort ||
+            port > IPEndPoint.MaxPort)
+        {
+            failures.Add(
+                $"Invalid value for {BeanBotConfiguration.HealthCheckPortVariable}. " +
+                "Expected a TCP port from 0 through 65535.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.BindAddress) &&
+            !IPAddress.TryParse(settings.BindAddress, out _))
+        {
+            failures.Add(
+                $"Invalid value for {BeanBotConfiguration.HealthCheckBindAddressVariable}. " +
+                "Expected an IP address such as 0.0.0.0 or 127.0.0.1.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.RateLimitSeconds) &&
+            (!int.TryParse(
+                settings.RateLimitSeconds,
                 NumberStyles.None,
                 CultureInfo.InvariantCulture,
-                out _))
-            {
-                failures.Add(
-                    $"Invalid value for {BeanBotConfiguration.GeneralChannelVariable}. " +
-                    "Expected a Discord snowflake ID.");
-            }
-
-            ValidateHttpUri(
-                settings.HatoeteUrl,
-                BeanBotConfiguration.HatoeteUrlVariable,
-                "hatoeteUrl",
-                failures);
-            ValidateHttpUri(
-                settings.YoshimaruUrl,
-                BeanBotConfiguration.YoshimaruUrlVariable,
-                "yoshimaruUrl",
-                failures);
-
-            ValidateHealthCheck(settings.HealthCheck, failures);
-
-            return failures.Count == 0
-                ? ValidateOptionsResult.Success
-                : ValidateOptionsResult.Fail(failures);
-        }
-
-        private static void ValidateHealthCheck(
-            BeanBotHealthCheckSettings settings,
-            List<string> failures)
+                out var rateLimitSeconds) ||
+             rateLimitSeconds <= 0))
         {
-            if (string.IsNullOrWhiteSpace(settings.Port))
-            {
-                return;
-            }
-
-            if (!int.TryParse(settings.Port, NumberStyles.None, CultureInfo.InvariantCulture, out var port) ||
-                port < IPEndPoint.MinPort ||
-                port > IPEndPoint.MaxPort)
-            {
-                failures.Add(
-                    $"Invalid value for {BeanBotConfiguration.HealthCheckPortVariable}. " +
-                    "Expected a TCP port from 0 through 65535.");
-            }
-
-            if (!string.IsNullOrWhiteSpace(settings.BindAddress) &&
-                !IPAddress.TryParse(settings.BindAddress, out _))
-            {
-                failures.Add(
-                    $"Invalid value for {BeanBotConfiguration.HealthCheckBindAddressVariable}. " +
-                    "Expected an IP address such as 0.0.0.0 or 127.0.0.1.");
-            }
-
-            if (!string.IsNullOrWhiteSpace(settings.RateLimitSeconds) &&
-                (!int.TryParse(
-                    settings.RateLimitSeconds,
-                    NumberStyles.None,
-                    CultureInfo.InvariantCulture,
-                    out var rateLimitSeconds) ||
-                 rateLimitSeconds <= 0))
-            {
-                failures.Add(
-                    $"Invalid value for {BeanBotConfiguration.HealthCheckRateLimitVariable}. " +
-                    "Expected a positive number of seconds.");
-            }
+            failures.Add(
+                $"Invalid value for {BeanBotConfiguration.HealthCheckRateLimitVariable}. " +
+                "Expected a positive number of seconds.");
         }
-
-        private static void ValidateHttpUri(
-            string? value,
-            string variableName,
-            string legacyName,
-            List<string> failures)
-        {
-            if (string.IsNullOrWhiteSpace(value))
-            {
-                failures.Add(Missing(variableName, legacyName));
-                return;
-            }
-
-            if (!Uri.TryCreate(value, UriKind.Absolute, out var uri) ||
-                (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
-            {
-                failures.Add(
-                    $"Invalid value for {variableName}. Expected an absolute HTTP or HTTPS URL.");
-            }
-        }
-
-        private static void Require(
-            string? value,
-            string variableName,
-            string legacyName,
-            List<string> failures)
-        {
-            if (string.IsNullOrWhiteSpace(value))
-            {
-                failures.Add(Missing(variableName, legacyName));
-            }
-        }
-
-        private static string Missing(string variableName, string legacyName)
-            => $"Missing required environment variable: {variableName} (or legacy {legacyName}).";
     }
+
+    private static void ValidateHttpUri(
+        string? value,
+        string variableName,
+        string legacyName,
+        List<string> failures)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            failures.Add(Missing(variableName, legacyName));
+            return;
+        }
+
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            failures.Add(
+                $"Invalid value for {variableName}. Expected an absolute HTTP or HTTPS URL.");
+        }
+    }
+
+    private static void Require(
+        string? value,
+        string variableName,
+        string legacyName,
+        List<string> failures)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            failures.Add(Missing(variableName, legacyName));
+        }
+    }
+
+    private static string Missing(string variableName, string legacyName)
+        => $"Missing required environment variable: {variableName} (or legacy {legacyName}).";
 }

--- a/BeanBot/Entities/Pun.cs
+++ b/BeanBot/Entities/Pun.cs
@@ -1,7 +1,6 @@
-﻿namespace BeanBot.Entities
+﻿namespace BeanBot.Entities;
+
+public class Pun
 {
-    public class Pun
-    {
-        public string BadPost { get; set; } = string.Empty;
-    }
+    public string BadPost { get; set; } = string.Empty;
 }

--- a/BeanBot/Entities/RoleEmotePair.cs
+++ b/BeanBot/Entities/RoleEmotePair.cs
@@ -1,37 +1,34 @@
-﻿using MongoDB.Bson.Serialization.Attributes;
+﻿using System.Text.Json.Serialization;
+using MongoDB.Bson.Serialization.Attributes;
 
-using System;
-using System.Text.Json.Serialization;
+namespace BeanBot.Entities;
 
-namespace BeanBot.Entities
+public class RoleEmotePair
 {
-    public class RoleEmotePair
+    private string _roleId = string.Empty;
+    private string _emojiId = string.Empty;
+
+    [BsonElement("roleId")]
+    [JsonPropertyName("roleId")]
+    public string RoleId
     {
-        private string _roleId = string.Empty;
-        private string _emojiId = string.Empty;
+        get => _roleId;
+        init => _roleId = value ?? string.Empty;
+    }
 
-        [BsonElement("roleId")]
-        [JsonPropertyName("roleId")]
-        public string RoleId
-        {
-            get => _roleId;
-            init => _roleId = value ?? string.Empty;
-        }
+    [BsonElement("emojiId")]
+    [JsonPropertyName("emojiId")]
+    public string EmojiId
+    {
+        get => _emojiId;
+        init => _emojiId = value ?? string.Empty;
+    }
 
-        [BsonElement("emojiId")]
-        [JsonPropertyName("emojiId")]
-        public string EmojiId
-        {
-            get => _emojiId;
-            init => _emojiId = value ?? string.Empty;
-        }
+    public RoleEmotePair() { }
 
-        public RoleEmotePair() { }
-
-        public RoleEmotePair(string roleId, string emojiId)
-        {
-            RoleId = roleId ?? throw new ArgumentNullException(nameof(roleId));
-            EmojiId = emojiId ?? throw new ArgumentNullException(nameof(emojiId));
-        }
+    public RoleEmotePair(string roleId, string emojiId)
+    {
+        RoleId = roleId ?? throw new ArgumentNullException(nameof(roleId));
+        EmojiId = emojiId ?? throw new ArgumentNullException(nameof(emojiId));
     }
 }

--- a/BeanBot/Entities/RoleSettings.cs
+++ b/BeanBot/Entities/RoleSettings.cs
@@ -1,82 +1,78 @@
-﻿using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
-using System;
-using System.Collections.Generic;
-using System.Text.Json;
+﻿using System.Text.Json;
 using System.Text.Json.Serialization;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
 
-namespace BeanBot.Entities
+namespace BeanBot.Entities;
+
+public class RoleSettings
 {
-    public class RoleSettings
+    private static readonly JsonSerializerOptions JsonOptions = new()
     {
-        private static readonly JsonSerializerOptions JsonOptions = new()
-        {
-            WriteIndented = true
-        };
-        private List<RoleEmotePair> _roleEmotePairs = new();
-        private string _guildId = string.Empty;
-        private string _channelId = string.Empty;
-        private string _messageId = string.Empty;
+        WriteIndented = true
+    };
+    private List<RoleEmotePair> _roleEmotePairs = [];
+    private string _guildId = string.Empty;
+    private string _channelId = string.Empty;
+    private string _messageId = string.Empty;
 
-        [BsonId]
-        [JsonPropertyName("id")]
-        public ObjectId Id { get; init; }
+    [BsonId]
+    [JsonPropertyName("id")]
+    public ObjectId Id { get; init; }
 
-        [BsonElement("roleEmotePair")]
-        [JsonPropertyName("roleEmotePair")]
-        public List<RoleEmotePair> RoleEmotePairs
-        {
-            get => _roleEmotePairs;
-            init => _roleEmotePairs = value ?? new List<RoleEmotePair>();
-        }
+    [BsonElement("roleEmotePair")]
+    [JsonPropertyName("roleEmotePair")]
+    public List<RoleEmotePair> RoleEmotePairs
+    {
+        get => _roleEmotePairs;
+        init => _roleEmotePairs = value ?? [];
+    }
 
-        [BsonElement("guildId")]
-        [JsonPropertyName("guildId")]
-        public string GuildId
-        {
-            get => _guildId;
-            init => _guildId = value ?? string.Empty;
-        }
+    [BsonElement("guildId")]
+    [JsonPropertyName("guildId")]
+    public string GuildId
+    {
+        get => _guildId;
+        init => _guildId = value ?? string.Empty;
+    }
 
-        [BsonElement("channelId")]
-        [JsonPropertyName("channelId")]
-        public string ChannelId
-        {
-            get => _channelId;
-            init => _channelId = value ?? string.Empty;
-        }
+    [BsonElement("channelId")]
+    [JsonPropertyName("channelId")]
+    public string ChannelId
+    {
+        get => _channelId;
+        init => _channelId = value ?? string.Empty;
+    }
 
-        [BsonElement("messageId")]
-        [JsonPropertyName("messageId")]
-        public string MessageId
-        {
-            get => _messageId;
-            init => _messageId = value ?? string.Empty;
-        }
+    [BsonElement("messageId")]
+    [JsonPropertyName("messageId")]
+    public string MessageId
+    {
+        get => _messageId;
+        init => _messageId = value ?? string.Empty;
+    }
 
-        [BsonElement("lastAccessed")]
-        [BsonDateTimeOptions(Kind = DateTimeKind.Utc)]
-        [JsonPropertyName("lastAccessed")]
-        public DateTime LastAccessedUtc { get; internal set; }
+    [BsonElement("lastAccessed")]
+    [BsonDateTimeOptions(Kind = DateTimeKind.Utc)]
+    [JsonPropertyName("lastAccessed")]
+    public DateTime LastAccessedUtc { get; internal set; }
 
-        public RoleSettings() { }
+    public RoleSettings() { }
 
-        public RoleSettings(
-            List<RoleEmotePair> roleEmotePairs,
-            string guildId,
-            string channelId,
-            string messageId)
-        {
-            RoleEmotePairs = new List<RoleEmotePair>(
-                roleEmotePairs ?? throw new ArgumentNullException(nameof(roleEmotePairs)));
-            GuildId = guildId ?? throw new ArgumentNullException(nameof(guildId));
-            ChannelId = channelId ?? throw new ArgumentNullException(nameof(channelId));
-            MessageId = messageId ?? throw new ArgumentNullException(nameof(messageId));
-        }
+    public RoleSettings(
+        List<RoleEmotePair> roleEmotePairs,
+        string guildId,
+        string channelId,
+        string messageId)
+    {
+        RoleEmotePairs = [.. roleEmotePairs ?? throw new ArgumentNullException(nameof(roleEmotePairs))];
+        GuildId = guildId ?? throw new ArgumentNullException(nameof(guildId));
+        ChannelId = channelId ?? throw new ArgumentNullException(nameof(channelId));
+        MessageId = messageId ?? throw new ArgumentNullException(nameof(messageId));
+    }
 
-        public override string ToString()
-        {
-            return JsonSerializer.Serialize(this, JsonOptions);
-        }
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonOptions);
     }
 }

--- a/BeanBot/EventHandlers/CommandHandler.cs
+++ b/BeanBot/EventHandlers/CommandHandler.cs
@@ -1,112 +1,106 @@
-﻿using BeanBot.Services;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using BeanBot.Services;
 using BeanBot.Util;
-
 using Discord.Commands;
 using Discord.WebSocket;
-
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
-using System.Threading.Tasks;
+namespace BeanBot.EventHandlers;
 
-namespace BeanBot.EventHandlers
+public sealed class CommandHandler : IDisposable
 {
-    public sealed class CommandHandler : IDisposable
+    private readonly DiscordSocketClient _discordClient;
+    private readonly CommandService _commandService;
+    private readonly IServiceProvider _services;
+    private readonly FortuneAnswerStore _fortuneAnswers;
+    private readonly DiscordMessageWaiter _messageWaiter;
+    private readonly LogHandler _logHandler;
+    private readonly ILogger<CommandHandler> _logger;
+    private bool _initialized;
+
+    public CommandHandler(
+        DiscordSocketClient discordClient,
+        CommandService commandService,
+        IServiceProvider services,
+        LogHandler logHandler,
+        ILogger<CommandHandler> logger)
     {
-        private readonly DiscordSocketClient _discordClient;
-        private readonly CommandService _commandService;
-        private readonly IServiceProvider _services;
-        private readonly FortuneAnswerStore _fortuneAnswers;
-        private readonly DiscordMessageWaiter _messageWaiter;
-        private readonly LogHandler _logHandler;
-        private readonly ILogger<CommandHandler> _logger;
-        private bool _initialized;
+        _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
+        _commandService = commandService ?? throw new ArgumentNullException(nameof(commandService));
+        _services = services ?? throw new ArgumentNullException(nameof(services));
+        _logHandler = logHandler ?? throw new ArgumentNullException(nameof(logHandler));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _fortuneAnswers = _services.GetRequiredService<FortuneAnswerStore>();
+        _messageWaiter = _services.GetRequiredService<DiscordMessageWaiter>();
+        BeanBotLog.CommandHandlerCreated(_logger);
+    }
 
-        public CommandHandler(
-            DiscordSocketClient discordClient,
-            CommandService commandService,
-            IServiceProvider services,
-            LogHandler logHandler,
-            ILogger<CommandHandler> logger)
+    public async Task InitializeCommandsAsync()
+    {
+        if (_initialized)
         {
-            _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
-            _commandService = commandService ?? throw new ArgumentNullException(nameof(commandService));
-            _services = services ?? throw new ArgumentNullException(nameof(services));
-            _logHandler = logHandler ?? throw new ArgumentNullException(nameof(logHandler));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _fortuneAnswers = _services.GetRequiredService<FortuneAnswerStore>();
-            _messageWaiter = _services.GetRequiredService<DiscordMessageWaiter>();
-            BeanBotLog.CommandHandlerCreated(_logger);
+            return;
         }
 
-        public async Task InitializeCommandsAsync()
+        BeanBotLog.CommandsInstalling(_logger);
+        _discordClient.MessageReceived += HandleCommandAsync;
+        _commandService.CommandExecuted += _logHandler.LogCommands;
+        await _commandService.AddModulesAsync(assembly: Assembly.GetEntryAssembly() ?? typeof(CommandHandler).Assembly,
+                                              services: _services);
+        _initialized = true;
+    }
+
+    public void Dispose()
+    {
+        if (_initialized)
         {
-            if (_initialized)
-            {
-                return;
-            }
-
-            BeanBotLog.CommandsInstalling(_logger);
-            _discordClient.MessageReceived += HandleCommandAsync;
-            _commandService.CommandExecuted += _logHandler.LogCommands;
-            await _commandService.AddModulesAsync(assembly: Assembly.GetEntryAssembly() ?? typeof(CommandHandler).Assembly,
-                                                  services: _services);
-            _initialized = true;
+            _discordClient.MessageReceived -= HandleCommandAsync;
+            _commandService.CommandExecuted -= _logHandler.LogCommands;
+            _initialized = false;
         }
-
-        public void Dispose()
-        {
-            if (_initialized)
-            {
-                _discordClient.MessageReceived -= HandleCommandAsync;
-                _commandService.CommandExecuted -= _logHandler.LogCommands;
-                _initialized = false;
-            }
-
-        }
-
-        internal async Task HandleCommandAsync(SocketMessage messageEvent)
-        {
-            _messageWaiter.TryPublish(messageEvent);
-            var discordMessage = messageEvent as SocketUserMessage;
-            if (MessageIsSystemMessage(discordMessage))
-            {
-                return; //Return and ignore if the message is a discord system message
-            }
-
-            int argPos = 0;
-            if (discordMessage.Author.Id == BotOwner.DiscordUserId &&
-                discordMessage.Content.Contains("queue8", StringComparison.OrdinalIgnoreCase))
-            {
-                _fortuneAnswers.Queue(
-                    discordMessage.Author.Id,
-                    discordMessage.Content.Contains("yes", StringComparison.OrdinalIgnoreCase));
-            }
-            if (!MessageHasCommandPrefix(discordMessage, ref argPos) ||
-                messageEvent.Author.IsBot)
-            {
-                return; //Return and ignore if the discord message does not have the command prefixes or if the author of the message is a bot
-            }
-
-            var context = new SocketCommandContext(_discordClient, discordMessage);
-            await _commandService.ExecuteAsync(
-                context: context,
-                argPos: argPos,
-                services: _services);
-        }
-
-        internal bool MessageHasCommandPrefix(SocketUserMessage discordMessage, ref int argPos)
-        {
-            return (discordMessage.HasStringPrefix("succ ", ref argPos, StringComparison.OrdinalIgnoreCase) ||
-                            discordMessage.HasMentionPrefix(_discordClient.CurrentUser, ref argPos) ||
-                            discordMessage.HasCharPrefix('%', ref argPos));
-        }
-
-        internal static bool MessageIsSystemMessage([NotNullWhen(false)] SocketUserMessage? discordMessage)
-            => discordMessage == null;
 
     }
+
+    internal async Task HandleCommandAsync(SocketMessage messageEvent)
+    {
+        _messageWaiter.TryPublish(messageEvent);
+        var discordMessage = messageEvent as SocketUserMessage;
+        if (MessageIsSystemMessage(discordMessage))
+        {
+            return; //Return and ignore if the message is a discord system message
+        }
+
+        int argPos = 0;
+        if (discordMessage.Author.Id == BotOwner.DiscordUserId &&
+            discordMessage.Content.Contains("queue8", StringComparison.OrdinalIgnoreCase))
+        {
+            _fortuneAnswers.Queue(
+                discordMessage.Author.Id,
+                discordMessage.Content.Contains("yes", StringComparison.OrdinalIgnoreCase));
+        }
+        if (!MessageHasCommandPrefix(discordMessage, ref argPos) ||
+            messageEvent.Author.IsBot)
+        {
+            return; //Return and ignore if the discord message does not have the command prefixes or if the author of the message is a bot
+        }
+
+        var context = new SocketCommandContext(_discordClient, discordMessage);
+        await _commandService.ExecuteAsync(
+            context: context,
+            argPos: argPos,
+            services: _services);
+    }
+
+    internal bool MessageHasCommandPrefix(SocketUserMessage discordMessage, ref int argPos)
+    {
+        return (discordMessage.HasStringPrefix("succ ", ref argPos, StringComparison.OrdinalIgnoreCase) ||
+                        discordMessage.HasMentionPrefix(_discordClient.CurrentUser, ref argPos) ||
+                        discordMessage.HasCharPrefix('%', ref argPos));
+    }
+
+    internal static bool MessageIsSystemMessage([NotNullWhen(false)] SocketUserMessage? discordMessage)
+        => discordMessage == null;
+
 }

--- a/BeanBot/EventHandlers/EditMessageHandler.cs
+++ b/BeanBot/EventHandlers/EditMessageHandler.cs
@@ -1,43 +1,41 @@
 using BeanBot.Services;
 using Discord.WebSocket;
-using System;
 
-namespace BeanBot.EventHandlers
+namespace BeanBot.EventHandlers;
+
+public sealed class EditMessageHandler : IDisposable
 {
-    public sealed class EditMessageHandler : IDisposable
+    private readonly DiscordSocketClient _discordClient;
+    private readonly EditMessageEventServices _editMessageEventService;
+    private bool _initialized;
+
+    public EditMessageHandler(
+        DiscordSocketClient discordClient,
+        EditMessageEventServices editMessageEventService)
     {
-        private readonly DiscordSocketClient _discordClient;
-        private readonly EditMessageEventServices _editMessageEventService;
-        private bool _initialized;
+        _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
+        _editMessageEventService = editMessageEventService ?? throw new ArgumentNullException(nameof(editMessageEventService));
+    }
 
-        public EditMessageHandler(
-            DiscordSocketClient discordClient,
-            EditMessageEventServices editMessageEventService)
+    public void InitializeEventListener()
+    {
+        if (_initialized)
         {
-            _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
-            _editMessageEventService = editMessageEventService ?? throw new ArgumentNullException(nameof(editMessageEventService));
+            return;
         }
 
-        public void InitializeEventListener()
-        {
-            if (_initialized)
-            {
-                return;
-            }
+        _discordClient.MessageUpdated += _editMessageEventService.HandleUpdate;
+        _initialized = true;
+    }
 
-            _discordClient.MessageUpdated += _editMessageEventService.HandleUpdate;
-            _initialized = true;
+    public void Dispose()
+    {
+        if (!_initialized)
+        {
+            return;
         }
 
-        public void Dispose()
-        {
-            if (!_initialized)
-            {
-                return;
-            }
-
-            _discordClient.MessageUpdated -= _editMessageEventService.HandleUpdate;
-            _initialized = false;
-        }
+        _discordClient.MessageUpdated -= _editMessageEventService.HandleUpdate;
+        _initialized = false;
     }
 }

--- a/BeanBot/EventHandlers/NewMemberHandler.cs
+++ b/BeanBot/EventHandlers/NewMemberHandler.cs
@@ -1,70 +1,67 @@
 using BeanBot.Util;
 using Discord.WebSocket;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Threading.Tasks;
 
-namespace BeanBot.EventHandlers
+namespace BeanBot.EventHandlers;
+
+internal sealed class NewMemberHandler : IDisposable
 {
-    internal sealed class NewMemberHandler : IDisposable
+    private readonly DiscordSocketClient _discordClient;
+    private readonly LogHandler _logHandler;
+    private readonly ILogger<NewMemberHandler> _logger;
+    private bool _initialized;
+
+    public NewMemberHandler(
+        DiscordSocketClient client,
+        LogHandler logHandler,
+        ILogger<NewMemberHandler> logger)
     {
-        private readonly DiscordSocketClient _discordClient;
-        private readonly LogHandler _logHandler;
-        private readonly ILogger<NewMemberHandler> _logger;
-        private bool _initialized;
+        _discordClient = client ?? throw new ArgumentNullException(nameof(client));
+        _logHandler = logHandler ?? throw new ArgumentNullException(nameof(logHandler));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
 
-        public NewMemberHandler(
-            DiscordSocketClient client,
-            LogHandler logHandler,
-            ILogger<NewMemberHandler> logger)
+    public void InitializeNewMembers()
+    {
+        if (_initialized)
         {
-            _discordClient = client ?? throw new ArgumentNullException(nameof(client));
-            _logHandler = logHandler ?? throw new ArgumentNullException(nameof(logHandler));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            return;
         }
 
-        public void InitializeNewMembers()
-        {
-            if (_initialized)
-            {
-                return;
-            }
+        BeanBotLog.NewMemberHandlerInitializing(_logger);
+        _discordClient.UserJoined += WelcomeNewMemberAsync;
+        _discordClient.UserJoined += _logHandler.LogNewMember;
+        _initialized = true;
+    }
 
-            BeanBotLog.NewMemberHandlerInitializing(_logger);
-            _discordClient.UserJoined += WelcomeNewMemberAsync;
-            _discordClient.UserJoined += _logHandler.LogNewMember;
-            _initialized = true;
+    private async Task WelcomeNewMemberAsync(SocketGuildUser user)
+    {
+        if (user.IsBot)
+        {
+            return;
         }
 
-        private async Task WelcomeNewMemberAsync(SocketGuildUser user)
+        try
         {
-            if (user.IsBot)
-            {
-                return;
-            }
+            var userDmChannel = await user.CreateDMChannelAsync();
+            await userDmChannel.SendMessageAsync("Please read the rules in the Eli's Charter channel. If you agree to these rules and are over the age of 17, please DM one of the moderators with the blue role \"Student Council\" (i.e discount Hatate/Makoto Kikuchi#2351) for full access to the server! (I promise it's worth it)");
+            BeanBotLog.WelcomeMessageSent(_logger, user.Id);
+        }
+        catch (Exception exception)
+        {
+            BeanBotLog.WelcomeMessageFailed(_logger, user.Id, exception);
+        }
+    }
 
-            try
-            {
-                var userDmChannel = await user.CreateDMChannelAsync();
-                await userDmChannel.SendMessageAsync("Please read the rules in the Eli's Charter channel. If you agree to these rules and are over the age of 17, please DM one of the moderators with the blue role \"Student Council\" (i.e discount Hatate/Makoto Kikuchi#2351) for full access to the server! (I promise it's worth it)");
-                BeanBotLog.WelcomeMessageSent(_logger, user.Id);
-            }
-            catch (Exception exception)
-            {
-                BeanBotLog.WelcomeMessageFailed(_logger, user.Id, exception);
-            }
+    public void Dispose()
+    {
+        if (!_initialized)
+        {
+            return;
         }
 
-        public void Dispose()
-        {
-            if (!_initialized)
-            {
-                return;
-            }
-
-            _discordClient.UserJoined -= WelcomeNewMemberAsync;
-            _discordClient.UserJoined -= _logHandler.LogNewMember;
-            _initialized = false;
-        }
+        _discordClient.UserJoined -= WelcomeNewMemberAsync;
+        _discordClient.UserJoined -= _logHandler.LogNewMember;
+        _initialized = false;
     }
 }

--- a/BeanBot/EventHandlers/PunHandler.cs
+++ b/BeanBot/EventHandlers/PunHandler.cs
@@ -1,211 +1,205 @@
-﻿using BeanBot.Entities;
+﻿using System.Globalization;
+using System.Security.Cryptography;
 using BeanBot.Configuration;
+using BeanBot.Entities;
 using BeanBot.Util;
 using CsvHelper;
 using Discord.WebSocket;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Security.Cryptography;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace BeanBot.EventHandlers
+namespace BeanBot.EventHandlers;
+
+public sealed class PunHandler : IAsyncDisposable
 {
-    public sealed class PunHandler : IAsyncDisposable
+    private readonly DiscordSocketClient _discordClient;
+    private readonly ulong _generalChannelId;
+    private readonly ILogger<PunHandler> _logger;
+    private readonly CancellationTokenSource _tokenSource = new();
+    private Task? _runner;
+    private int _disposed;
+
+    private static readonly TimeSpan PostTimeLocal = new(16, 20, 0);
+
+    public PunHandler(
+        DiscordSocketClient discordSocketClient,
+        BeanBotOptions options,
+        ILogger<PunHandler> logger)
     {
-        private readonly DiscordSocketClient _discordClient;
-        private readonly ulong _generalChannelId;
-        private readonly ILogger<PunHandler> _logger;
-        private readonly CancellationTokenSource _tokenSource = new();
-        private Task? _runner;
-        private int _disposed;
+        _discordClient = discordSocketClient ?? throw new ArgumentNullException(nameof(discordSocketClient));
+        _generalChannelId = (options ?? throw new ArgumentNullException(nameof(options))).GeneralChannelId;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        BeanBotLog.PunServiceInitializing(_logger);
+    }
 
-        private static readonly TimeSpan PostTimeLocal = new TimeSpan(16, 20, 0);
+    public void Start()
+    {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
 
-        public PunHandler(
-            DiscordSocketClient discordSocketClient,
-            BeanBotOptions options,
-            ILogger<PunHandler> logger)
+        if (_runner is not null)
         {
-            _discordClient = discordSocketClient ?? throw new ArgumentNullException(nameof(discordSocketClient));
-            _generalChannelId = (options ?? throw new ArgumentNullException(nameof(options))).GeneralChannelId;
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            BeanBotLog.PunServiceInitializing(_logger);
+            throw new InvalidOperationException("The daily pun service has already been started.");
         }
 
-        public void Start()
+        _runner = Task.Run(() => RunAsync(_tokenSource.Token));
+    }
+
+    private async Task RunAsync(CancellationToken token)
+    {
+        var timezone = GetChicagoTimeZone();
+
+        while (!token.IsCancellationRequested)
         {
-            ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
-
-            if (_runner is not null)
-            {
-                throw new InvalidOperationException("The daily pun service has already been started.");
-            }
-
-            _runner = Task.Run(() => RunAsync(_tokenSource.Token));
-        }
-
-        private async Task RunAsync(CancellationToken token)
-        {
-            var timezone = GetChicagoTimeZone();
-
-            while (!token.IsCancellationRequested)
-            {
-                try
-                {
-                    var nextRunUtc = ComputeNextOccurenceUtc(timezone, PostTimeLocal);
-                    var delay = nextRunUtc - DateTimeOffset.UtcNow;
-                    if (delay < TimeSpan.Zero)
-                    {
-                        delay = TimeSpan.Zero;
-                    }
-
-                    var chicagoNow = GetChicagoNow(timezone);
-                    if (_logger.IsEnabled(LogLevel.Information))
-                    {
-                        var nextLocal = TimeZoneInfo.ConvertTime(nextRunUtc, timezone)
-                            .ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
-                        var nextUtc = nextRunUtc.UtcDateTime
-                            .ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
-                        var nowLocal = chicagoNow.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
-                        BeanBotLog.PunScheduled(
-                            _logger,
-                            nextLocal,
-                            nextUtc,
-                            nowLocal);
-                    }
-
-                    await Task.Delay(delay, token);
-
-                    await PostDailyAsync(timezone, token);
-                }
-                catch (OperationCanceledException)
-                {
-                    BeanBotLog.PunServiceShuttingDown(_logger);
-                }
-                catch (Exception ex)
-                {
-                    BeanBotLog.PunLoopFailed(_logger, ex);
-                    await Task.Delay(TimeSpan.FromSeconds(30), token);
-                }
-            }
-        }
-
-        private async Task PostDailyAsync(TimeZoneInfo timezone, CancellationToken token)
-        {
-            var chicagoNow = GetChicagoNow(timezone);
-            BeanBotLog.PunPosting(_logger, chicagoNow);
-
-            var channel = _discordClient.GetChannel(_generalChannelId) as SocketTextChannel;
-            if (channel is null)
-            {
-                BeanBotLog.PunChannelMissing(_logger, _generalChannelId);
-                return;
-            }
-
-            await channel.SendMessageAsync("The time has come and so have I, Bean Bot here to deliver you your daily pun(?)");
-            await channel.SendMessageAsync("<:420stolfoit:675553715759087618>");
-
             try
             {
-                using var reader = new StreamReader("Resources/puns.csv");
-                using var punCsv = new CsvReader(reader, CultureInfo.InvariantCulture);
-                var puns = punCsv.GetRecords<Pun>()
-                    .Where(pun => !string.IsNullOrEmpty(pun.BadPost))
-                    .ToList();
-
-                if (puns.Count == 0)
+                var nextRunUtc = ComputeNextOccurenceUtc(timezone, PostTimeLocal);
+                var delay = nextRunUtc - DateTimeOffset.UtcNow;
+                if (delay < TimeSpan.Zero)
                 {
-                    BeanBotLog.PunFileEmpty(_logger);
-                    return;
+                    delay = TimeSpan.Zero;
                 }
 
-                var randomIndex = RandomNumberGenerator.GetInt32(0, puns.Count);
-                var randomPun = puns[randomIndex];
+                var chicagoNow = GetChicagoNow(timezone);
+                if (_logger.IsEnabled(LogLevel.Information))
+                {
+                    var nextLocal = TimeZoneInfo.ConvertTime(nextRunUtc, timezone)
+                        .ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+                    var nextUtc = nextRunUtc.UtcDateTime
+                        .ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+                    var nowLocal = chicagoNow.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+                    BeanBotLog.PunScheduled(
+                        _logger,
+                        nextLocal,
+                        nextUtc,
+                        nowLocal);
+                }
 
-                await channel.SendMessageAsync(randomPun.BadPost);
+                await Task.Delay(delay, token);
+
+                await PostDailyAsync(timezone, token);
             }
-            catch (FileNotFoundException)
+            catch (OperationCanceledException)
             {
-                BeanBotLog.PunFileMissing(_logger);
+                BeanBotLog.PunServiceShuttingDown(_logger);
             }
             catch (Exception ex)
             {
-                BeanBotLog.PunPostingFailed(_logger, ex);
+                BeanBotLog.PunLoopFailed(_logger, ex);
+                await Task.Delay(TimeSpan.FromSeconds(30), token);
             }
         }
+    }
 
-        private static TimeZoneInfo GetChicagoTimeZone()
+    private async Task PostDailyAsync(TimeZoneInfo timezone, CancellationToken token)
+    {
+        var chicagoNow = GetChicagoNow(timezone);
+        BeanBotLog.PunPosting(_logger, chicagoNow);
+
+        var channel = _discordClient.GetChannel(_generalChannelId) as SocketTextChannel;
+        if (channel is null)
         {
-            try
-            {
-                // If on Linux or MacOS
-                return TimeZoneInfo.FindSystemTimeZoneById("America/Chicago");
-            }
-            catch (TimeZoneNotFoundException)
-            {
-                // If on Windows
-                return TimeZoneInfo.FindSystemTimeZoneById("Central Standard Time");
-            }
+            BeanBotLog.PunChannelMissing(_logger, _generalChannelId);
+            return;
         }
 
-        private static DateTimeOffset GetChicagoNow(TimeZoneInfo timezone)
-            => TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, timezone);
+        await channel.SendMessageAsync("The time has come and so have I, Bean Bot here to deliver you your daily pun(?)");
+        await channel.SendMessageAsync("<:420stolfoit:675553715759087618>");
 
-
-        private static DateTimeOffset ComputeNextOccurenceUtc(TimeZoneInfo timezone, TimeSpan localTime)
+        try
         {
-            var currentChicagoTime = GetChicagoNow(timezone);
-            var tentativeNextPostTime = new DateTime(
-                currentChicagoTime.Year,
-                currentChicagoTime.Month,
-                currentChicagoTime.Day,
-                localTime.Hours,
-                localTime.Minutes,
-                localTime.Seconds,
-                DateTimeKind.Unspecified
-            );
+            using var reader = new StreamReader("Resources/puns.csv");
+            using var punCsv = new CsvReader(reader, CultureInfo.InvariantCulture);
+            var puns = punCsv.GetRecords<Pun>()
+                .Where(pun => !string.IsNullOrEmpty(pun.BadPost))
+                .ToList();
 
-            if (currentChicagoTime.TimeOfDay >= localTime)
+            if (puns.Count == 0)
             {
-                tentativeNextPostTime = tentativeNextPostTime.AddDays(1);
-            }
-
-            if (timezone.IsInvalidTime(tentativeNextPostTime))
-            {
-                tentativeNextPostTime = tentativeNextPostTime.AddHours(1);
-            }
-            else if (timezone.IsAmbiguousTime(tentativeNextPostTime))
-            {
-                return new DateTimeOffset(tentativeNextPostTime, timezone.GetAmbiguousTimeOffsets(tentativeNextPostTime)[0]);
-            }
-
-            var utc = TimeZoneInfo.ConvertTimeToUtc(tentativeNextPostTime, timezone);
-
-            return new DateTimeOffset(utc, TimeSpan.Zero);
-        }
-
-
-        public async ValueTask DisposeAsync()
-        {
-            if (Interlocked.Exchange(ref _disposed, 1) != 0)
-            {
+                BeanBotLog.PunFileEmpty(_logger);
                 return;
             }
 
-            try
-            {
-                _tokenSource.Cancel();
-                if (_runner is not null)
-                {
-                    await _runner.ConfigureAwait(false);
-                }
-            }
-            catch (OperationCanceledException) { }
-            _tokenSource.Dispose();
+            var randomIndex = RandomNumberGenerator.GetInt32(0, puns.Count);
+            var randomPun = puns[randomIndex];
+
+            await channel.SendMessageAsync(randomPun.BadPost);
         }
+        catch (FileNotFoundException)
+        {
+            BeanBotLog.PunFileMissing(_logger);
+        }
+        catch (Exception ex)
+        {
+            BeanBotLog.PunPostingFailed(_logger, ex);
+        }
+    }
+
+    private static TimeZoneInfo GetChicagoTimeZone()
+    {
+        try
+        {
+            // If on Linux or MacOS
+            return TimeZoneInfo.FindSystemTimeZoneById("America/Chicago");
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            // If on Windows
+            return TimeZoneInfo.FindSystemTimeZoneById("Central Standard Time");
+        }
+    }
+
+    private static DateTimeOffset GetChicagoNow(TimeZoneInfo timezone)
+        => TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, timezone);
+
+
+    private static DateTimeOffset ComputeNextOccurenceUtc(TimeZoneInfo timezone, TimeSpan localTime)
+    {
+        var currentChicagoTime = GetChicagoNow(timezone);
+        var tentativeNextPostTime = new DateTime(
+            currentChicagoTime.Year,
+            currentChicagoTime.Month,
+            currentChicagoTime.Day,
+            localTime.Hours,
+            localTime.Minutes,
+            localTime.Seconds,
+            DateTimeKind.Unspecified
+        );
+
+        if (currentChicagoTime.TimeOfDay >= localTime)
+        {
+            tentativeNextPostTime = tentativeNextPostTime.AddDays(1);
+        }
+
+        if (timezone.IsInvalidTime(tentativeNextPostTime))
+        {
+            tentativeNextPostTime = tentativeNextPostTime.AddHours(1);
+        }
+        else if (timezone.IsAmbiguousTime(tentativeNextPostTime))
+        {
+            return new DateTimeOffset(tentativeNextPostTime, timezone.GetAmbiguousTimeOffsets(tentativeNextPostTime)[0]);
+        }
+
+        var utc = TimeZoneInfo.ConvertTimeToUtc(tentativeNextPostTime, timezone);
+
+        return new DateTimeOffset(utc, TimeSpan.Zero);
+    }
+
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            _tokenSource.Cancel();
+            if (_runner is not null)
+            {
+                await _runner.ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) { }
+        _tokenSource.Dispose();
     }
 }

--- a/BeanBot/EventHandlers/ReactHandler.cs
+++ b/BeanBot/EventHandlers/ReactHandler.cs
@@ -2,51 +2,49 @@ using BeanBot.Services;
 using BeanBot.Util;
 using Discord.WebSocket;
 using Microsoft.Extensions.Logging;
-using System;
 
-namespace BeanBot.EventHandlers
+namespace BeanBot.EventHandlers;
+
+public sealed class ReactHandler : IDisposable
 {
-    public sealed class ReactHandler : IDisposable
+    private readonly DiscordSocketClient _discordClient;
+    private readonly RoleReactService _roleService;
+    private readonly ILogger<ReactHandler> _logger;
+    private bool _initialized;
+
+    public ReactHandler(
+        DiscordSocketClient discordClient,
+        RoleReactService roleReactService,
+        ILogger<ReactHandler> logger)
     {
-        private readonly DiscordSocketClient _discordClient;
-        private readonly RoleReactService _roleService;
-        private readonly ILogger<ReactHandler> _logger;
-        private bool _initialized;
+        _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
+        _roleService = roleReactService ?? throw new ArgumentNullException(nameof(roleReactService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        BeanBotLog.ReactHandlerCreated(_logger);
+    }
 
-        public ReactHandler(
-            DiscordSocketClient discordClient,
-            RoleReactService roleReactService,
-            ILogger<ReactHandler> logger)
+    public void InitializeReactDependentServices()
+    {
+        if (_initialized)
         {
-            _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
-            _roleService = roleReactService ?? throw new ArgumentNullException(nameof(roleReactService));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            BeanBotLog.ReactHandlerCreated(_logger);
+            return;
         }
 
-        public void InitializeReactDependentServices()
-        {
-            if (_initialized)
-            {
-                return;
-            }
+        BeanBotLog.RoleServicesCreated(_logger);
+        _discordClient.ReactionAdded += _roleService.HandleReact;
+        _discordClient.ReactionRemoved += _roleService.HandleRemoveReact;
+        _initialized = true;
+    }
 
-            BeanBotLog.RoleServicesCreated(_logger);
-            _discordClient.ReactionAdded += _roleService.HandleReact;
-            _discordClient.ReactionRemoved += _roleService.HandleRemoveReact;
-            _initialized = true;
+    public void Dispose()
+    {
+        if (!_initialized)
+        {
+            return;
         }
 
-        public void Dispose()
-        {
-            if (!_initialized)
-            {
-                return;
-            }
-
-            _discordClient.ReactionAdded -= _roleService.HandleReact;
-            _discordClient.ReactionRemoved -= _roleService.HandleRemoveReact;
-            _initialized = false;
-        }
+        _discordClient.ReactionAdded -= _roleService.HandleReact;
+        _discordClient.ReactionRemoved -= _roleService.HandleRemoveReact;
+        _initialized = false;
     }
 }

--- a/BeanBot/Hosting/BeanBotApplication.cs
+++ b/BeanBot/Hosting/BeanBotApplication.cs
@@ -1,84 +1,79 @@
 using BeanBot.Util;
 using Microsoft.Extensions.Logging;
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
+namespace BeanBot.Hosting;
 
-namespace BeanBot.Hosting
+internal interface IBeanBotRuntime
 {
-    internal interface IBeanBotRuntime
+    bool HasUnfinishedDiscordStartupOperation { get; }
+    void SubscribeApplicationEvents();
+    Task StartHealthServerAsync(CancellationToken cancellationToken);
+    Task StartDiscordAsync(CancellationToken cancellationToken);
+    void StartGatewayRecovery();
+    Task StartCommandServicesAsync();
+    void StartEventAndBackgroundServices();
+    void StopEventAndCommandServices();
+    Task StopGatewayRecoveryAsync();
+    void UnsubscribeApplicationEvents();
+    Task StopBackgroundServicesAsync(CancellationToken cancellationToken);
+    Task FlushOwnerAlertsAsync();
+    Task StopDiscordAsync(CancellationToken cancellationToken);
+    void DisposeDiscordClient();
+}
+
+internal sealed class BeanBotApplication : IBeanBotApplication
+{
+    private readonly IBeanBotRuntime _runtime;
+    private readonly ILogger<BeanBotApplication> _logger;
+    private int _startRequested;
+    private int _stopRequested;
+
+    public BeanBotApplication(
+        IBeanBotRuntime runtime,
+        ILogger<BeanBotApplication> logger)
     {
-        bool HasUnfinishedDiscordStartupOperation { get; }
-        void SubscribeApplicationEvents();
-        Task StartHealthServerAsync(CancellationToken cancellationToken);
-        Task StartDiscordAsync(CancellationToken cancellationToken);
-        void StartGatewayRecovery();
-        Task StartCommandServicesAsync();
-        void StartEventAndBackgroundServices();
-        void StopEventAndCommandServices();
-        Task StopGatewayRecoveryAsync();
-        void UnsubscribeApplicationEvents();
-        Task StopBackgroundServicesAsync(CancellationToken cancellationToken);
-        Task FlushOwnerAlertsAsync();
-        Task StopDiscordAsync(CancellationToken cancellationToken);
-        void DisposeDiscordClient();
+        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    internal sealed class BeanBotApplication : IBeanBotApplication
+    public async Task StartAsync(CancellationToken cancellationToken)
     {
-        private readonly IBeanBotRuntime _runtime;
-        private readonly ILogger<BeanBotApplication> _logger;
-        private int _startRequested;
-        private int _stopRequested;
-
-        public BeanBotApplication(
-            IBeanBotRuntime runtime,
-            ILogger<BeanBotApplication> logger)
+        if (Interlocked.Exchange(ref _startRequested, 1) != 0)
         {
-            _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            return;
         }
 
-        public async Task StartAsync(CancellationToken cancellationToken)
-        {
-            if (Interlocked.Exchange(ref _startRequested, 1) != 0)
-            {
-                return;
-            }
+        _runtime.SubscribeApplicationEvents();
+        await _runtime.StartHealthServerAsync(cancellationToken);
+        await _runtime.StartDiscordAsync(cancellationToken);
+        _runtime.StartGatewayRecovery();
+        await _runtime.StartCommandServicesAsync();
+        _runtime.StartEventAndBackgroundServices();
+    }
 
-            _runtime.SubscribeApplicationEvents();
-            await _runtime.StartHealthServerAsync(cancellationToken);
-            await _runtime.StartDiscordAsync(cancellationToken);
-            _runtime.StartGatewayRecovery();
-            await _runtime.StartCommandServicesAsync();
-            _runtime.StartEventAndBackgroundServices();
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (Interlocked.Exchange(ref _stopRequested, 1) != 0)
+        {
+            return;
         }
 
-        public async Task StopAsync(CancellationToken cancellationToken)
+        _runtime.StopEventAndCommandServices();
+        await _runtime.StopGatewayRecoveryAsync();
+        _runtime.UnsubscribeApplicationEvents();
+        await _runtime.StopBackgroundServicesAsync(cancellationToken);
+
+        await _runtime.FlushOwnerAlertsAsync();
+        if (_runtime.HasUnfinishedDiscordStartupOperation)
         {
-            if (Interlocked.Exchange(ref _stopRequested, 1) != 0)
-            {
-                return;
-            }
-
-            _runtime.StopEventAndCommandServices();
-            await _runtime.StopGatewayRecoveryAsync();
-            _runtime.UnsubscribeApplicationEvents();
-            await _runtime.StopBackgroundServicesAsync(cancellationToken);
-
-            await _runtime.FlushOwnerAlertsAsync();
-            if (_runtime.HasUnfinishedDiscordStartupOperation)
-            {
-                BeanBotLog.DiscordStopSkipped(_logger);
-            }
-            else
-            {
-                await _runtime.StopDiscordAsync(cancellationToken);
-                _runtime.DisposeDiscordClient();
-            }
-
-            await _runtime.FlushOwnerAlertsAsync();
+            BeanBotLog.DiscordStopSkipped(_logger);
         }
+        else
+        {
+            await _runtime.StopDiscordAsync(cancellationToken);
+            _runtime.DisposeDiscordClient();
+        }
+
+        await _runtime.FlushOwnerAlertsAsync();
     }
 }

--- a/BeanBot/Hosting/BeanBotHostedService.cs
+++ b/BeanBot/Hosting/BeanBotHostedService.cs
@@ -2,59 +2,54 @@ using BeanBot.Util;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
+namespace BeanBot.Hosting;
 
-namespace BeanBot.Hosting
+internal interface IBeanBotApplication
 {
-    internal interface IBeanBotApplication
+    Task StartAsync(CancellationToken cancellationToken);
+    Task StopAsync(CancellationToken cancellationToken);
+}
+
+internal sealed class BeanBotHostedService : IHostedService
+{
+    private readonly IBeanBotApplication _application;
+    private readonly IHostApplicationLifetime _hostLifetime;
+    private readonly ILogger<BeanBotHostedService> _logger;
+
+    public BeanBotHostedService(
+        IBeanBotApplication application,
+        IHostApplicationLifetime hostLifetime,
+        ILogger<BeanBotHostedService> logger)
     {
-        Task StartAsync(CancellationToken cancellationToken);
-        Task StopAsync(CancellationToken cancellationToken);
+        _application = application ?? throw new ArgumentNullException(nameof(application));
+        _hostLifetime = hostLifetime ?? throw new ArgumentNullException(nameof(hostLifetime));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    internal sealed class BeanBotHostedService : IHostedService
+    public async Task StartAsync(CancellationToken cancellationToken)
     {
-        private readonly IBeanBotApplication _application;
-        private readonly IHostApplicationLifetime _hostLifetime;
-        private readonly ILogger<BeanBotHostedService> _logger;
-
-        public BeanBotHostedService(
-            IBeanBotApplication application,
-            IHostApplicationLifetime hostLifetime,
-            ILogger<BeanBotHostedService> logger)
+        try
         {
-            _application = application ?? throw new ArgumentNullException(nameof(application));
-            _hostLifetime = hostLifetime ?? throw new ArgumentNullException(nameof(hostLifetime));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            using var startupCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken,
+                _hostLifetime.ApplicationStopping);
+            await _application.StartAsync(startupCancellation.Token);
         }
-
-        public async Task StartAsync(CancellationToken cancellationToken)
+        catch
         {
             try
             {
-                using var startupCancellation = CancellationTokenSource.CreateLinkedTokenSource(
-                    cancellationToken,
-                    _hostLifetime.ApplicationStopping);
-                await _application.StartAsync(startupCancellation.Token);
+                await _application.StopAsync(CancellationToken.None);
             }
-            catch
+            catch (Exception cleanupException)
             {
-                try
-                {
-                    await _application.StopAsync(CancellationToken.None);
-                }
-                catch (Exception cleanupException)
-                {
-                    BeanBotLog.StartupCleanupFailed(_logger, cleanupException);
-                }
-
-                throw;
+                BeanBotLog.StartupCleanupFailed(_logger, cleanupException);
             }
-        }
 
-        public Task StopAsync(CancellationToken cancellationToken)
-            => _application.StopAsync(cancellationToken);
+            throw;
+        }
     }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+        => _application.StopAsync(cancellationToken);
 }

--- a/BeanBot/Hosting/BeanBotRuntime.cs
+++ b/BeanBot/Hosting/BeanBotRuntime.cs
@@ -1,263 +1,256 @@
 using BeanBot.EventHandlers;
 using BeanBot.Services;
 using BeanBot.Util;
-
 using Discord.WebSocket;
-
 using Microsoft.Extensions.Logging;
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
+namespace BeanBot.Hosting;
 
-namespace BeanBot.Hosting
+internal sealed class BeanBotRuntime : IBeanBotRuntime
 {
-    internal sealed class BeanBotRuntime : IBeanBotRuntime
+    private readonly DiscordSocketClient _discordClient;
+    private readonly DiscordConnectionHealth _discordConnectionHealth;
+    private readonly DiscordGatewayRecoveryService _discordGatewayRecovery;
+    private readonly DiscordOutageRecoveryNotifier _discordOutageRecoveryNotifier;
+    private readonly DiscordStartupLifecycle _discordStartupLifecycle;
+    private readonly DiscordStartupService _discordStartupService;
+    private readonly DiscordOwnerErrorNotifier _ownerErrorNotifier;
+    private readonly HealthCheckServer _healthCheckServer;
+    private readonly CommandHandler _commandHandler;
+    private readonly PunHandler _punHandler;
+    private readonly EditMessageHandler _editMessageHandler;
+    private readonly NewMemberHandler _newMemberHandler;
+    private readonly ReactHandler _reactHandler;
+    private readonly DiscordMessageWaiter _messageWaiter;
+    private readonly DiscordPaginatorService _paginatorService;
+    private readonly LogHandler _logHandler;
+    private readonly ILogger<BeanBotRuntime> _logger;
+
+    public BeanBotRuntime(
+        DiscordSocketClient discordClient,
+        DiscordConnectionHealth discordConnectionHealth,
+        DiscordGatewayRecoveryService discordGatewayRecovery,
+        DiscordOutageRecoveryNotifier discordOutageRecoveryNotifier,
+        DiscordStartupLifecycle discordStartupLifecycle,
+        DiscordStartupService discordStartupService,
+        DiscordOwnerErrorNotifier ownerErrorNotifier,
+        HealthCheckServer healthCheckServer,
+        CommandHandler commandHandler,
+        PunHandler punHandler,
+        EditMessageHandler editMessageHandler,
+        NewMemberHandler newMemberHandler,
+        ReactHandler reactHandler,
+        DiscordMessageWaiter messageWaiter,
+        DiscordPaginatorService paginatorService,
+        LogHandler logHandler,
+        ILogger<BeanBotRuntime> logger)
     {
-        private readonly DiscordSocketClient _discordClient;
-        private readonly DiscordConnectionHealth _discordConnectionHealth;
-        private readonly DiscordGatewayRecoveryService _discordGatewayRecovery;
-        private readonly DiscordOutageRecoveryNotifier _discordOutageRecoveryNotifier;
-        private readonly DiscordStartupLifecycle _discordStartupLifecycle;
-        private readonly DiscordStartupService _discordStartupService;
-        private readonly DiscordOwnerErrorNotifier _ownerErrorNotifier;
-        private readonly HealthCheckServer _healthCheckServer;
-        private readonly CommandHandler _commandHandler;
-        private readonly PunHandler _punHandler;
-        private readonly EditMessageHandler _editMessageHandler;
-        private readonly NewMemberHandler _newMemberHandler;
-        private readonly ReactHandler _reactHandler;
-        private readonly DiscordMessageWaiter _messageWaiter;
-        private readonly DiscordPaginatorService _paginatorService;
-        private readonly LogHandler _logHandler;
-        private readonly ILogger<BeanBotRuntime> _logger;
+        _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
+        _discordConnectionHealth = discordConnectionHealth ?? throw new ArgumentNullException(nameof(discordConnectionHealth));
+        _discordGatewayRecovery = discordGatewayRecovery ?? throw new ArgumentNullException(nameof(discordGatewayRecovery));
+        _discordOutageRecoveryNotifier = discordOutageRecoveryNotifier ?? throw new ArgumentNullException(nameof(discordOutageRecoveryNotifier));
+        _discordStartupLifecycle = discordStartupLifecycle ?? throw new ArgumentNullException(nameof(discordStartupLifecycle));
+        _discordStartupService = discordStartupService ?? throw new ArgumentNullException(nameof(discordStartupService));
+        _ownerErrorNotifier = ownerErrorNotifier ?? throw new ArgumentNullException(nameof(ownerErrorNotifier));
+        _healthCheckServer = healthCheckServer ?? throw new ArgumentNullException(nameof(healthCheckServer));
+        _commandHandler = commandHandler ?? throw new ArgumentNullException(nameof(commandHandler));
+        _punHandler = punHandler ?? throw new ArgumentNullException(nameof(punHandler));
+        _editMessageHandler = editMessageHandler ?? throw new ArgumentNullException(nameof(editMessageHandler));
+        _newMemberHandler = newMemberHandler ?? throw new ArgumentNullException(nameof(newMemberHandler));
+        _reactHandler = reactHandler ?? throw new ArgumentNullException(nameof(reactHandler));
+        _messageWaiter = messageWaiter ?? throw new ArgumentNullException(nameof(messageWaiter));
+        _paginatorService = paginatorService ?? throw new ArgumentNullException(nameof(paginatorService));
+        _logHandler = logHandler ?? throw new ArgumentNullException(nameof(logHandler));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
 
-        public BeanBotRuntime(
-            DiscordSocketClient discordClient,
-            DiscordConnectionHealth discordConnectionHealth,
-            DiscordGatewayRecoveryService discordGatewayRecovery,
-            DiscordOutageRecoveryNotifier discordOutageRecoveryNotifier,
-            DiscordStartupLifecycle discordStartupLifecycle,
-            DiscordStartupService discordStartupService,
-            DiscordOwnerErrorNotifier ownerErrorNotifier,
-            HealthCheckServer healthCheckServer,
-            CommandHandler commandHandler,
-            PunHandler punHandler,
-            EditMessageHandler editMessageHandler,
-            NewMemberHandler newMemberHandler,
-            ReactHandler reactHandler,
-            DiscordMessageWaiter messageWaiter,
-            DiscordPaginatorService paginatorService,
-            LogHandler logHandler,
-            ILogger<BeanBotRuntime> logger)
+    public bool HasUnfinishedDiscordStartupOperation
+        => _discordStartupLifecycle.HasUnfinishedOperation;
+
+    public void SubscribeApplicationEvents()
+    {
+        AppDomain.CurrentDomain.UnhandledException += HandleUnhandledException;
+        TaskScheduler.UnobservedTaskException += HandleUnobservedTaskException;
+        _discordClient.Ready += OnDiscordReadyAsync;
+        _discordClient.Disconnected += OnDiscordDisconnectedAsync;
+    }
+
+    public Task StartHealthServerAsync(CancellationToken cancellationToken)
+        => _healthCheckServer.StartAsync(cancellationToken);
+
+    public Task StartDiscordAsync(CancellationToken cancellationToken)
+        => _discordStartupService.StartAsync(cancellationToken);
+
+    public void StartGatewayRecovery() => _discordGatewayRecovery.StartMonitoring();
+
+    public async Task StartCommandServicesAsync()
+    {
+        BeanBotLog.CommandServicesCreated(_logger);
+        await _commandHandler.InitializeCommandsAsync();
+    }
+
+    public void StartEventAndBackgroundServices()
+    {
+        _discordClient.Log += _logHandler.LogMessages;
+        _punHandler.Start();
+        _editMessageHandler.InitializeEventListener();
+        _newMemberHandler.InitializeNewMembers();
+        _reactHandler.InitializeReactDependentServices();
+    }
+
+    public void StopEventAndCommandServices()
+    {
+        _reactHandler.Dispose();
+        _newMemberHandler.Dispose();
+        _editMessageHandler.Dispose();
+        _commandHandler.Dispose();
+        _messageWaiter.Dispose();
+        _paginatorService.Dispose();
+        _discordClient.Log -= _logHandler.LogMessages;
+    }
+
+    public Task StopGatewayRecoveryAsync()
+        => _discordGatewayRecovery.DisposeAsync().AsTask();
+
+    public void UnsubscribeApplicationEvents()
+    {
+        _discordClient.Ready -= OnDiscordReadyAsync;
+        _discordClient.Disconnected -= OnDiscordDisconnectedAsync;
+        AppDomain.CurrentDomain.UnhandledException -= HandleUnhandledException;
+        TaskScheduler.UnobservedTaskException -= HandleUnobservedTaskException;
+    }
+
+    public async Task StopBackgroundServicesAsync(CancellationToken cancellationToken)
+    {
+        await _punHandler.DisposeAsync();
+        await _healthCheckServer.StopAsync(cancellationToken);
+    }
+
+    public Task FlushOwnerAlertsAsync()
+        => _ownerErrorNotifier.FlushAsync(TimeSpan.FromSeconds(3));
+
+    public async Task StopDiscordAsync(CancellationToken cancellationToken)
+    {
+        var operationTimeout = DiscordGatewayRecoveryOptions.Default.LifecycleOperationTimeout;
+        if (!await RunBoundedShutdownOperationAsync(
+            _discordClient.StopAsync,
+            "stop",
+            operationTimeout,
+            cancellationToken))
         {
-            _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
-            _discordConnectionHealth = discordConnectionHealth ?? throw new ArgumentNullException(nameof(discordConnectionHealth));
-            _discordGatewayRecovery = discordGatewayRecovery ?? throw new ArgumentNullException(nameof(discordGatewayRecovery));
-            _discordOutageRecoveryNotifier = discordOutageRecoveryNotifier ?? throw new ArgumentNullException(nameof(discordOutageRecoveryNotifier));
-            _discordStartupLifecycle = discordStartupLifecycle ?? throw new ArgumentNullException(nameof(discordStartupLifecycle));
-            _discordStartupService = discordStartupService ?? throw new ArgumentNullException(nameof(discordStartupService));
-            _ownerErrorNotifier = ownerErrorNotifier ?? throw new ArgumentNullException(nameof(ownerErrorNotifier));
-            _healthCheckServer = healthCheckServer ?? throw new ArgumentNullException(nameof(healthCheckServer));
-            _commandHandler = commandHandler ?? throw new ArgumentNullException(nameof(commandHandler));
-            _punHandler = punHandler ?? throw new ArgumentNullException(nameof(punHandler));
-            _editMessageHandler = editMessageHandler ?? throw new ArgumentNullException(nameof(editMessageHandler));
-            _newMemberHandler = newMemberHandler ?? throw new ArgumentNullException(nameof(newMemberHandler));
-            _reactHandler = reactHandler ?? throw new ArgumentNullException(nameof(reactHandler));
-            _messageWaiter = messageWaiter ?? throw new ArgumentNullException(nameof(messageWaiter));
-            _paginatorService = paginatorService ?? throw new ArgumentNullException(nameof(paginatorService));
-            _logHandler = logHandler ?? throw new ArgumentNullException(nameof(logHandler));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            return;
         }
 
-        public bool HasUnfinishedDiscordStartupOperation
-            => _discordStartupLifecycle.HasUnfinishedOperation;
+        await RunBoundedShutdownOperationAsync(
+            _discordClient.LogoutAsync,
+            "logout",
+            operationTimeout,
+            cancellationToken);
+    }
 
-        public void SubscribeApplicationEvents()
+    public void DisposeDiscordClient() => _discordClient.Dispose();
+
+    private async Task<bool> RunBoundedShutdownOperationAsync(
+        Func<Task> beginOperation,
+        string operationName,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
         {
-            AppDomain.CurrentDomain.UnhandledException += HandleUnhandledException;
-            TaskScheduler.UnobservedTaskException += HandleUnobservedTaskException;
-            _discordClient.Ready += OnDiscordReadyAsync;
-            _discordClient.Disconnected += OnDiscordDisconnectedAsync;
+            BeanBotLog.DiscordShutdownOperationSkipped(_logger, operationName);
+            return false;
         }
 
-        public Task StartHealthServerAsync(CancellationToken cancellationToken)
-            => _healthCheckServer.StartAsync(cancellationToken);
-
-        public Task StartDiscordAsync(CancellationToken cancellationToken)
-            => _discordStartupService.StartAsync(cancellationToken);
-
-        public void StartGatewayRecovery() => _discordGatewayRecovery.StartMonitoring();
-
-        public async Task StartCommandServicesAsync()
+        var operation = beginOperation();
+        try
         {
-            BeanBotLog.CommandServicesCreated(_logger);
-            await _commandHandler.InitializeCommandsAsync();
+            await operation.WaitAsync(timeout, cancellationToken);
+            return true;
         }
-
-        public void StartEventAndBackgroundServices()
+        catch (Exception exception)
         {
-            _discordClient.Log += _logHandler.LogMessages;
-            _punHandler.Start();
-            _editMessageHandler.InitializeEventListener();
-            _newMemberHandler.InitializeNewMembers();
-            _reactHandler.InitializeReactDependentServices();
-        }
-
-        public void StopEventAndCommandServices()
-        {
-            _reactHandler.Dispose();
-            _newMemberHandler.Dispose();
-            _editMessageHandler.Dispose();
-            _commandHandler.Dispose();
-            _messageWaiter.Dispose();
-            _paginatorService.Dispose();
-            _discordClient.Log -= _logHandler.LogMessages;
-        }
-
-        public Task StopGatewayRecoveryAsync()
-            => _discordGatewayRecovery.DisposeAsync().AsTask();
-
-        public void UnsubscribeApplicationEvents()
-        {
-            _discordClient.Ready -= OnDiscordReadyAsync;
-            _discordClient.Disconnected -= OnDiscordDisconnectedAsync;
-            AppDomain.CurrentDomain.UnhandledException -= HandleUnhandledException;
-            TaskScheduler.UnobservedTaskException -= HandleUnobservedTaskException;
-        }
-
-        public async Task StopBackgroundServicesAsync(CancellationToken cancellationToken)
-        {
-            await _punHandler.DisposeAsync();
-            await _healthCheckServer.StopAsync(cancellationToken);
-        }
-
-        public Task FlushOwnerAlertsAsync()
-            => _ownerErrorNotifier.FlushAsync(TimeSpan.FromSeconds(3));
-
-        public async Task StopDiscordAsync(CancellationToken cancellationToken)
-        {
-            var operationTimeout = DiscordGatewayRecoveryOptions.Default.LifecycleOperationTimeout;
-            if (!await RunBoundedShutdownOperationAsync(
-                _discordClient.StopAsync,
-                "stop",
-                operationTimeout,
-                cancellationToken))
+            if (!operation.IsCompleted)
             {
-                return;
+                _ = operation.ContinueWith(
+                    completedTask => BeanBotLog.DiscordShutdownLateFailure(
+                        _logger,
+                        operationName,
+                        completedTask.Exception),
+                    CancellationToken.None,
+                    TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
             }
 
-            await RunBoundedShutdownOperationAsync(
-                _discordClient.LogoutAsync,
-                "logout",
-                operationTimeout,
-                cancellationToken);
+            BeanBotLog.DiscordShutdownOperationFailed(_logger, operationName, exception);
+            return false;
         }
+    }
 
-        public void DisposeDiscordClient() => _discordClient.Dispose();
-
-        private async Task<bool> RunBoundedShutdownOperationAsync(
-            Func<Task> beginOperation,
-            string operationName,
-            TimeSpan timeout,
-            CancellationToken cancellationToken)
+    private async Task OnDiscordReadyAsync()
+    {
+        _discordConnectionHealth.MarkReady();
+        _discordGatewayRecovery.NotifyReady();
+        if (_logger.IsEnabled(LogLevel.Information))
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                BeanBotLog.DiscordShutdownOperationSkipped(_logger, operationName);
-                return false;
-            }
-
-            var operation = beginOperation();
-            try
-            {
-                await operation.WaitAsync(timeout, cancellationToken);
-                return true;
-            }
-            catch (Exception exception)
-            {
-                if (!operation.IsCompleted)
-                {
-                    _ = operation.ContinueWith(
-                        completedTask => BeanBotLog.DiscordShutdownLateFailure(
-                            _logger,
-                            operationName,
-                            completedTask.Exception),
-                        CancellationToken.None,
-                        TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
-                        TaskScheduler.Default);
-                }
-
-                BeanBotLog.DiscordShutdownOperationFailed(_logger, operationName, exception);
-                return false;
-            }
+            var loginState = _discordClient.LoginState;
+            var connectionState = _discordClient.ConnectionState;
+            BeanBotLog.DiscordReady(
+                _logger,
+                loginState,
+                connectionState);
         }
-
-        private async Task OnDiscordReadyAsync()
+        try
         {
-            _discordConnectionHealth.MarkReady();
-            _discordGatewayRecovery.NotifyReady();
-            if (_logger.IsEnabled(LogLevel.Information))
-            {
-                var loginState = _discordClient.LoginState;
-                var connectionState = _discordClient.ConnectionState;
-                BeanBotLog.DiscordReady(
-                    _logger,
-                    loginState,
-                    connectionState);
-            }
-            try
-            {
-                await _discordOutageRecoveryNotifier.NotifyIfOutageRecoveredAsync(DateTimeOffset.UtcNow);
-            }
-            catch (Exception exception)
-            {
-                BeanBotLog.OutageRecoveryProcessingFailed(_logger, exception);
-            }
+            await _discordOutageRecoveryNotifier.NotifyIfOutageRecoveredAsync(DateTimeOffset.UtcNow);
         }
-
-        private Task OnDiscordDisconnectedAsync(Exception? exception)
+        catch (Exception exception)
         {
-            _discordConnectionHealth.MarkDisconnected(exception);
-            var snapshot = _discordConnectionHealth.CreateSnapshot(_discordClient);
-            if (exception is null)
-            {
-                BeanBotLog.DiscordDisconnected(
-                    _logger,
-                    snapshot.LoginState,
-                    snapshot.ConnectionState,
-                    snapshot.MostRecentDisconnectReason);
-            }
-            else
-            {
-                BeanBotLog.DiscordDisconnected(
-                    _logger,
-                    snapshot.LoginState,
-                    snapshot.ConnectionState,
-                    snapshot.MostRecentDisconnectReason,
-                    exception);
-            }
-
-            _discordGatewayRecovery.StartMonitoring();
-            return Task.CompletedTask;
+            BeanBotLog.OutageRecoveryProcessingFailed(_logger, exception);
         }
+    }
 
-        private void HandleUnhandledException(object sender, UnhandledExceptionEventArgs eventArgs)
+    private Task OnDiscordDisconnectedAsync(Exception? exception)
+    {
+        _discordConnectionHealth.MarkDisconnected(exception);
+        var snapshot = _discordConnectionHealth.CreateSnapshot(_discordClient);
+        if (exception is null)
         {
-            if (eventArgs.ExceptionObject is Exception exception)
-            {
-                BeanBotLog.UnhandledApplicationException(_logger, exception);
-            }
-            else
-            {
-                BeanBotLog.UnhandledApplicationError(_logger, eventArgs.ExceptionObject);
-            }
+            BeanBotLog.DiscordDisconnected(
+                _logger,
+                snapshot.LoginState,
+                snapshot.ConnectionState,
+                snapshot.MostRecentDisconnectReason);
+        }
+        else
+        {
+            BeanBotLog.DiscordDisconnected(
+                _logger,
+                snapshot.LoginState,
+                snapshot.ConnectionState,
+                snapshot.MostRecentDisconnectReason,
+                exception);
         }
 
-        private void HandleUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs eventArgs)
+        _discordGatewayRecovery.StartMonitoring();
+        return Task.CompletedTask;
+    }
+
+    private void HandleUnhandledException(object sender, UnhandledExceptionEventArgs eventArgs)
+    {
+        if (eventArgs.ExceptionObject is Exception exception)
         {
-            BeanBotLog.UnobservedTaskException(_logger, eventArgs.Exception);
-            eventArgs.SetObserved();
+            BeanBotLog.UnhandledApplicationException(_logger, exception);
         }
+        else
+        {
+            BeanBotLog.UnhandledApplicationError(_logger, eventArgs.ExceptionObject);
+        }
+    }
+
+    private void HandleUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs eventArgs)
+    {
+        BeanBotLog.UnobservedTaskException(_logger, eventArgs.Exception);
+        eventArgs.SetObserved();
     }
 }

--- a/BeanBot/Hosting/BeanBotServiceCollectionExtensions.cs
+++ b/BeanBot/Hosting/BeanBotServiceCollectionExtensions.cs
@@ -3,143 +3,136 @@ using BeanBot.EventHandlers;
 using BeanBot.Repository;
 using BeanBot.Services;
 using BeanBot.Util;
-
 using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
-
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-
 using MongoDB.Driver;
 
-using System;
-using System.IO;
+namespace BeanBot.Hosting;
 
-namespace BeanBot.Hosting
+internal static class BeanBotServiceCollectionExtensions
 {
-    internal static class BeanBotServiceCollectionExtensions
+    internal static IServiceCollection AddBeanBot(
+        this IServiceCollection services,
+        IConfiguration configuration)
     {
-        internal static IServiceCollection AddBeanBot(
-            this IServiceCollection services,
-            IConfiguration configuration)
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        // Register the client as an existing singleton so the host container does not
+        // dispose it automatically. BeanBotApplication owns its conditional teardown
+        // because a timed-out Discord.Net startup operation may still be using it.
+        var discordClient = new DiscordSocketClient(DiscordSocketConfiguration.Create());
+        services.AddSingleton(discordClient);
+
+        services.AddSingleton<IValidateOptions<BeanBotSettings>, BeanBotSettingsValidator>();
+        services.AddOptions<BeanBotSettings>()
+            .Bind(configuration.GetSection(BeanBotSettings.SectionName))
+            .ValidateOnStart();
+        services.AddSingleton(provider => BeanBotOptionsFactory.Create(
+            provider.GetRequiredService<IOptions<BeanBotSettings>>().Value));
+        services.AddSingleton(_ => new CommandService(new CommandServiceConfig
         {
-            ArgumentNullException.ThrowIfNull(services);
-            ArgumentNullException.ThrowIfNull(configuration);
+            LogLevel = LogSeverity.Verbose,
+            CaseSensitiveCommands = false
+        }));
 
-            // Register the client as an existing singleton so the host container does not
-            // dispose it automatically. BeanBotApplication owns its conditional teardown
-            // because a timed-out Discord.Net startup operation may still be using it.
-            var discordClient = new DiscordSocketClient(DiscordSocketConfiguration.Create());
-            services.AddSingleton(discordClient);
+        services.AddSingleton<MongoClient>(provider =>
+            new MongoClient(provider.GetRequiredService<BeanBotOptions>().MongoConnectionString));
+        services.AddSingleton<IMongoDatabase>(provider =>
+            provider.GetRequiredService<MongoClient>().GetDatabase("BeanBotDB"));
 
-            services.AddSingleton<IValidateOptions<BeanBotSettings>, BeanBotSettingsValidator>();
-            services.AddOptions<BeanBotSettings>()
-                .Bind(configuration.GetSection(BeanBotSettings.SectionName))
-                .ValidateOnStart();
-            services.AddSingleton(provider => BeanBotOptionsFactory.Create(
-                provider.GetRequiredService<IOptions<BeanBotSettings>>().Value));
-            services.AddSingleton(_ => new CommandService(new CommandServiceConfig
-            {
-                LogLevel = LogSeverity.Verbose,
-                CaseSensitiveCommands = false
-            }));
-
-            services.AddSingleton<MongoClient>(provider =>
-                new MongoClient(provider.GetRequiredService<BeanBotOptions>().MongoConnectionString));
-            services.AddSingleton<IMongoDatabase>(provider =>
-                provider.GetRequiredService<MongoClient>().GetDatabase("BeanBotDB"));
-
-            services.AddSingleton<DiscordConnectionHealth>();
-            services.AddSingleton(DiscordStartupOptions.Default);
-            services.AddSingleton<DiscordStartupLifecycle>(provider =>
-            {
-                var options = provider.GetRequiredService<DiscordStartupOptions>();
-                return new DiscordStartupLifecycle(
-                    provider.GetRequiredService<DiscordSocketClient>(),
-                    provider.GetRequiredService<BeanBotOptions>().BotToken,
-                    options.LifecycleOperationTimeout,
-                    provider.GetRequiredService<ILogger<DiscordStartupLifecycle>>());
-            });
-            services.AddSingleton<IDiscordStartupLifecycle>(provider =>
-                provider.GetRequiredService<DiscordStartupLifecycle>());
-            services.AddSingleton<IDiscordStartupDelay, DiscordStartupDelay>();
-            services.AddSingleton<DiscordStartupService>();
-
-            services.AddSingleton(DiscordGatewayRecoveryOptions.Default);
-            services.AddSingleton<IDiscordGatewayLifecycle>(provider =>
-            {
-                var options = provider.GetRequiredService<DiscordGatewayRecoveryOptions>();
-                return new DiscordGatewayLifecycle(
-                    provider.GetRequiredService<DiscordSocketClient>(),
-                    provider.GetRequiredService<BeanBotOptions>().BotToken,
-                    options.LifecycleOperationTimeout,
-                    provider.GetRequiredService<ILogger<DiscordGatewayLifecycle>>());
-            });
-            services.AddSingleton<IRecoveryDelay, TaskRecoveryDelay>();
-
-            services.AddSingleton<DiscordOutageStore>(provider => new DiscordOutageStore(
-                Path.GetFullPath(DirectorySetup.botBaseDirectory),
-                provider.GetRequiredService<ILogger<DiscordOutageStore>>()));
-            services.AddSingleton<IDiscordOutageStore>(provider =>
-                provider.GetRequiredService<DiscordOutageStore>());
-
-            services.AddSingleton<DiscordOwnerAlertDelivery>();
-            services.AddSingleton<IOwnerAlertDelivery>(provider =>
-                provider.GetRequiredService<DiscordOwnerAlertDelivery>());
-            services.AddSingleton<DiscordOwnerErrorNotifier>(provider =>
-                new DiscordOwnerErrorNotifier(provider.GetRequiredService<IOwnerAlertDelivery>()));
-            services.AddSingleton<IOwnerErrorNotifier>(provider =>
-                provider.GetRequiredService<DiscordOwnerErrorNotifier>());
-            services.AddSingleton<DiscordOutageRecoveryNotifier>();
-            services.AddSingleton<LogHandler>();
-
-            services.AddSingleton<DiscordGatewayRecoveryService>(provider =>
-            {
-                var client = provider.GetRequiredService<DiscordSocketClient>();
-                var connectionHealth = provider.GetRequiredService<DiscordConnectionHealth>();
-                return new DiscordGatewayRecoveryService(
-                    () => connectionHealth.CreateSnapshot(client),
-                    provider.GetRequiredService<IDiscordGatewayLifecycle>(),
-                    provider.GetRequiredService<IDiscordOutageStore>(),
-                    provider.GetRequiredService<ILogger<DiscordGatewayRecoveryService>>(),
-                    provider.GetRequiredService<DiscordGatewayRecoveryOptions>(),
-                    provider.GetRequiredService<IRecoveryDelay>());
-            });
-
-            services.AddSingleton<FortuneAnswerStore>();
-            services.AddSingleton<DiscordMessageWaiter>();
-            services.AddSingleton<DiscordPaginatorService>();
-            services.AddSingleton<EditMessageEventServices>();
-            services.AddSingleton<RoleReactRepository>();
-            services.AddSingleton<RoleReactService>();
-            services.AddSingleton<DiscordMessageCleanupService>();
-
-            services.AddSingleton<CommandHandler>();
-            services.AddSingleton<PunHandler>();
-            services.AddSingleton<EditMessageHandler>();
-            services.AddSingleton<NewMemberHandler>();
-            services.AddSingleton<ReactHandler>();
-            services.AddSingleton<HealthCheckServer>(provider => new HealthCheckServer(
-                provider.GetRequiredService<BeanBotOptions>().HealthCheck,
+        services.AddSingleton<DiscordConnectionHealth>();
+        services.AddSingleton(DiscordStartupOptions.Default);
+        services.AddSingleton<DiscordStartupLifecycle>(provider =>
+        {
+            var options = provider.GetRequiredService<DiscordStartupOptions>();
+            return new DiscordStartupLifecycle(
                 provider.GetRequiredService<DiscordSocketClient>(),
-                provider.GetRequiredService<DiscordConnectionHealth>(),
-                provider.GetRequiredService<ILogger<HealthCheckServer>>()));
+                provider.GetRequiredService<BeanBotOptions>().BotToken,
+                options.LifecycleOperationTimeout,
+                provider.GetRequiredService<ILogger<DiscordStartupLifecycle>>());
+        });
+        services.AddSingleton<IDiscordStartupLifecycle>(provider =>
+            provider.GetRequiredService<DiscordStartupLifecycle>());
+        services.AddSingleton<IDiscordStartupDelay, DiscordStartupDelay>();
+        services.AddSingleton<DiscordStartupService>();
 
-            services.AddSingleton<BeanBotRuntime>();
-            services.AddSingleton<IBeanBotRuntime>(provider =>
-                provider.GetRequiredService<BeanBotRuntime>());
-            services.AddSingleton<BeanBotApplication>();
-            services.AddSingleton<IBeanBotApplication>(provider =>
-                provider.GetRequiredService<BeanBotApplication>());
-            services.AddSingleton<BeanBotHostedService>();
-            services.AddSingleton<IHostedService>(provider =>
-                provider.GetRequiredService<BeanBotHostedService>());
+        services.AddSingleton(DiscordGatewayRecoveryOptions.Default);
+        services.AddSingleton<IDiscordGatewayLifecycle>(provider =>
+        {
+            var options = provider.GetRequiredService<DiscordGatewayRecoveryOptions>();
+            return new DiscordGatewayLifecycle(
+                provider.GetRequiredService<DiscordSocketClient>(),
+                provider.GetRequiredService<BeanBotOptions>().BotToken,
+                options.LifecycleOperationTimeout,
+                provider.GetRequiredService<ILogger<DiscordGatewayLifecycle>>());
+        });
+        services.AddSingleton<IRecoveryDelay, TaskRecoveryDelay>();
 
-            return services;
-        }
+        services.AddSingleton<DiscordOutageStore>(provider => new DiscordOutageStore(
+            Path.GetFullPath(DirectorySetup.botBaseDirectory),
+            provider.GetRequiredService<ILogger<DiscordOutageStore>>()));
+        services.AddSingleton<IDiscordOutageStore>(provider =>
+            provider.GetRequiredService<DiscordOutageStore>());
+
+        services.AddSingleton<DiscordOwnerAlertDelivery>();
+        services.AddSingleton<IOwnerAlertDelivery>(provider =>
+            provider.GetRequiredService<DiscordOwnerAlertDelivery>());
+        services.AddSingleton<DiscordOwnerErrorNotifier>(provider =>
+            new DiscordOwnerErrorNotifier(provider.GetRequiredService<IOwnerAlertDelivery>()));
+        services.AddSingleton<IOwnerErrorNotifier>(provider =>
+            provider.GetRequiredService<DiscordOwnerErrorNotifier>());
+        services.AddSingleton<DiscordOutageRecoveryNotifier>();
+        services.AddSingleton<LogHandler>();
+
+        services.AddSingleton<DiscordGatewayRecoveryService>(provider =>
+        {
+            var client = provider.GetRequiredService<DiscordSocketClient>();
+            var connectionHealth = provider.GetRequiredService<DiscordConnectionHealth>();
+            return new DiscordGatewayRecoveryService(
+                () => connectionHealth.CreateSnapshot(client),
+                provider.GetRequiredService<IDiscordGatewayLifecycle>(),
+                provider.GetRequiredService<IDiscordOutageStore>(),
+                provider.GetRequiredService<ILogger<DiscordGatewayRecoveryService>>(),
+                provider.GetRequiredService<DiscordGatewayRecoveryOptions>(),
+                provider.GetRequiredService<IRecoveryDelay>());
+        });
+
+        services.AddSingleton<FortuneAnswerStore>();
+        services.AddSingleton<DiscordMessageWaiter>();
+        services.AddSingleton<DiscordPaginatorService>();
+        services.AddSingleton<EditMessageEventServices>();
+        services.AddSingleton<RoleReactRepository>();
+        services.AddSingleton<RoleReactService>();
+        services.AddSingleton<DiscordMessageCleanupService>();
+
+        services.AddSingleton<CommandHandler>();
+        services.AddSingleton<PunHandler>();
+        services.AddSingleton<EditMessageHandler>();
+        services.AddSingleton<NewMemberHandler>();
+        services.AddSingleton<ReactHandler>();
+        services.AddSingleton<HealthCheckServer>(provider => new HealthCheckServer(
+            provider.GetRequiredService<BeanBotOptions>().HealthCheck,
+            provider.GetRequiredService<DiscordSocketClient>(),
+            provider.GetRequiredService<DiscordConnectionHealth>(),
+            provider.GetRequiredService<ILogger<HealthCheckServer>>()));
+
+        services.AddSingleton<BeanBotRuntime>();
+        services.AddSingleton<IBeanBotRuntime>(provider =>
+            provider.GetRequiredService<BeanBotRuntime>());
+        services.AddSingleton<BeanBotApplication>();
+        services.AddSingleton<IBeanBotApplication>(provider =>
+            provider.GetRequiredService<BeanBotApplication>());
+        services.AddSingleton<BeanBotHostedService>();
+        services.AddSingleton<IHostedService>(provider =>
+            provider.GetRequiredService<BeanBotHostedService>());
+
+        return services;
     }
 }

--- a/BeanBot/Hosting/DiscordSocketConfiguration.cs
+++ b/BeanBot/Hosting/DiscordSocketConfiguration.cs
@@ -1,26 +1,25 @@
 using Discord;
 using Discord.WebSocket;
 
-namespace BeanBot.Hosting
+namespace BeanBot.Hosting;
+
+internal static class DiscordSocketConfiguration
 {
-    internal static class DiscordSocketConfiguration
+    internal static DiscordSocketConfig Create()
     {
-        internal static DiscordSocketConfig Create()
+        return new DiscordSocketConfig
         {
-            return new DiscordSocketConfig
-            {
-                LogLevel = LogSeverity.Verbose,
-                MessageCacheSize = 50,
-                AlwaysDownloadUsers = false,
-                GatewayIntents = GatewayIntents.Guilds
-                    | GatewayIntents.GuildMembers
-                    | GatewayIntents.GuildEmojis
-                    | GatewayIntents.GuildMessages
-                    | GatewayIntents.DirectMessages
-                    | GatewayIntents.GuildMessageReactions
-                    | GatewayIntents.DirectMessageReactions
-                    | GatewayIntents.MessageContent
-            };
-        }
+            LogLevel = LogSeverity.Verbose,
+            MessageCacheSize = 50,
+            AlwaysDownloadUsers = false,
+            GatewayIntents = GatewayIntents.Guilds
+                | GatewayIntents.GuildMembers
+                | GatewayIntents.GuildEmojis
+                | GatewayIntents.GuildMessages
+                | GatewayIntents.DirectMessages
+                | GatewayIntents.GuildMessageReactions
+                | GatewayIntents.DirectMessageReactions
+                | GatewayIntents.MessageContent
+        };
     }
 }

--- a/BeanBot/Modules/AdministrativeModule.cs
+++ b/BeanBot/Modules/AdministrativeModule.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using BeanBot.Attributes;
 using BeanBot.Entities;
 using BeanBot.Services;
@@ -6,286 +7,280 @@ using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Threading.Tasks;
 
-namespace BeanBot.Modules
+namespace BeanBot.Modules;
+
+[Name("Administrative Commands")]
+public class AdministrativeModule : ModuleBase<SocketCommandContext>
 {
-    [Name("Administrative Commands")]
-    public class AdministrativeModule : ModuleBase<SocketCommandContext>
+    internal enum RoleResolutionStatus
     {
-        internal enum RoleResolutionStatus
+        Resolved,
+        NotFound,
+        MultipleMentions,
+        AmbiguousName
+    }
+
+    internal readonly record struct RoleCandidate(ulong Id, string Name);
+
+    internal readonly record struct RoleResolution(RoleResolutionStatus Status, ulong? RoleId);
+
+    private const int MaximumRolesPerGroup = 25;
+    private static readonly TimeSpan InteractionTimeout = TimeSpan.FromSeconds(60);
+    private readonly RoleReactService _roleReactService;
+    private readonly DiscordMessageCleanupService _messageCleanupService;
+    private readonly DiscordMessageWaiter _messageWaiter;
+    private readonly ILogger<AdministrativeModule> _logger;
+
+    public AdministrativeModule(
+        RoleReactService roleReactService,
+        DiscordMessageCleanupService messageCleanupService,
+        DiscordMessageWaiter messageWaiter,
+        ILogger<AdministrativeModule> logger)
+    {
+        _roleReactService = roleReactService ?? throw new ArgumentNullException(nameof(roleReactService));
+        _messageCleanupService = messageCleanupService ?? throw new ArgumentNullException(nameof(messageCleanupService));
+        _messageWaiter = messageWaiter ?? throw new ArgumentNullException(nameof(messageWaiter));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    [Command("role setting", RunMode = RunMode.Async)]
+    [Summary("Will create a message for auto-role based on reactions")]
+    [Alias("rolesetting", "role settings", "rolesettings")]
+    [Remarks("role setting")]
+    [RequireGuild]
+    [RequireUserPermission(GuildPermission.ManageRoles)]
+    [RequireBotPermission(GuildPermission.EmbedLinks)]
+    public Task RoleSetting() => InvokeRoleSettingsAsync();
+
+    internal async Task InvokeRoleSettingsAsync()
+    {
+        var messagesInInteraction = new List<IMessage> { Context.Message };
+        try
         {
-            Resolved,
-            NotFound,
-            MultipleMentions,
-            AmbiguousName
-        }
-
-        internal readonly record struct RoleCandidate(ulong Id, string Name);
-
-        internal readonly record struct RoleResolution(RoleResolutionStatus Status, ulong? RoleId);
-
-        private const int MaximumRolesPerGroup = 25;
-        private static readonly TimeSpan InteractionTimeout = TimeSpan.FromSeconds(60);
-        private readonly RoleReactService _roleReactService;
-        private readonly DiscordMessageCleanupService _messageCleanupService;
-        private readonly DiscordMessageWaiter _messageWaiter;
-        private readonly ILogger<AdministrativeModule> _logger;
-
-        public AdministrativeModule(
-            RoleReactService roleReactService,
-            DiscordMessageCleanupService messageCleanupService,
-            DiscordMessageWaiter messageWaiter,
-            ILogger<AdministrativeModule> logger)
-        {
-            _roleReactService = roleReactService ?? throw new ArgumentNullException(nameof(roleReactService));
-            _messageCleanupService = messageCleanupService ?? throw new ArgumentNullException(nameof(messageCleanupService));
-            _messageWaiter = messageWaiter ?? throw new ArgumentNullException(nameof(messageWaiter));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        }
-
-        [Command("role setting", RunMode = RunMode.Async)]
-        [Summary("Will create a message for auto-role based on reactions")]
-        [Alias("rolesetting", "role settings", "rolesettings")]
-        [Remarks("role setting")]
-        [RequireGuild]
-        [RequireUserPermission(GuildPermission.ManageRoles)]
-        [RequireBotPermission(GuildPermission.EmbedLinks)]
-        public Task RoleSetting() => InvokeRoleSettingsAsync();
-
-        internal async Task InvokeRoleSettingsAsync()
-        {
-            var messagesInInteraction = new List<IMessage> { Context.Message };
-            try
-            {
-                var roleEmotePairs = new List<RoleEmotePair>();
-                messagesInInteraction.Add(await ReplyAsync($"How many roles do you wish to configure? (1-{MaximumRolesPerGroup})"));
-                var amountMessage = await _messageWaiter.WaitForNextMessageAsync(Context, InteractionTimeout);
-                var roleCountResult = await GetRoleCountAsync(messagesInInteraction, amountMessage);
-                if (!roleCountResult.Success)
-                {
-                    return;
-                }
-
-                for (var index = 0; index < roleCountResult.RoleCount; index++)
-                {
-                    messagesInInteraction.Add(await ReplyAsync("Which role would you like to set up?"));
-                    var roleMessage = await _messageWaiter.WaitForNextMessageAsync(Context, InteractionTimeout);
-                    var role = await GetRoleAsync(messagesInInteraction, roleMessage);
-                    if (role == null)
-                    {
-                        return;
-                    }
-
-                    messagesInInteraction.Add(await ReplyAsync($"Which emote would you like to set up with the role {role.Name}?"));
-                    var emoteMessage = await _messageWaiter.WaitForNextMessageAsync(Context, InteractionTimeout);
-                    var emote = await GetEmoteAsync(messagesInInteraction, emoteMessage);
-                    if (emote == null)
-                    {
-                        return;
-                    }
-
-                    if (roleEmotePairs.Any(pair =>
-                        pair.RoleId == role.Id.ToString(CultureInfo.InvariantCulture)
-                        || pair.EmojiId == emote.Id.ToString(CultureInfo.InvariantCulture)))
-                    {
-                        messagesInInteraction.Add(await ReplyAsync("That role or emote is already being configured. Please start again."));
-                        return;
-                    }
-
-                    roleEmotePairs.Add(new RoleEmotePair(
-                        role.Id.ToString(CultureInfo.InvariantCulture),
-                        emote.Id.ToString(CultureInfo.InvariantCulture)));
-                }
-
-                messagesInInteraction.Add(await ReplyAsync("Please label this group of roles (i.e. Games, Position, NSFW, etc)."));
-                var labelMessage = await _messageWaiter.WaitForNextMessageAsync(Context, InteractionTimeout);
-                if (labelMessage == null)
-                {
-                    messagesInInteraction.Add(await ReplyAsync("Time has expired, please try again."));
-                    return;
-                }
-
-                messagesInInteraction.Add(labelMessage);
-                await ReactionRoleSetupTransaction.ExecuteAsync(
-                    () => CreateRoleMessageAsync(roleEmotePairs, labelMessage.Content),
-                    async messageToListen =>
-                    {
-                        await AddRoleReactionsAsync(messageToListen, roleEmotePairs);
-                        await _roleReactService.SaveRoleSettings(roleEmotePairs, messageToListen);
-                    },
-                    messageToListen => messageToListen.DeleteAsync(),
-                    exception => BeanBotLog.IncompleteReactionRoleCleanupFailed(_logger, exception));
-            }
-            finally
-            {
-                await CleanUpMessagesAsync(messagesInInteraction);
-            }
-        }
-
-        private async Task<IUserMessage> CreateRoleMessageAsync(IEnumerable<RoleEmotePair> roleEmotePairs, string roleGroupLabel)
-        {
-            var pairs = roleEmotePairs.ToList();
-            var roleEmbed = new EmbedBuilder();
-            foreach (var pair in pairs)
-            {
-                var emote = Context.Guild.Emotes.First(candidate =>
-                    candidate.Id.ToString(CultureInfo.InvariantCulture) == pair.EmojiId);
-                roleEmbed.AddField(emote.ToString(), $"<@&{pair.RoleId}>", inline: true);
-            }
-
-            roleEmbed.WithFooter(footer => footer.Text = $"Role Group: {roleGroupLabel}");
-            return await ReplyAsync(embed: roleEmbed.Build());
-        }
-
-        private async Task AddRoleReactionsAsync(IUserMessage messageToListen, IEnumerable<RoleEmotePair> roleEmotePairs)
-        {
-            var pairs = roleEmotePairs.ToList();
-            foreach (var pair in pairs)
-            {
-                var emote = Context.Guild.Emotes.First(candidate =>
-                    candidate.Id.ToString(CultureInfo.InvariantCulture) == pair.EmojiId);
-                await messageToListen.AddReactionAsync(emote);
-                await Task.Delay(TimeSpan.FromMilliseconds(250));
-            }
-        }
-
-        private async Task<(bool Success, int RoleCount)> GetRoleCountAsync(List<IMessage> messages, SocketMessage? response)
-        {
-            if (response == null)
-            {
-                messages.Add(await ReplyAsync("Time has expired, please try again."));
-                return (false, 0);
-            }
-
-            messages.Add(response);
-            if (!int.TryParse(response.Content, out var roleCount) || roleCount < 1 || roleCount > MaximumRolesPerGroup)
-            {
-                messages.Add(await ReplyAsync($"Please enter a whole number from 1 to {MaximumRolesPerGroup}."));
-                return (false, 0);
-            }
-
-            return (true, roleCount);
-        }
-
-        private async Task<SocketRole?> GetRoleAsync(List<IMessage> messages, SocketMessage? response)
-        {
-            if (response == null)
-            {
-                messages.Add(await ReplyAsync("Time has expired, please try again."));
-                return null;
-            }
-
-            messages.Add(response);
-            var availableRoles = Context.Guild.Roles.ToList();
-            var roleResolution = ResolveRole(
-                response.Content,
-                response.MentionedRoleIds,
-                availableRoles.Select(role => new RoleCandidate(role.Id, role.Name)));
-
-            if (roleResolution.Status == RoleResolutionStatus.MultipleMentions)
-            {
-                messages.Add(await ReplyAsync("Please mention only one role. Please start again."));
-                return null;
-            }
-
-            if (roleResolution.Status == RoleResolutionStatus.AmbiguousName)
-            {
-                messages.Add(await ReplyAsync("Multiple roles have that name. Please mention the role you want and start again."));
-                return null;
-            }
-
-            if (roleResolution.Status == RoleResolutionStatus.NotFound)
-            {
-                messages.Add(await ReplyAsync($"The role {response.Content} does not exist. Please start again."));
-                return null;
-            }
-
-            return availableRoles.Single(role => role.Id == roleResolution.RoleId);
-        }
-
-        internal static RoleResolution ResolveRole(
-            string roleName,
-            IEnumerable<ulong> mentionedRoleIds,
-            IEnumerable<RoleCandidate> availableRoles)
-        {
-            var roleCandidates = availableRoles.ToList();
-            var distinctMentionedRoleIds = mentionedRoleIds.Distinct().Take(2).ToList();
-            if (distinctMentionedRoleIds.Count > 1)
-            {
-                return new RoleResolution(RoleResolutionStatus.MultipleMentions, null);
-            }
-
-            if (distinctMentionedRoleIds.Count == 1)
-            {
-                var mentionedRoleId = distinctMentionedRoleIds[0];
-                return roleCandidates.Any(candidate => candidate.Id == mentionedRoleId)
-                    ? new RoleResolution(RoleResolutionStatus.Resolved, mentionedRoleId)
-                    : new RoleResolution(RoleResolutionStatus.NotFound, null);
-            }
-
-            if (string.IsNullOrWhiteSpace(roleName))
-            {
-                return new RoleResolution(RoleResolutionStatus.NotFound, null);
-            }
-
-            var normalizedRoleName = roleName.Trim();
-            var matchingRoles = roleCandidates
-                .Where(candidate => string.Equals(
-                    normalizedRoleName,
-                    candidate.Name.Trim(),
-                    StringComparison.OrdinalIgnoreCase))
-                .Take(2)
-                .ToList();
-
-            return matchingRoles.Count switch
-            {
-                1 => new RoleResolution(RoleResolutionStatus.Resolved, matchingRoles[0].Id),
-                > 1 => new RoleResolution(RoleResolutionStatus.AmbiguousName, null),
-                _ => new RoleResolution(RoleResolutionStatus.NotFound, null)
-            };
-        }
-
-        private async Task<Emote?> GetEmoteAsync(List<IMessage> messages, SocketMessage? response)
-        {
-            if (response == null)
-            {
-                messages.Add(await ReplyAsync("Time has expired, please try again."));
-                return null;
-            }
-
-            messages.Add(response);
-            var emote = Context.Guild.Emotes.FirstOrDefault(candidate =>
-                response.Content.Contains(candidate.Name, StringComparison.OrdinalIgnoreCase));
-            if (emote == null)
-            {
-                messages.Add(await ReplyAsync($"The emote {response.Content} does not exist. Please start again."));
-                return null;
-            }
-
-            return emote;
-        }
-
-        private async Task CleanUpMessagesAsync(List<IMessage> messages)
-        {
-            await Task.Delay(TimeSpan.FromSeconds(5));
-            if (Context.Channel is not ITextChannel textChannel || messages.Count == 0)
+            var roleEmotePairs = new List<RoleEmotePair>();
+            messagesInInteraction.Add(await ReplyAsync($"How many roles do you wish to configure? (1-{MaximumRolesPerGroup})"));
+            var amountMessage = await _messageWaiter.WaitForNextMessageAsync(Context, InteractionTimeout);
+            var roleCountResult = await GetRoleCountAsync(messagesInInteraction, amountMessage);
+            if (!roleCountResult.Success)
             {
                 return;
             }
 
-            try
+            for (var index = 0; index < roleCountResult.RoleCount; index++)
             {
-                await _messageCleanupService.DeleteAsync(textChannel, messages);
+                messagesInInteraction.Add(await ReplyAsync("Which role would you like to set up?"));
+                var roleMessage = await _messageWaiter.WaitForNextMessageAsync(Context, InteractionTimeout);
+                var role = await GetRoleAsync(messagesInInteraction, roleMessage);
+                if (role == null)
+                {
+                    return;
+                }
+
+                messagesInInteraction.Add(await ReplyAsync($"Which emote would you like to set up with the role {role.Name}?"));
+                var emoteMessage = await _messageWaiter.WaitForNextMessageAsync(Context, InteractionTimeout);
+                var emote = await GetEmoteAsync(messagesInInteraction, emoteMessage);
+                if (emote == null)
+                {
+                    return;
+                }
+
+                if (roleEmotePairs.Any(pair =>
+                    pair.RoleId == role.Id.ToString(CultureInfo.InvariantCulture)
+                    || pair.EmojiId == emote.Id.ToString(CultureInfo.InvariantCulture)))
+                {
+                    messagesInInteraction.Add(await ReplyAsync("That role or emote is already being configured. Please start again."));
+                    return;
+                }
+
+                roleEmotePairs.Add(new RoleEmotePair(
+                    role.Id.ToString(CultureInfo.InvariantCulture),
+                    emote.Id.ToString(CultureInfo.InvariantCulture)));
             }
-            catch (Exception exception)
+
+            messagesInInteraction.Add(await ReplyAsync("Please label this group of roles (i.e. Games, Position, NSFW, etc)."));
+            var labelMessage = await _messageWaiter.WaitForNextMessageAsync(Context, InteractionTimeout);
+            if (labelMessage == null)
             {
-                BeanBotLog.ReactionRoleCleanupFailed(_logger, exception);
+                messagesInInteraction.Add(await ReplyAsync("Time has expired, please try again."));
+                return;
             }
+
+            messagesInInteraction.Add(labelMessage);
+            await ReactionRoleSetupTransaction.ExecuteAsync(
+                () => CreateRoleMessageAsync(roleEmotePairs, labelMessage.Content),
+                async messageToListen =>
+                {
+                    await AddRoleReactionsAsync(messageToListen, roleEmotePairs);
+                    await _roleReactService.SaveRoleSettings(roleEmotePairs, messageToListen);
+                },
+                messageToListen => messageToListen.DeleteAsync(),
+                exception => BeanBotLog.IncompleteReactionRoleCleanupFailed(_logger, exception));
+        }
+        finally
+        {
+            await CleanUpMessagesAsync(messagesInInteraction);
+        }
+    }
+
+    private async Task<IUserMessage> CreateRoleMessageAsync(IEnumerable<RoleEmotePair> roleEmotePairs, string roleGroupLabel)
+    {
+        var pairs = roleEmotePairs.ToList();
+        var roleEmbed = new EmbedBuilder();
+        foreach (var pair in pairs)
+        {
+            var emote = Context.Guild.Emotes.First(candidate =>
+                candidate.Id.ToString(CultureInfo.InvariantCulture) == pair.EmojiId);
+            roleEmbed.AddField(emote.ToString(), $"<@&{pair.RoleId}>", inline: true);
+        }
+
+        roleEmbed.WithFooter(footer => footer.Text = $"Role Group: {roleGroupLabel}");
+        return await ReplyAsync(embed: roleEmbed.Build());
+    }
+
+    private async Task AddRoleReactionsAsync(IUserMessage messageToListen, IEnumerable<RoleEmotePair> roleEmotePairs)
+    {
+        var pairs = roleEmotePairs.ToList();
+        foreach (var pair in pairs)
+        {
+            var emote = Context.Guild.Emotes.First(candidate =>
+                candidate.Id.ToString(CultureInfo.InvariantCulture) == pair.EmojiId);
+            await messageToListen.AddReactionAsync(emote);
+            await Task.Delay(TimeSpan.FromMilliseconds(250));
+        }
+    }
+
+    private async Task<(bool Success, int RoleCount)> GetRoleCountAsync(List<IMessage> messages, SocketMessage? response)
+    {
+        if (response == null)
+        {
+            messages.Add(await ReplyAsync("Time has expired, please try again."));
+            return (false, 0);
+        }
+
+        messages.Add(response);
+        if (!int.TryParse(response.Content, out var roleCount) || roleCount < 1 || roleCount > MaximumRolesPerGroup)
+        {
+            messages.Add(await ReplyAsync($"Please enter a whole number from 1 to {MaximumRolesPerGroup}."));
+            return (false, 0);
+        }
+
+        return (true, roleCount);
+    }
+
+    private async Task<SocketRole?> GetRoleAsync(List<IMessage> messages, SocketMessage? response)
+    {
+        if (response == null)
+        {
+            messages.Add(await ReplyAsync("Time has expired, please try again."));
+            return null;
+        }
+
+        messages.Add(response);
+        var availableRoles = Context.Guild.Roles.ToList();
+        var roleResolution = ResolveRole(
+            response.Content,
+            response.MentionedRoleIds,
+            availableRoles.Select(role => new RoleCandidate(role.Id, role.Name)));
+
+        if (roleResolution.Status == RoleResolutionStatus.MultipleMentions)
+        {
+            messages.Add(await ReplyAsync("Please mention only one role. Please start again."));
+            return null;
+        }
+
+        if (roleResolution.Status == RoleResolutionStatus.AmbiguousName)
+        {
+            messages.Add(await ReplyAsync("Multiple roles have that name. Please mention the role you want and start again."));
+            return null;
+        }
+
+        if (roleResolution.Status == RoleResolutionStatus.NotFound)
+        {
+            messages.Add(await ReplyAsync($"The role {response.Content} does not exist. Please start again."));
+            return null;
+        }
+
+        return availableRoles.Single(role => role.Id == roleResolution.RoleId);
+    }
+
+    internal static RoleResolution ResolveRole(
+        string roleName,
+        IEnumerable<ulong> mentionedRoleIds,
+        IEnumerable<RoleCandidate> availableRoles)
+    {
+        var roleCandidates = availableRoles.ToList();
+        var distinctMentionedRoleIds = mentionedRoleIds.Distinct().Take(2).ToList();
+        if (distinctMentionedRoleIds.Count > 1)
+        {
+            return new RoleResolution(RoleResolutionStatus.MultipleMentions, null);
+        }
+
+        if (distinctMentionedRoleIds.Count == 1)
+        {
+            var mentionedRoleId = distinctMentionedRoleIds[0];
+            return roleCandidates.Any(candidate => candidate.Id == mentionedRoleId)
+                ? new RoleResolution(RoleResolutionStatus.Resolved, mentionedRoleId)
+                : new RoleResolution(RoleResolutionStatus.NotFound, null);
+        }
+
+        if (string.IsNullOrWhiteSpace(roleName))
+        {
+            return new RoleResolution(RoleResolutionStatus.NotFound, null);
+        }
+
+        var normalizedRoleName = roleName.Trim();
+        var matchingRoles = roleCandidates
+            .Where(candidate => string.Equals(
+                normalizedRoleName,
+                candidate.Name.Trim(),
+                StringComparison.OrdinalIgnoreCase))
+            .Take(2)
+            .ToList();
+
+        return matchingRoles.Count switch
+        {
+            1 => new RoleResolution(RoleResolutionStatus.Resolved, matchingRoles[0].Id),
+            > 1 => new RoleResolution(RoleResolutionStatus.AmbiguousName, null),
+            _ => new RoleResolution(RoleResolutionStatus.NotFound, null)
+        };
+    }
+
+    private async Task<Emote?> GetEmoteAsync(List<IMessage> messages, SocketMessage? response)
+    {
+        if (response == null)
+        {
+            messages.Add(await ReplyAsync("Time has expired, please try again."));
+            return null;
+        }
+
+        messages.Add(response);
+        var emote = Context.Guild.Emotes.FirstOrDefault(candidate =>
+            response.Content.Contains(candidate.Name, StringComparison.OrdinalIgnoreCase));
+        if (emote == null)
+        {
+            messages.Add(await ReplyAsync($"The emote {response.Content} does not exist. Please start again."));
+            return null;
+        }
+
+        return emote;
+    }
+
+    private async Task CleanUpMessagesAsync(List<IMessage> messages)
+    {
+        await Task.Delay(TimeSpan.FromSeconds(5));
+        if (Context.Channel is not ITextChannel textChannel || messages.Count == 0)
+        {
+            return;
+        }
+
+        try
+        {
+            await _messageCleanupService.DeleteAsync(textChannel, messages);
+        }
+        catch (Exception exception)
+        {
+            BeanBotLog.ReactionRoleCleanupFailed(_logger, exception);
         }
     }
 }

--- a/BeanBot/Modules/HelpModule.cs
+++ b/BeanBot/Modules/HelpModule.cs
@@ -1,67 +1,63 @@
+using System.Text;
 using Discord;
 using Discord.Commands;
-using System;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace BeanBot.Modules
+namespace BeanBot.Modules;
+
+[Name("Command Information/Help")]
+public class HelpModule : ModuleBase<SocketCommandContext>
 {
-    [Name("Command Information/Help")]
-    public class HelpModule : ModuleBase<SocketCommandContext>
+    private readonly CommandService _commandService;
+
+    public HelpModule(CommandService commandService)
     {
-        private readonly CommandService _commandService;
+        _commandService = commandService ?? throw new ArgumentNullException(nameof(commandService));
+    }
 
-        public HelpModule(CommandService commandService)
+    [Command("help")]
+    [Summary("Lists all the commands that Bean Bot is able to use")]
+    public async Task HelpCommand()
+    {
+        var helpBuilder = new EmbedBuilder
         {
-            _commandService = commandService ?? throw new ArgumentNullException(nameof(commandService));
-        }
+            Title = "Bean Bot Commands",
+            Description = "These are the commands that are available to you\nTo use them, type % or succ followed by any of the commands below.\nEx: %shine or succ shine",
+            Color = new Color(218, 112, 214),
+            ThumbnailUrl = "https://cdn.discordapp.com/avatars/630470467261693982/91f45a4463007f73ff73ff5178847056.png?size=256"
+        };
 
-        [Command("help")]
-        [Summary("Lists all the commands that Bean Bot is able to use")]
-        public async Task HelpCommand()
+        foreach (var module in _commandService.Modules)
         {
-            var helpBuilder = new EmbedBuilder
+            var description = new StringBuilder();
+            foreach (var command in module.Commands)
             {
-                Title = "Bean Bot Commands",
-                Description = "These are the commands that are available to you\nTo use them, type % or succ followed by any of the commands below.\nEx: %shine or succ shine",
-                Color = new Color(218, 112, 214),
-                ThumbnailUrl = "https://cdn.discordapp.com/avatars/630470467261693982/91f45a4463007f73ff73ff5178847056.png?size=256"
-            };
-
-            foreach (var module in _commandService.Modules)
-            {
-                var description = new StringBuilder();
-                foreach (var command in module.Commands)
+                var result = await command.CheckPreconditionsAsync(Context);
+                if (!result.IsSuccess)
                 {
-                    var result = await command.CheckPreconditionsAsync(Context);
-                    if (!result.IsSuccess)
-                    {
-                        continue;
-                    }
-
-                    description.Append("**").Append(command.Aliases[0]).AppendLine("**");
-                    if (command.Aliases.Count > 1)
-                    {
-                        description.AppendLine(command.Aliases.Count > 2
-                            ? "This command can also be used with the following aliases:"
-                            : "This command can also be used with the following alias:");
-                        foreach (var alias in command.Aliases.Skip(1))
-                        {
-                            description.Append('\t').Append('*').Append(alias).AppendLine("*");
-                        }
-                    }
-
-                    description.AppendLine();
+                    continue;
                 }
 
-                if (description.Length > 0)
+                description.Append("**").Append(command.Aliases[0]).AppendLine("**");
+                if (command.Aliases.Count > 1)
                 {
-                    helpBuilder.AddField($"**=== {module.Name} ===**", description.ToString());
+                    description.AppendLine(command.Aliases.Count > 2
+                        ? "This command can also be used with the following aliases:"
+                        : "This command can also be used with the following alias:");
+                    foreach (var alias in command.Aliases.Skip(1))
+                    {
+                        description.Append('\t').Append('*').Append(alias).AppendLine("*");
+                    }
                 }
+
+                description.AppendLine();
             }
 
-            await ReplyAsync(string.Empty, false, helpBuilder.Build());
+            if (description.Length > 0)
+            {
+                helpBuilder.AddField($"**=== {module.Name} ===**", description.ToString());
+            }
         }
+
+        await ReplyAsync(string.Empty, false, helpBuilder.Build());
     }
 }

--- a/BeanBot/Modules/InfoModule.cs
+++ b/BeanBot/Modules/InfoModule.cs
@@ -1,20 +1,18 @@
 using Discord;
 using Discord.Commands;
-using System.Threading.Tasks;
 
-namespace BeanBot.Modules
+namespace BeanBot.Modules;
+
+[Name("Bot Information")]
+public class InfoModule : ModuleBase<SocketCommandContext>
 {
-    [Name("Bot Information")]
-    public class InfoModule : ModuleBase<SocketCommandContext>
+    [Command("dev")]
+    [Summary("Tags the lead developer on Discord")]
+    [Remarks("succ dev")]
+    [RequireBotPermission(ChannelPermission.SendMessages)]
+    public async Task DeveloperCommand()
     {
-        [Command("dev")]
-        [Summary("Tags the lead developer on Discord")]
-        [Remarks("succ dev")]
-        [RequireBotPermission(ChannelPermission.SendMessages)]
-        public async Task DeveloperCommand()
-        {
-            const long leadDeveloperDiscordUserId = 114559039731531781;
-            await ReplyAsync($"<@{leadDeveloperDiscordUserId}> is my lead developer");
-        }
+        const long leadDeveloperDiscordUserId = 114559039731531781;
+        await ReplyAsync($"<@{leadDeveloperDiscordUserId}> is my lead developer");
     }
 }

--- a/BeanBot/Modules/MemeModule.cs
+++ b/BeanBot/Modules/MemeModule.cs
@@ -1,385 +1,377 @@
-﻿using BeanBot.Entities;
+﻿using System.Globalization;
 using BeanBot.Configuration;
+using BeanBot.Entities;
 using BeanBot.Services;
 using BeanBot.Util;
 using CsvHelper;
 using Discord;
 using Discord.Commands;
-using Discord.WebSocket;
 using MemeApiDotNetWrapper;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Threading.Tasks;
 
-namespace BeanBot.Modules
+namespace BeanBot.Modules;
+
+[Name("Meme Commands")]
+public class MemeModule : ModuleBase<SocketCommandContext>
 {
-    [Name("Meme Commands")]
-    public class MemeModule : ModuleBase<SocketCommandContext>
+    private static readonly HttpClient HttpClient = new();
+    private readonly MemeMachine _memeMachine = new();
+    private readonly BeanBotOptions _options;
+    private readonly FortuneAnswerStore _fortuneAnswers;
+    private readonly DiscordPaginatorService _paginator;
+    private readonly ILogger<MemeModule> _logger;
+
+    public MemeModule(
+        BeanBotOptions options,
+        FortuneAnswerStore fortuneAnswers,
+        DiscordPaginatorService paginator,
+        ILogger<MemeModule> logger)
     {
-        private static readonly HttpClient HttpClient = new HttpClient();
-        private readonly MemeMachine _memeMachine = new MemeMachine();
-        private readonly BeanBotOptions _options;
-        private readonly FortuneAnswerStore _fortuneAnswers;
-        private readonly DiscordPaginatorService _paginator;
-        private readonly ILogger<MemeModule> _logger;
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _fortuneAnswers = fortuneAnswers ?? throw new ArgumentNullException(nameof(fortuneAnswers));
+        _paginator = paginator ?? throw new ArgumentNullException(nameof(paginator));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
 
-        public MemeModule(
-            BeanBotOptions options,
-            FortuneAnswerStore fortuneAnswers,
-            DiscordPaginatorService paginator,
-            ILogger<MemeModule> logger)
+    private static readonly string[] EightBallResponses =
+    [
+        "Hell yeah brother",
+        "Yeehaw",
+        "Yes uwu",
+        "The spirit of Texas tells me No",
+        "No umu",
+        "The answer is yes if you let me suck your toes",
+        "It is unclear, let me succ you and try asking again",
+        "*succ succ succ* lol you're gay"
+    ];
+
+    private static readonly string[] TexasFactResponses =
+    [
+        "The tale of the Alamo is retold through the stars",
+        "The King Ranch in Texas is bigger than the entire state of California",
+        "Texas is the largest country in the world",
+        "Texas is the largest exporter of Freedom per capita in the world",
+        "Texas boasts the largest herd of wild padorus",
+        "Astolfo, the most famous Texan cowboy, was born in Europe",
+        "More species of cursed bean live in Texas than any other part of the world",
+        "The entire country of Texas has 5 Jollibees"
+    ];
+
+    [Command("succ")]
+    [Summary("Astolfo will suck your dick and call you gay")]
+    [Alias("cursed bean")]
+    [Remarks("succ")]
+    [RequireBotPermission(ChannelPermission.SendMessages)]
+    public async Task UserSucc([Summary("The (optional) user to succ")] params string[] input)
+    {
+        var userToSucc = NormalizeSuccTarget(input, Context.Message.Author.Mention);
+        await ReplyAsync($"*succ succ succ* lol you're gay {userToSucc}");
+    }
+
+    [Command("2am")]
+    [Summary("There's only one thing to do at 2 AM...")]
+    [Alias("mcdonalds")]
+    [Remarks("succ mcdonalds")]
+    [RequireBotPermission(ChannelPermission.SendMessages)]
+    public async Task McDonalds()
+    {
+        await ReplyAsync("<:mcdonalds:661337575704887337>");
+    }
+
+    [Command("fancy ocho ocho")]
+    [Summary("Everyone that went to the Music Box is banned from this server")]
+    [Remarks("succ ocho ocho")]
+    [RequireBotPermission(ChannelPermission.SendMessages)]
+    public async Task OchoOcho2()
+    {
+        await ReplyWithOchoOcho();
+    }
+
+
+    [Command("420")]
+    [Summary("Astolfour-twenty blaze it")]
+    [Alias("blaze", "blaze it", "weed")]
+    [RequireBotPermission(ChannelPermission.SendMessages)]
+    public async Task BlazeIt()
+    {
+        await ReplyAsync("<:420stolfoit:675553715759087618>");
+    }
+
+    [Command("toes")]
+    [Summary("You've doomed yourself, Hatate")]
+    [Alias("toe", "kaz", "the toe fetish is just a joke")]
+    [RequireBotPermission(ChannelPermission.SendMessages)]
+    [RequireBotPermission(ChannelPermission.AttachFiles)]
+    public async Task Toes()
+    {
+        await SendImageFromUrl(_options.HatoeteImageUrl);
+    }
+
+    [Command("yoshimaru")]
+    [Summary("The superior ship")]
+    [Alias("yohamaru", "canon ship")]
+    [RequireBotPermission(ChannelPermission.SendMessages)]
+    [RequireBotPermission(ChannelPermission.AttachFiles)]
+    public async Task YoshiMaru()
+    {
+        await SendImageFromUrl(_options.YoshimaruImageUrl);
+    }
+
+    [Command("echo")]
+    [Summary("Gives the bot braincells")]
+    [Alias("say")]
+    [RequireBotPermission(ChannelPermission.SendMessages)]
+    public async Task Echo([Remainder] string text)
+    {
+        try
         {
-            _options = options ?? throw new ArgumentNullException(nameof(options));
-            _fortuneAnswers = fortuneAnswers ?? throw new ArgumentNullException(nameof(fortuneAnswers));
-            _paginator = paginator ?? throw new ArgumentNullException(nameof(paginator));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            await Context.Message.DeleteAsync();
         }
-
-        private static readonly string[] EightBallResponses = new string[8]
+        catch (Exception exception)
         {
-            "Hell yeah brother",
-            "Yeehaw",
-            "Yes uwu",
-            "The spirit of Texas tells me No",
-            "No umu",
-            "The answer is yes if you let me suck your toes",
-            "It is unclear, let me succ you and try asking again",
-            "*succ succ succ* lol you're gay"
-        };
-
-        private static readonly string[] TexasFactResponses = new string[8]
-        {
-            "The tale of the Alamo is retold through the stars",
-            "The King Ranch in Texas is bigger than the entire state of California",
-            "Texas is the largest country in the world",
-            "Texas is the largest exporter of Freedom per capita in the world",
-            "Texas boasts the largest herd of wild padorus",
-            "Astolfo, the most famous Texan cowboy, was born in Europe",
-            "More species of cursed bean live in Texas than any other part of the world",
-            "The entire country of Texas has 5 Jollibees"
-        };
-
-        [Command("succ")]
-        [Summary("Astolfo will suck your dick and call you gay")]
-        [Alias("cursed bean")]
-        [Remarks("succ")]
-        [RequireBotPermission(ChannelPermission.SendMessages)]
-        public async Task UserSucc([Summary("The (optional) user to succ")] params string[] input)
-        {
-            var userToSucc = NormalizeSuccTarget(input, Context.Message.Author.Mention);
-            await ReplyAsync($"*succ succ succ* lol you're gay {userToSucc}");
+            BeanBotLog.EchoSourceDeleteFailed(_logger, Context.Message.Id, exception);
         }
+        await ReplyAsync(text);
+    }
 
-        [Command("2am")]
-        [Summary("There's only one thing to do at 2 AM...")]
-        [Alias("mcdonalds")]
-        [Remarks("succ mcdonalds")]
-        [RequireBotPermission(ChannelPermission.SendMessages)]
-        public async Task McDonalds()
+    [Command("8ball")]
+    [Summary("Let me predict your future.. for a price")]
+    [Alias("fortune")]
+    [RequireBotPermission(ChannelPermission.SendMessages)]
+    public async Task EightBall([Remainder] string question)
+    {
+        await ChooseRandomAnswer(question);
+    }
+
+    [Command("pun")]
+    [Summary("I will give you one PunMaster™ branded pun")]
+    [RequireBotPermission(ChannelPermission.SendMessages)]
+    public async Task Pun()
+    {
+        await ChooseRandomPun();
+    }
+
+    [Command("meme")]
+    [Summary("Will give you a random meme from reddit")]
+    [Remarks("meme")]
+    [RequireBotPermission(ChannelPermission.SendMessages)]
+    public async Task Meme(string subreddit = "")
+    {
+        await InvokeMemeApi(subreddit);
+    }
+    private async Task InvokeMemeApi(string subreddit)
+    {
+        Meme? meme;
+        try
         {
-            await ReplyAsync("<:mcdonalds:661337575704887337>");
-        }
-
-        [Command("fancy ocho ocho")]
-        [Summary("Everyone that went to the Music Box is banned from this server")]
-        [Remarks("succ ocho ocho")]
-        [RequireBotPermission(ChannelPermission.SendMessages)]
-        public async Task OchoOcho2()
-        {
-            await ReplyWithOchoOcho();
-        }
-
-
-        [Command("420")]
-        [Summary("Astolfour-twenty blaze it")]
-        [Alias("blaze", "blaze it", "weed")]
-        [RequireBotPermission(ChannelPermission.SendMessages)]
-        public async Task BlazeIt()
-        {
-            await ReplyAsync("<:420stolfoit:675553715759087618>");
-        }
-
-        [Command("toes")]
-        [Summary("You've doomed yourself, Hatate")]
-        [Alias("toe", "kaz", "the toe fetish is just a joke")]
-        [RequireBotPermission(ChannelPermission.SendMessages)]
-        [RequireBotPermission(ChannelPermission.AttachFiles)]
-        public async Task Toes()
-        {
-            await SendImageFromUrl(_options.HatoeteImageUrl);
-        }
-
-        [Command("yoshimaru")]
-        [Summary("The superior ship")]
-        [Alias("yohamaru", "canon ship")]
-        [RequireBotPermission(ChannelPermission.SendMessages)]
-        [RequireBotPermission(ChannelPermission.AttachFiles)]
-        public async Task YoshiMaru()
-        {
-            await SendImageFromUrl(_options.YoshimaruImageUrl);
-        }
-
-        [Command("echo")]
-        [Summary("Gives the bot braincells")]
-        [Alias("say")]
-        [RequireBotPermission(ChannelPermission.SendMessages)]
-        public async Task Echo([Remainder] string text)
-        {
-            try
+            if (string.IsNullOrEmpty(subreddit))
             {
-                await Context.Message.DeleteAsync();
-            }
-            catch (Exception exception)
-            {
-                BeanBotLog.EchoSourceDeleteFailed(_logger, Context.Message.Id, exception);
-            }
-            await ReplyAsync(text);
-        }
-
-        [Command("8ball")]
-        [Summary("Let me predict your future.. for a price")]
-        [Alias("fortune")]
-        [RequireBotPermission(ChannelPermission.SendMessages)]
-        public async Task EightBall([Remainder] string question)
-        {
-            await ChooseRandomAnswer(question);
-        }
-
-        [Command("pun")]
-        [Summary("I will give you one PunMaster™ branded pun")]
-        [RequireBotPermission(ChannelPermission.SendMessages)]
-        public async Task Pun()
-        {
-            await ChooseRandomPun();
-        }
-
-        [Command("meme")]
-        [Summary("Will give you a random meme from reddit")]
-        [Remarks("meme")]
-        [RequireBotPermission(ChannelPermission.SendMessages)]
-        public async Task Meme(string subreddit = "")
-        {
-            await InvokeMemeApi(subreddit);
-        }
-        private async Task InvokeMemeApi(string subreddit)
-        {
-            Meme? meme;
-            try
-            {
-                if (string.IsNullOrEmpty(subreddit))
-                {
-                    meme = await _memeMachine.GetMemeAsync();
-                }
-                else
-                {
-                    meme = await _memeMachine.GetMemeAsync(subreddit);
-                }
-            }
-            catch (Exception ex)
-            {
-                BeanBotLog.MemeApiFailed(_logger, ex);
-                meme = null;
-            }
-
-            if (meme == null)
-            {
-                await ReplyAsync("The meme machine is down, quick, call 911!");
+                meme = await _memeMachine.GetMemeAsync();
             }
             else
             {
-                EmbedBuilder memeBuilder = new EmbedBuilder()
-                {
-                    Title = meme.Title,
-                    Description = $"/r/{meme.SubReddit}",
-                    ImageUrl = meme.ImageUrl
-                };
-                await ReplyAsync(embed: memeBuilder.Build());
+                meme = await _memeMachine.GetMemeAsync(subreddit);
             }
         }
-
-        [Command("texasnationalbird")]
-        [Summary("I will educate you on Texas' official national bird")]
-        [Remarks("texasnationalbird")]
-        [RequireBotPermission(ChannelPermission.SendMessages)]
-        public async Task NationalBird()
+        catch (Exception ex)
         {
-            await ReplyAsync("The Texas Offical National Bird is the AR-15");
+            BeanBotLog.MemeApiFailed(_logger, ex);
+            meme = null;
         }
 
-        [Command("texasnationalflower")]
-        [Summary("I will educate you on the Texas' official national flower")]
-        [Remarks("texasnationalflower")]
-        public async Task NationalFlower()
+        if (meme == null)
         {
-            await ReplyAsync("The Texas Official National Flower is the Jimmy Dean breakfast taco");
+            await ReplyAsync("The meme machine is down, quick, call 911!");
         }
-
-        [Command("texasfacts")]
-        [Summary("I will give you a random Texas fact")]
-        [Remarks("texasfacts")]
-        public async Task TexasFacts()
+        else
         {
-            var fact = TexasFactResponses[Random.Shared.Next(TexasFactResponses.Length)];
-            await ReplyAsync($"Did you know: {fact}");
-        }
-
-
-        private async Task ChooseRandomPun()
-        {
-            using (var reader = new StreamReader("Resources/puns.csv"))
-            using (var csv = new CsvReader(reader, CultureInfo.InvariantCulture))
+            EmbedBuilder memeBuilder = new EmbedBuilder()
             {
-                var puns = csv.GetRecords<Pun>()
-                    .Select(record => record.BadPost)
-                    .Where(pun => !string.IsNullOrWhiteSpace(pun))
-                    .ToList();
+                Title = meme.Title,
+                Description = $"/r/{meme.SubReddit}",
+                ImageUrl = meme.ImageUrl
+            };
+            await ReplyAsync(embed: memeBuilder.Build());
+        }
+    }
 
-                if (puns.Count == 0)
-                {
-                    BeanBotLog.ModulePunFileEmpty(_logger);
-                    await ReplyAsync("The PunMaster is temporarily out of material.");
-                    return;
-                }
+    [Command("texasnationalbird")]
+    [Summary("I will educate you on Texas' official national bird")]
+    [Remarks("texasnationalbird")]
+    [RequireBotPermission(ChannelPermission.SendMessages)]
+    public async Task NationalBird()
+    {
+        await ReplyAsync("The Texas Offical National Bird is the AR-15");
+    }
 
-                await ReplyAsync(puns[Random.Shared.Next(puns.Count)]);
+    [Command("texasnationalflower")]
+    [Summary("I will educate you on the Texas' official national flower")]
+    [Remarks("texasnationalflower")]
+    public async Task NationalFlower()
+    {
+        await ReplyAsync("The Texas Official National Flower is the Jimmy Dean breakfast taco");
+    }
+
+    [Command("texasfacts")]
+    [Summary("I will give you a random Texas fact")]
+    [Remarks("texasfacts")]
+    public async Task TexasFacts()
+    {
+        var fact = TexasFactResponses[Random.Shared.Next(TexasFactResponses.Length)];
+        await ReplyAsync($"Did you know: {fact}");
+    }
+
+
+    private async Task ChooseRandomPun()
+    {
+        using (var reader = new StreamReader("Resources/puns.csv"))
+        using (var csv = new CsvReader(reader, CultureInfo.InvariantCulture))
+        {
+            var puns = csv.GetRecords<Pun>()
+                .Select(record => record.BadPost)
+                .Where(pun => !string.IsNullOrWhiteSpace(pun))
+                .ToList();
+
+            if (puns.Count == 0)
+            {
+                BeanBotLog.ModulePunFileEmpty(_logger);
+                await ReplyAsync("The PunMaster is temporarily out of material.");
+                return;
+            }
+
+            await ReplyAsync(puns[Random.Shared.Next(puns.Count)]);
+        }
+    }
+
+    private async Task ChooseRandomAnswer(string question)
+    {
+        var responseOverride = FortuneResponseOverrides.GetResponse(question);
+        if (responseOverride != null)
+        {
+            var hasQueuedAnswer = _fortuneAnswers.TryReserve(Context.Message.Author.Id, out var reservation);
+            await ReplyAsync($"> {question} \n{responseOverride}");
+            if (hasQueuedAnswer)
+            {
+                _fortuneAnswers.Consume(reservation);
             }
         }
-
-        private async Task ChooseRandomAnswer(string question)
+        else if (QuestionValidator.IsQuestion(question))
         {
-            var responseOverride = FortuneResponseOverrides.GetResponse(question);
-            if (responseOverride != null)
+            if (IsPunMaster())
             {
-                var hasQueuedAnswer = _fortuneAnswers.TryReserve(Context.Message.Author.Id, out var reservation);
-                await ReplyAsync($"> {question} \n{responseOverride}");
-                if (hasQueuedAnswer)
-                {
-                    _fortuneAnswers.Consume(reservation);
-                }
+                await HandlePunMaster(question);
             }
-            else if (QuestionValidator.IsQuestion(question))
+            else
             {
-                if (IsPunMaster())
+                if (_fortuneAnswers.TryReserve(Context.Message.Author.Id, out var reservation))
                 {
-                    await HandlePunMaster(question);
-                }
-                else
-                {
-                    if (_fortuneAnswers.TryReserve(Context.Message.Author.Id, out var reservation))
+                    if (reservation.Answer == "positive")
                     {
-                        if (reservation.Answer == "positive")
-                        {
-                            var answer = EightBallResponses[Random.Shared.Next(0, 3)];
-                            await ReplyAsync($"> {question} \n{answer}");
-                        }
-                        else
-                        {
-                            var answer = EightBallResponses[Random.Shared.Next(3, 5)];
-                            await ReplyAsync($"> {question} \n{answer}");
-                        }
-                        _fortuneAnswers.Consume(reservation);
+                        var answer = EightBallResponses[Random.Shared.Next(0, 3)];
+                        await ReplyAsync($"> {question} \n{answer}");
                     }
                     else
                     {
-                        var answer = EightBallResponses[Random.Shared.Next(EightBallResponses.Length)];
+                        var answer = EightBallResponses[Random.Shared.Next(3, 5)];
                         await ReplyAsync($"> {question} \n{answer}");
                     }
-                }
-            }
-            else
-            {
-                var gordonGif = Random.Shared.Next(1, 9);
-                var rejection = $"> {question} \nThat is not a question";
-                try
-                {
-                    await Context.Channel.SendFileAsync($"Resources/gordon{gordonGif}.gif", rejection);
-                }
-                catch (Exception exception)
-                {
-                    BeanBotLog.GordonAttachmentFailed(_logger, exception);
-                    await ReplyAsync(rejection);
-                }
-            }
-        }
-
-        private async Task HandlePunMaster(string question)
-        {
-            if (question.Contains("post", StringComparison.OrdinalIgnoreCase) && question.Contains("succ", StringComparison.OrdinalIgnoreCase) ||
-                question.Contains("rigged", StringComparison.OrdinalIgnoreCase) && !question.Contains("not", StringComparison.OrdinalIgnoreCase) ||
-                question.Contains("ban", StringComparison.OrdinalIgnoreCase) && question.Contains("padoru", StringComparison.OrdinalIgnoreCase) && !question.Contains("not", StringComparison.OrdinalIgnoreCase))
-            {
-                await ReplyAsync($"> {question} \nThe spirit of Texas tells me No");
-            }
-            else
-            {
-                var chance = Random.Shared.Next(1, 101);
-                if (chance >= 1 && chance <= 10)
-                {
-                    var positiveAns = EightBallResponses[Random.Shared.Next(0, 3)];
-                    await ReplyAsync($"> {question} \n{positiveAns}");
-                }
-                else if (chance > 10 && chance <= 40)
-                {
-                    var negativeAns = EightBallResponses[Random.Shared.Next(3, 5)];
-                    await ReplyAsync($"> {question} \n{negativeAns}");
+                    _fortuneAnswers.Consume(reservation);
                 }
                 else
                 {
-                    var succAns = EightBallResponses[Random.Shared.Next(5, 8)];
-                    await ReplyAsync($"> {question} \n{succAns}");
+                    var answer = EightBallResponses[Random.Shared.Next(EightBallResponses.Length)];
+                    await ReplyAsync($"> {question} \n{answer}");
                 }
             }
         }
-
-        private bool IsPunMaster()
+        else
         {
-            return (Context.Message.Author.Id == 262010462323998720);
-        }
-
-        private async Task SendImageFromUrl(Uri url)
-        {
+            var gordonGif = Random.Shared.Next(1, 9);
+            var rejection = $"> {question} \nThat is not a question";
             try
             {
-                using var response = await HttpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
-                response.EnsureSuccessStatusCode();
-                using Stream image = await response.Content.ReadAsStreamAsync();
-                await Context.Channel.SendFileAsync(image, "image.png");
+                await Context.Channel.SendFileAsync($"Resources/gordon{gordonGif}.gif", rejection);
             }
-            catch (Exception ex)
+            catch (Exception exception)
             {
-                BeanBotLog.ImageDownloadFailed(_logger, url, ex);
-                await ReplyAsync("I couldn't download that image right now.");
+                BeanBotLog.GordonAttachmentFailed(_logger, exception);
+                await ReplyAsync(rejection);
             }
         }
+    }
 
-        internal static string NormalizeSuccTarget(IEnumerable<string> input, string authorMention)
+    private async Task HandlePunMaster(string question)
+    {
+        if (question.Contains("post", StringComparison.OrdinalIgnoreCase) && question.Contains("succ", StringComparison.OrdinalIgnoreCase) ||
+            question.Contains("rigged", StringComparison.OrdinalIgnoreCase) && !question.Contains("not", StringComparison.OrdinalIgnoreCase) ||
+            question.Contains("ban", StringComparison.OrdinalIgnoreCase) && question.Contains("padoru", StringComparison.OrdinalIgnoreCase) && !question.Contains("not", StringComparison.OrdinalIgnoreCase))
         {
-            var words = (input ?? Enumerable.Empty<string>()).ToList();
-            if (words.Count > 0 && string.Equals(words[0], "succ", StringComparison.OrdinalIgnoreCase))
-            {
-                words.RemoveAt(0);
-            }
-
-            var target = string.Join(" ", words).Trim();
-            if (string.IsNullOrWhiteSpace(target) ||
-                target.Contains("Bean Bot", StringComparison.OrdinalIgnoreCase) ||
-                target.Contains("<@!630470467261693982>", StringComparison.Ordinal))
-            {
-                return authorMention;
-            }
-
-            return target;
+            await ReplyAsync($"> {question} \nThe spirit of Texas tells me No");
         }
-
-        private async Task ReplyWithOchoOcho()
+        else
         {
-            var pages = new[] { "One plus one, equals two.", "Two plus two, equals four.", "Four plus four, equals eight.", "Doblehin ang eight.", "Tayo'y mag ocho ocho, ocho ocho, mag ocho ocho pa" };
-            await _paginator.SendAsync(Context, pages);
+            var chance = Random.Shared.Next(1, 101);
+            if (chance >= 1 && chance <= 10)
+            {
+                var positiveAns = EightBallResponses[Random.Shared.Next(0, 3)];
+                await ReplyAsync($"> {question} \n{positiveAns}");
+            }
+            else if (chance > 10 && chance <= 40)
+            {
+                var negativeAns = EightBallResponses[Random.Shared.Next(3, 5)];
+                await ReplyAsync($"> {question} \n{negativeAns}");
+            }
+            else
+            {
+                var succAns = EightBallResponses[Random.Shared.Next(5, 8)];
+                await ReplyAsync($"> {question} \n{succAns}");
+            }
         }
+    }
+
+    private bool IsPunMaster()
+    {
+        return (Context.Message.Author.Id == 262010462323998720);
+    }
+
+    private async Task SendImageFromUrl(Uri url)
+    {
+        try
+        {
+            using var response = await HttpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
+            response.EnsureSuccessStatusCode();
+            using Stream image = await response.Content.ReadAsStreamAsync();
+            await Context.Channel.SendFileAsync(image, "image.png");
+        }
+        catch (Exception ex)
+        {
+            BeanBotLog.ImageDownloadFailed(_logger, url, ex);
+            await ReplyAsync("I couldn't download that image right now.");
+        }
+    }
+
+    internal static string NormalizeSuccTarget(IEnumerable<string> input, string authorMention)
+    {
+        var words = (input ?? []).ToList();
+        if (words.Count > 0 && string.Equals(words[0], "succ", StringComparison.OrdinalIgnoreCase))
+        {
+            words.RemoveAt(0);
+        }
+
+        var target = string.Join(" ", words).Trim();
+        if (string.IsNullOrWhiteSpace(target) ||
+            target.Contains("Bean Bot", StringComparison.OrdinalIgnoreCase) ||
+            target.Contains("<@!630470467261693982>", StringComparison.Ordinal))
+        {
+            return authorMention;
+        }
+
+        return target;
+    }
+
+    private async Task ReplyWithOchoOcho()
+    {
+        var pages = new[] { "One plus one, equals two.", "Two plus two, equals four.", "Four plus four, equals eight.", "Doblehin ang eight.", "Tayo'y mag ocho ocho, ocho ocho, mag ocho ocho pa" };
+        await _paginator.SendAsync(Context, pages);
     }
 }

--- a/BeanBot/Program.cs
+++ b/BeanBot/Program.cs
@@ -1,84 +1,77 @@
-using BeanBot.Hosting;
 using BeanBot.Configuration;
+using BeanBot.Hosting;
 using BeanBot.Util;
-
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-
 using Serilog;
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
+namespace BeanBot;
 
-namespace BeanBot
+internal static class Program
 {
-    internal static class Program
-    {
-        internal static readonly TimeSpan HostShutdownTimeout = TimeSpan.FromMinutes(2);
+    internal static readonly TimeSpan HostShutdownTimeout = TimeSpan.FromMinutes(2);
 
-        private static async Task<int> Main(string[] args)
+    private static async Task<int> Main(string[] args)
+    {
+        IHost? host = null;
+        Log.Logger = LogHandler.CreateBootstrapLogger();
+        try
         {
-            IHost? host = null;
-            Log.Logger = LogHandler.CreateBootstrapLogger();
+            DirectorySetup.MakeSureAllDirectoriesExist();
+
+            var builder = Host.CreateApplicationBuilder(args);
+            builder.Configuration.AddBeanBotConfiguration();
+            builder.Logging.ClearProviders();
+            builder.Services.Configure<HostOptions>(options =>
+                options.ShutdownTimeout = HostShutdownTimeout);
+            builder.Services.AddBeanBot(builder.Configuration);
+            builder.Services.AddSerilog((services, loggerConfiguration) =>
+                LogHandler.ConfigureLogger(
+                    loggerConfiguration,
+                    services.GetRequiredService<DiscordOwnerErrorNotifier>()));
+
+            host = builder.Build();
+
+            await host.RunAsync();
+            return 0;
+        }
+        catch (OperationCanceledException) when (IsHostStopping(host))
+        {
+            Log.Warning("Shutting down");
+            return 0;
+        }
+        catch (Exception exception)
+        {
+            Log.Fatal(exception, "BeanBot terminated because of an unhandled exception");
+            return 1;
+        }
+        finally
+        {
             try
             {
-                DirectorySetup.MakeSureAllDirectoriesExist();
-
-                var builder = Host.CreateApplicationBuilder(args);
-                builder.Configuration.AddBeanBotConfiguration();
-                builder.Logging.ClearProviders();
-                builder.Services.Configure<HostOptions>(options =>
-                    options.ShutdownTimeout = HostShutdownTimeout);
-                builder.Services.AddBeanBot(builder.Configuration);
-                builder.Services.AddSerilog((services, loggerConfiguration) =>
-                    LogHandler.ConfigureLogger(
-                        loggerConfiguration,
-                        services.GetRequiredService<DiscordOwnerErrorNotifier>()));
-
-                host = builder.Build();
-
-                await host.RunAsync();
-                return 0;
-            }
-            catch (OperationCanceledException) when (IsHostStopping(host))
-            {
-                Log.Warning("Shutting down");
-                return 0;
-            }
-            catch (Exception exception)
-            {
-                Log.Fatal(exception, "BeanBot terminated because of an unhandled exception");
-                return 1;
+                if (host is not null)
+                {
+                    if (host is IAsyncDisposable asyncDisposableHost)
+                    {
+                        await asyncDisposableHost.DisposeAsync();
+                    }
+                    else
+                    {
+                        host.Dispose();
+                    }
+                }
             }
             finally
             {
-                try
-                {
-                    if (host is not null)
-                    {
-                        if (host is IAsyncDisposable asyncDisposableHost)
-                        {
-                            await asyncDisposableHost.DisposeAsync();
-                        }
-                        else
-                        {
-                            host.Dispose();
-                        }
-                    }
-                }
-                finally
-                {
-                    await Log.CloseAndFlushAsync();
-                }
+                await Log.CloseAndFlushAsync();
             }
         }
-
-        private static bool IsHostStopping(IHost? host)
-            => host?.Services
-                .GetService<IHostApplicationLifetime>()
-                ?.ApplicationStopping
-                .IsCancellationRequested == true;
     }
+
+    private static bool IsHostStopping(IHost? host)
+        => host?.Services
+            .GetService<IHostApplicationLifetime>()
+            ?.ApplicationStopping
+            .IsCancellationRequested == true;
 }

--- a/BeanBot/Repository/RoleReactRepository.cs
+++ b/BeanBot/Repository/RoleReactRepository.cs
@@ -1,107 +1,99 @@
+using System.Globalization;
 using BeanBot.Entities;
 using BeanBot.Util;
-
 using Microsoft.Extensions.Logging;
-
 using MongoDB.Driver;
 
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Threading;
-using System.Threading.Tasks;
+namespace BeanBot.Repository;
 
-namespace BeanBot.Repository
+internal interface IRoleSettingsStore
 {
-    internal interface IRoleSettingsStore
+    Task InsertAsync(RoleSettings roleSettings, CancellationToken cancellationToken);
+    Task<List<RoleSettings>> GetRecentAsync(DateTime oldestLastAccessedUtc, CancellationToken cancellationToken);
+    Task<RoleSettings?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken);
+}
+
+internal sealed class MongoRoleSettingsStore : IRoleSettingsStore
+{
+    private readonly IMongoCollection<RoleSettings> _roleSettings;
+
+    public MongoRoleSettingsStore(IMongoDatabase database)
     {
-        Task InsertAsync(RoleSettings roleSettings, CancellationToken cancellationToken);
-        Task<List<RoleSettings>> GetRecentAsync(DateTime oldestLastAccessedUtc, CancellationToken cancellationToken);
-        Task<RoleSettings?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken);
+        _roleSettings = (database ?? throw new ArgumentNullException(nameof(database)))
+            .GetCollection<RoleSettings>("roleSettings");
     }
 
-    internal sealed class MongoRoleSettingsStore : IRoleSettingsStore
+    public Task InsertAsync(RoleSettings roleSettings, CancellationToken cancellationToken)
+        => _roleSettings.InsertOneAsync(roleSettings, cancellationToken: cancellationToken);
+
+    public async Task<List<RoleSettings>> GetRecentAsync(
+        DateTime oldestLastAccessedUtc,
+        CancellationToken cancellationToken)
     {
-        private readonly IMongoCollection<RoleSettings> _roleSettings;
-
-        public MongoRoleSettingsStore(IMongoDatabase database)
-        {
-            _roleSettings = (database ?? throw new ArgumentNullException(nameof(database)))
-                .GetCollection<RoleSettings>("roleSettings");
-        }
-
-        public Task InsertAsync(RoleSettings roleSettings, CancellationToken cancellationToken)
-            => _roleSettings.InsertOneAsync(roleSettings, cancellationToken: cancellationToken);
-
-        public async Task<List<RoleSettings>> GetRecentAsync(
-            DateTime oldestLastAccessedUtc,
-            CancellationToken cancellationToken)
-        {
-            var filter = Builders<RoleSettings>.Filter.Where(
-                result => result.LastAccessedUtc >= oldestLastAccessedUtc);
-            using var results = await _roleSettings.FindAsync(
-                filter,
-                cancellationToken: cancellationToken);
-            return await results.ToListAsync(cancellationToken);
-        }
-
-        public async Task<RoleSettings?> GetByMessageIdAsync(
-            string messageId,
-            CancellationToken cancellationToken)
-        {
-            var filter = Builders<RoleSettings>.Filter.Where(
-                document => document.MessageId == messageId);
-            return await _roleSettings.Find(filter).FirstOrDefaultAsync(cancellationToken);
-        }
+        var filter = Builders<RoleSettings>.Filter.Where(
+            result => result.LastAccessedUtc >= oldestLastAccessedUtc);
+        using var results = await _roleSettings.FindAsync(
+            filter,
+            cancellationToken: cancellationToken);
+        return await results.ToListAsync(cancellationToken);
     }
 
-    public sealed class RoleReactRepository
+    public async Task<RoleSettings?> GetByMessageIdAsync(
+        string messageId,
+        CancellationToken cancellationToken)
     {
-        private readonly IRoleSettingsStore _roleSettingsStore;
-        private readonly ILogger<RoleReactRepository> _logger;
+        var filter = Builders<RoleSettings>.Filter.Where(
+            document => document.MessageId == messageId);
+        return await _roleSettings.Find(filter).FirstOrDefaultAsync(cancellationToken);
+    }
+}
 
-        public RoleReactRepository(
-            IMongoDatabase database,
-            ILogger<RoleReactRepository> logger)
-            : this(new MongoRoleSettingsStore(database), logger)
-        {
-        }
+public sealed class RoleReactRepository
+{
+    private readonly IRoleSettingsStore _roleSettingsStore;
+    private readonly ILogger<RoleReactRepository> _logger;
 
-        internal RoleReactRepository(
-            IRoleSettingsStore roleSettingsStore,
-            ILogger<RoleReactRepository> logger)
-        {
-            _roleSettingsStore = roleSettingsStore ?? throw new ArgumentNullException(nameof(roleSettingsStore));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        }
+    public RoleReactRepository(
+        IMongoDatabase database,
+        ILogger<RoleReactRepository> logger)
+        : this(new MongoRoleSettingsStore(database), logger)
+    {
+    }
 
-        public async Task InsertNewRoleSettings(
-            RoleSettings roleSettings,
-            CancellationToken cancellationToken = default)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            roleSettings.LastAccessedUtc = DateTime.UtcNow;
-            await _roleSettingsStore.InsertAsync(roleSettings, cancellationToken);
-            BeanBotLog.ReactionRoleSettingsCreated(_logger, roleSettings.MessageId);
-        }
+    internal RoleReactRepository(
+        IRoleSettingsStore roleSettingsStore,
+        ILogger<RoleReactRepository> logger)
+    {
+        _roleSettingsStore = roleSettingsStore ?? throw new ArgumentNullException(nameof(roleSettingsStore));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
 
-        public Task<List<RoleSettings>> GetRecentRoleSettings(
-            CancellationToken cancellationToken = default)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            return _roleSettingsStore.GetRecentAsync(
-                DateTime.UtcNow.AddDays(-30),
-                cancellationToken);
-        }
+    public async Task InsertNewRoleSettings(
+        RoleSettings roleSettings,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        roleSettings.LastAccessedUtc = DateTime.UtcNow;
+        await _roleSettingsStore.InsertAsync(roleSettings, cancellationToken);
+        BeanBotLog.ReactionRoleSettingsCreated(_logger, roleSettings.MessageId);
+    }
 
-        public Task<RoleSettings?> GetRoleSetting(
-            ulong messageId,
-            CancellationToken cancellationToken = default)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            return _roleSettingsStore.GetByMessageIdAsync(
-                messageId.ToString(CultureInfo.InvariantCulture),
-                cancellationToken);
-        }
+    public Task<List<RoleSettings>> GetRecentRoleSettings(
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return _roleSettingsStore.GetRecentAsync(
+            DateTime.UtcNow.AddDays(-30),
+            cancellationToken);
+    }
+
+    public Task<RoleSettings?> GetRoleSetting(
+        ulong messageId,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return _roleSettingsStore.GetByMessageIdAsync(
+            messageId.ToString(CultureInfo.InvariantCulture),
+            cancellationToken);
     }
 }

--- a/BeanBot/Services/BoundedClientRateLimiter.cs
+++ b/BeanBot/Services/BoundedClientRateLimiter.cs
@@ -1,160 +1,156 @@
-using System;
-using System.Collections.Generic;
+namespace BeanBot.Services;
 
-namespace BeanBot.Services
+internal sealed class BoundedClientRateLimiter
 {
-    internal sealed class BoundedClientRateLimiter
+    private const int CleanupFrequency = 64;
+    private readonly object _sync = new();
+    private readonly Dictionary<string, ClientEntry> _clients = new(StringComparer.Ordinal);
+    private readonly PriorityQueue<ExpirationCandidate, DateTimeOffset> _expirations = new();
+    private readonly TimeSpan _minimumPollInterval;
+    private readonly TimeSpan _retentionPeriod;
+    private readonly int _capacity;
+    private readonly Func<DateTimeOffset> _getUtcNow;
+    private int _requestCount;
+
+    public BoundedClientRateLimiter(
+        TimeSpan minimumPollInterval,
+        int capacity,
+        Func<DateTimeOffset>? getUtcNow = null)
     {
-        private const int CleanupFrequency = 64;
-        private readonly object _sync = new object();
-        private readonly Dictionary<string, ClientEntry> _clients = new Dictionary<string, ClientEntry>(StringComparer.Ordinal);
-        private readonly PriorityQueue<ExpirationCandidate, DateTimeOffset> _expirations = new PriorityQueue<ExpirationCandidate, DateTimeOffset>();
-        private readonly TimeSpan _minimumPollInterval;
-        private readonly TimeSpan _retentionPeriod;
-        private readonly int _capacity;
-        private readonly Func<DateTimeOffset> _getUtcNow;
-        private int _requestCount;
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(minimumPollInterval, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(capacity);
 
-        public BoundedClientRateLimiter(
-            TimeSpan minimumPollInterval,
-            int capacity,
-            Func<DateTimeOffset>? getUtcNow = null)
+        _minimumPollInterval = minimumPollInterval;
+        _retentionPeriod = minimumPollInterval.Ticks <= TimeSpan.MaxValue.Ticks / 2
+            ? TimeSpan.FromTicks(minimumPollInterval.Ticks * 2)
+            : TimeSpan.MaxValue;
+        _capacity = capacity;
+        _getUtcNow = getUtcNow ?? (() => DateTimeOffset.UtcNow);
+    }
+
+    public bool IsRateLimited(string clientIdentifier, out int retryAfterSeconds)
+    {
+        if (string.IsNullOrWhiteSpace(clientIdentifier))
         {
-            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(minimumPollInterval, TimeSpan.Zero);
-            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(capacity);
-
-            _minimumPollInterval = minimumPollInterval;
-            _retentionPeriod = minimumPollInterval.Ticks <= TimeSpan.MaxValue.Ticks / 2
-                ? TimeSpan.FromTicks(minimumPollInterval.Ticks * 2)
-                : TimeSpan.MaxValue;
-            _capacity = capacity;
-            _getUtcNow = getUtcNow ?? (() => DateTimeOffset.UtcNow);
+            throw new ArgumentException("A client identifier is required.", nameof(clientIdentifier));
         }
 
-        public bool IsRateLimited(string clientIdentifier, out int retryAfterSeconds)
+        var now = _getUtcNow();
+        lock (_sync)
         {
-            if (string.IsNullOrWhiteSpace(clientIdentifier))
+            _requestCount++;
+            if (_requestCount % CleanupFrequency == 0)
             {
-                throw new ArgumentException("A client identifier is required.", nameof(clientIdentifier));
+                RemoveExpiredEntries(now);
             }
 
-            var now = _getUtcNow();
-            lock (_sync)
+            if (_clients.TryGetValue(clientIdentifier, out var existingEntry))
             {
-                _requestCount++;
-                if (_requestCount % CleanupFrequency == 0)
+                var nextAllowedAt = existingEntry.LastAllowedAt.Add(_minimumPollInterval);
+                if (now < nextAllowedAt)
                 {
-                    RemoveExpiredEntries(now);
+                    retryAfterSeconds = Math.Max(1, (int)Math.Ceiling((nextAllowedAt - now).TotalSeconds));
+                    return true;
                 }
 
-                if (_clients.TryGetValue(clientIdentifier, out var existingEntry))
-                {
-                    var nextAllowedAt = existingEntry.LastAllowedAt.Add(_minimumPollInterval);
-                    if (now < nextAllowedAt)
-                    {
-                        retryAfterSeconds = Math.Max(1, (int)Math.Ceiling((nextAllowedAt - now).TotalSeconds));
-                        return true;
-                    }
-
-                    TrackAllowedRequest(clientIdentifier, existingEntry, now);
-                    retryAfterSeconds = 0;
-                    return false;
-                }
-
-                if (_clients.Count >= _capacity)
-                {
-                    RemoveExpiredEntries(now);
-                    if (_clients.Count >= _capacity)
-                    {
-                        // Preserve active rate limits instead of evicting them early. New
-                        // clients retry after one poll interval when the bounded store is full.
-                        retryAfterSeconds = Math.Max(1, (int)Math.Ceiling(_minimumPollInterval.TotalSeconds));
-                        return true;
-                    }
-                }
-
-                var entry = new ClientEntry();
-                _clients.Add(clientIdentifier, entry);
-                TrackAllowedRequest(clientIdentifier, entry, now);
+                TrackAllowedRequest(clientIdentifier, existingEntry, now);
                 retryAfterSeconds = 0;
                 return false;
             }
-        }
 
-        internal int CleanupStaleEntries()
+            if (_clients.Count >= _capacity)
+            {
+                RemoveExpiredEntries(now);
+                if (_clients.Count >= _capacity)
+                {
+                    // Preserve active rate limits instead of evicting them early. New
+                    // clients retry after one poll interval when the bounded store is full.
+                    retryAfterSeconds = Math.Max(1, (int)Math.Ceiling(_minimumPollInterval.TotalSeconds));
+                    return true;
+                }
+            }
+
+            var entry = new ClientEntry();
+            _clients.Add(clientIdentifier, entry);
+            TrackAllowedRequest(clientIdentifier, entry, now);
+            retryAfterSeconds = 0;
+            return false;
+        }
+    }
+
+    internal int CleanupStaleEntries()
+    {
+        lock (_sync)
+        {
+            return RemoveExpiredEntries(_getUtcNow());
+        }
+    }
+
+    internal int TrackedClientCount
+    {
+        get
         {
             lock (_sync)
             {
-                return RemoveExpiredEntries(_getUtcNow());
+                return _clients.Count;
             }
         }
+    }
 
-        internal int TrackedClientCount
+    private void TrackAllowedRequest(string clientIdentifier, ClientEntry entry, DateTimeOffset now)
+    {
+        entry.LastAllowedAt = now;
+        entry.ExpiresAt = AddSafely(now, _retentionPeriod);
+        entry.Version++;
+        _expirations.Enqueue(
+            new ExpirationCandidate(clientIdentifier, entry.Version),
+            entry.ExpiresAt);
+    }
+
+    private int RemoveExpiredEntries(DateTimeOffset now)
+    {
+        var removed = 0;
+        while (_expirations.TryPeek(out var candidate, out var expiresAt) && expiresAt <= now)
         {
-            get
+            _expirations.Dequeue();
+            if (_clients.TryGetValue(candidate.ClientIdentifier, out var entry) &&
+                entry.Version == candidate.Version &&
+                entry.ExpiresAt <= now &&
+                _clients.Remove(candidate.ClientIdentifier))
             {
-                lock (_sync)
-                {
-                    return _clients.Count;
-                }
+                removed++;
             }
         }
 
-        private void TrackAllowedRequest(string clientIdentifier, ClientEntry entry, DateTimeOffset now)
+        return removed;
+    }
+
+    private static DateTimeOffset AddSafely(DateTimeOffset value, TimeSpan duration)
+    {
+        if (duration == TimeSpan.MaxValue || duration > DateTimeOffset.MaxValue - value)
         {
-            entry.LastAllowedAt = now;
-            entry.ExpiresAt = AddSafely(now, _retentionPeriod);
-            entry.Version++;
-            _expirations.Enqueue(
-                new ExpirationCandidate(clientIdentifier, entry.Version),
-                entry.ExpiresAt);
+            return DateTimeOffset.MaxValue;
         }
 
-        private int RemoveExpiredEntries(DateTimeOffset now)
-        {
-            var removed = 0;
-            while (_expirations.TryPeek(out var candidate, out var expiresAt) && expiresAt <= now)
-            {
-                _expirations.Dequeue();
-                if (_clients.TryGetValue(candidate.ClientIdentifier, out var entry) &&
-                    entry.Version == candidate.Version &&
-                    entry.ExpiresAt <= now &&
-                    _clients.Remove(candidate.ClientIdentifier))
-                {
-                    removed++;
-                }
-            }
+        return value.Add(duration);
+    }
 
-            return removed;
+    private sealed class ClientEntry
+    {
+        public DateTimeOffset LastAllowedAt { get; set; }
+        public DateTimeOffset ExpiresAt { get; set; }
+        public long Version { get; set; }
+    }
+
+    private readonly struct ExpirationCandidate
+    {
+        public ExpirationCandidate(string clientIdentifier, long version)
+        {
+            ClientIdentifier = clientIdentifier;
+            Version = version;
         }
 
-        private static DateTimeOffset AddSafely(DateTimeOffset value, TimeSpan duration)
-        {
-            if (duration == TimeSpan.MaxValue || duration > DateTimeOffset.MaxValue - value)
-            {
-                return DateTimeOffset.MaxValue;
-            }
-
-            return value.Add(duration);
-        }
-
-        private sealed class ClientEntry
-        {
-            public DateTimeOffset LastAllowedAt { get; set; }
-            public DateTimeOffset ExpiresAt { get; set; }
-            public long Version { get; set; }
-        }
-
-        private readonly struct ExpirationCandidate
-        {
-            public ExpirationCandidate(string clientIdentifier, long version)
-            {
-                ClientIdentifier = clientIdentifier;
-                Version = version;
-            }
-
-            public string ClientIdentifier { get; }
-            public long Version { get; }
-        }
+        public string ClientIdentifier { get; }
+        public long Version { get; }
     }
 }

--- a/BeanBot/Services/DiscordConnectionHealth.cs
+++ b/BeanBot/Services/DiscordConnectionHealth.cs
@@ -1,118 +1,115 @@
 using Discord;
 using Discord.WebSocket;
 
-using System;
+namespace BeanBot.Services;
 
-namespace BeanBot.Services
+public sealed class DiscordConnectionHealth
 {
-    public sealed class DiscordConnectionHealth
+    private readonly object _syncRoot = new();
+    private bool _gatewayReady;
+    private DateTimeOffset? _lastReadyAtUtc;
+    private DateTimeOffset? _lastDisconnectedAtUtc;
+    private DateTimeOffset? _unhealthySinceAtUtc;
+    private string? _mostRecentDisconnectReason;
+
+    public void MarkReady()
     {
-        private readonly object _syncRoot = new();
-        private bool _gatewayReady;
-        private DateTimeOffset? _lastReadyAtUtc;
-        private DateTimeOffset? _lastDisconnectedAtUtc;
-        private DateTimeOffset? _unhealthySinceAtUtc;
-        private string? _mostRecentDisconnectReason;
-
-        public void MarkReady()
+        lock (_syncRoot)
         {
-            lock (_syncRoot)
-            {
-                _gatewayReady = true;
-                _lastReadyAtUtc = DateTimeOffset.UtcNow;
-                _unhealthySinceAtUtc = null;
-            }
-        }
-
-        public void MarkDisconnected(Exception? exception)
-        {
-            lock (_syncRoot)
-            {
-                var disconnectedAtUtc = DateTimeOffset.UtcNow;
-                _gatewayReady = false;
-                _lastDisconnectedAtUtc = disconnectedAtUtc;
-                _unhealthySinceAtUtc ??= disconnectedAtUtc;
-                _mostRecentDisconnectReason = exception?.Message ?? "Discord gateway disconnected.";
-            }
-        }
-
-        public DiscordHealthSnapshot CreateSnapshot(DiscordSocketClient discordClient)
-        {
-            lock (_syncRoot)
-            {
-                var loginState = discordClient.LoginState;
-                var connectionState = discordClient.ConnectionState;
-                var isHealthy = loginState == LoginState.LoggedIn
-                    && connectionState == ConnectionState.Connected
-                    && _gatewayReady;
-
-                return new DiscordHealthSnapshot(
-                    isHealthy,
-                    GetStatusMessage(loginState, connectionState),
-                    loginState.ToString(),
-                    connectionState.ToString(),
-                    _lastReadyAtUtc,
-                    _lastDisconnectedAtUtc,
-                    _unhealthySinceAtUtc,
-                    _mostRecentDisconnectReason);
-            }
-        }
-
-        private string GetStatusMessage(LoginState loginState, ConnectionState connectionState)
-        {
-            if (_gatewayReady && loginState == LoginState.LoggedIn && connectionState == ConnectionState.Connected)
-            {
-                return "BeanBot is connected to Discord.";
-            }
-
-            if (_mostRecentDisconnectReason is not null)
-            {
-                return $"{_mostRecentDisconnectReason} Current state: login={loginState}, connection={connectionState}.";
-            }
-
-            if (!_gatewayReady)
-            {
-                return "Discord gateway has not reached the Ready state yet.";
-            }
-
-            if (loginState != LoginState.LoggedIn)
-            {
-                return $"Discord login state is {loginState}.";
-            }
-
-            return $"Discord connection state is {connectionState}.";
+            _gatewayReady = true;
+            _lastReadyAtUtc = DateTimeOffset.UtcNow;
+            _unhealthySinceAtUtc = null;
         }
     }
 
-    public sealed class DiscordHealthSnapshot
+    public void MarkDisconnected(Exception? exception)
     {
-        public DiscordHealthSnapshot(
-            bool isHealthy,
-            string statusMessage,
-            string loginState,
-            string connectionState,
-            DateTimeOffset? lastReadyAtUtc,
-            DateTimeOffset? lastDisconnectedAtUtc,
-            DateTimeOffset? unhealthySinceAtUtc,
-            string? mostRecentDisconnectReason)
+        lock (_syncRoot)
         {
-            IsHealthy = isHealthy;
-            StatusMessage = statusMessage;
-            LoginState = loginState;
-            ConnectionState = connectionState;
-            LastReadyAtUtc = lastReadyAtUtc;
-            LastDisconnectedAtUtc = lastDisconnectedAtUtc;
-            UnhealthySinceAtUtc = unhealthySinceAtUtc;
-            MostRecentDisconnectReason = mostRecentDisconnectReason;
+            var disconnectedAtUtc = DateTimeOffset.UtcNow;
+            _gatewayReady = false;
+            _lastDisconnectedAtUtc = disconnectedAtUtc;
+            _unhealthySinceAtUtc ??= disconnectedAtUtc;
+            _mostRecentDisconnectReason = exception?.Message ?? "Discord gateway disconnected.";
+        }
+    }
+
+    public DiscordHealthSnapshot CreateSnapshot(DiscordSocketClient discordClient)
+    {
+        lock (_syncRoot)
+        {
+            var loginState = discordClient.LoginState;
+            var connectionState = discordClient.ConnectionState;
+            var isHealthy = loginState == LoginState.LoggedIn
+                && connectionState == ConnectionState.Connected
+                && _gatewayReady;
+
+            return new DiscordHealthSnapshot(
+                isHealthy,
+                GetStatusMessage(loginState, connectionState),
+                loginState.ToString(),
+                connectionState.ToString(),
+                _lastReadyAtUtc,
+                _lastDisconnectedAtUtc,
+                _unhealthySinceAtUtc,
+                _mostRecentDisconnectReason);
+        }
+    }
+
+    private string GetStatusMessage(LoginState loginState, ConnectionState connectionState)
+    {
+        if (_gatewayReady && loginState == LoginState.LoggedIn && connectionState == ConnectionState.Connected)
+        {
+            return "BeanBot is connected to Discord.";
         }
 
-        public bool IsHealthy { get; }
-        public string StatusMessage { get; }
-        public string LoginState { get; }
-        public string ConnectionState { get; }
-        public DateTimeOffset? LastReadyAtUtc { get; }
-        public DateTimeOffset? LastDisconnectedAtUtc { get; }
-        public DateTimeOffset? UnhealthySinceAtUtc { get; }
-        public string? MostRecentDisconnectReason { get; }
+        if (_mostRecentDisconnectReason is not null)
+        {
+            return $"{_mostRecentDisconnectReason} Current state: login={loginState}, connection={connectionState}.";
+        }
+
+        if (!_gatewayReady)
+        {
+            return "Discord gateway has not reached the Ready state yet.";
+        }
+
+        if (loginState != LoginState.LoggedIn)
+        {
+            return $"Discord login state is {loginState}.";
+        }
+
+        return $"Discord connection state is {connectionState}.";
     }
+}
+
+public sealed class DiscordHealthSnapshot
+{
+    public DiscordHealthSnapshot(
+        bool isHealthy,
+        string statusMessage,
+        string loginState,
+        string connectionState,
+        DateTimeOffset? lastReadyAtUtc,
+        DateTimeOffset? lastDisconnectedAtUtc,
+        DateTimeOffset? unhealthySinceAtUtc,
+        string? mostRecentDisconnectReason)
+    {
+        IsHealthy = isHealthy;
+        StatusMessage = statusMessage;
+        LoginState = loginState;
+        ConnectionState = connectionState;
+        LastReadyAtUtc = lastReadyAtUtc;
+        LastDisconnectedAtUtc = lastDisconnectedAtUtc;
+        UnhealthySinceAtUtc = unhealthySinceAtUtc;
+        MostRecentDisconnectReason = mostRecentDisconnectReason;
+    }
+
+    public bool IsHealthy { get; }
+    public string StatusMessage { get; }
+    public string LoginState { get; }
+    public string ConnectionState { get; }
+    public DateTimeOffset? LastReadyAtUtc { get; }
+    public DateTimeOffset? LastDisconnectedAtUtc { get; }
+    public DateTimeOffset? UnhealthySinceAtUtc { get; }
+    public string? MostRecentDisconnectReason { get; }
 }

--- a/BeanBot/Services/DiscordGatewayRecoveryService.cs
+++ b/BeanBot/Services/DiscordGatewayRecoveryService.cs
@@ -1,294 +1,310 @@
+using System.Diagnostics;
 using BeanBot.Util;
 using Discord;
 using Discord.WebSocket;
-
 using Microsoft.Extensions.Logging;
 
-using System;
-using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
+namespace BeanBot.Services;
 
-namespace BeanBot.Services
+internal sealed class DiscordGatewayRecoveryOptions
 {
-    internal sealed class DiscordGatewayRecoveryOptions
-    {
-        public static DiscordGatewayRecoveryOptions Default { get; } = new(
-            TimeSpan.FromMinutes(5),
-            TimeSpan.FromSeconds(30),
-            TimeSpan.FromMinutes(2));
+    public static DiscordGatewayRecoveryOptions Default { get; } = new(
+        TimeSpan.FromMinutes(5),
+        TimeSpan.FromSeconds(30),
+        TimeSpan.FromMinutes(2));
 
-        public DiscordGatewayRecoveryOptions(
-            TimeSpan builtInRecoveryGracePeriod,
-            TimeSpan lifecycleOperationTimeout,
-            TimeSpan readyTimeout)
+    public DiscordGatewayRecoveryOptions(
+        TimeSpan builtInRecoveryGracePeriod,
+        TimeSpan lifecycleOperationTimeout,
+        TimeSpan readyTimeout)
+    {
+        BuiltInRecoveryGracePeriod = builtInRecoveryGracePeriod;
+        LifecycleOperationTimeout = lifecycleOperationTimeout;
+        ReadyTimeout = readyTimeout;
+    }
+
+    public TimeSpan BuiltInRecoveryGracePeriod { get; }
+    public TimeSpan LifecycleOperationTimeout { get; }
+    public TimeSpan ReadyTimeout { get; }
+}
+
+internal interface IDiscordGatewayLifecycle
+{
+    Task ReconnectAsync(CancellationToken cancellationToken);
+}
+
+internal interface IRecoveryDelay
+{
+    Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken);
+}
+
+internal sealed class TaskRecoveryDelay : IRecoveryDelay
+{
+    public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+        => Task.Delay(delay, cancellationToken);
+}
+
+internal sealed class DiscordGatewayLifecycle : IDiscordGatewayLifecycle
+{
+    private readonly DiscordSocketClient _client;
+    private readonly string _botToken;
+    private readonly TimeSpan _operationTimeout;
+    private readonly ILogger<DiscordGatewayLifecycle> _logger;
+
+    public DiscordGatewayLifecycle(
+        DiscordSocketClient client,
+        string botToken,
+        TimeSpan operationTimeout,
+        ILogger<DiscordGatewayLifecycle> logger)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _botToken = botToken ?? throw new ArgumentNullException(nameof(botToken));
+        _operationTimeout = operationTimeout;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task ReconnectAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await RunBoundedAsync(_client.StopAsync(), "stop");
+        cancellationToken.ThrowIfCancellationRequested();
+        await RunBoundedAsync(_client.LogoutAsync(), "logout");
+        cancellationToken.ThrowIfCancellationRequested();
+        await RunBoundedAsync(
+            _client.LoginAsync(TokenType.Bot, _botToken),
+            "login");
+        cancellationToken.ThrowIfCancellationRequested();
+        await RunBoundedAsync(_client.StartAsync(), "start");
+    }
+
+    private async Task RunBoundedAsync(
+        Task operation,
+        string operationName)
+    {
+        try
         {
-            BuiltInRecoveryGracePeriod = builtInRecoveryGracePeriod;
-            LifecycleOperationTimeout = lifecycleOperationTimeout;
-            ReadyTimeout = readyTimeout;
+            // Once a Discord lifecycle operation starts, let it finish (or time out)
+            // instead of abandoning it midway and racing normal shutdown cleanup.
+            await operation.WaitAsync(_operationTimeout);
         }
-
-        public TimeSpan BuiltInRecoveryGracePeriod { get; }
-        public TimeSpan LifecycleOperationTimeout { get; }
-        public TimeSpan ReadyTimeout { get; }
-    }
-
-    internal interface IDiscordGatewayLifecycle
-    {
-        Task ReconnectAsync(CancellationToken cancellationToken);
-    }
-
-    internal interface IRecoveryDelay
-    {
-        Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken);
-    }
-
-    internal sealed class TaskRecoveryDelay : IRecoveryDelay
-    {
-        public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
-            => Task.Delay(delay, cancellationToken);
-    }
-
-    internal sealed class DiscordGatewayLifecycle : IDiscordGatewayLifecycle
-    {
-        private readonly DiscordSocketClient _client;
-        private readonly string _botToken;
-        private readonly TimeSpan _operationTimeout;
-        private readonly ILogger<DiscordGatewayLifecycle> _logger;
-
-        public DiscordGatewayLifecycle(
-            DiscordSocketClient client,
-            string botToken,
-            TimeSpan operationTimeout,
-            ILogger<DiscordGatewayLifecycle> logger)
+        catch
         {
-            _client = client ?? throw new ArgumentNullException(nameof(client));
-            _botToken = botToken ?? throw new ArgumentNullException(nameof(botToken));
-            _operationTimeout = operationTimeout;
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        }
-
-        public async Task ReconnectAsync(CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            await RunBoundedAsync(_client.StopAsync(), "stop");
-            cancellationToken.ThrowIfCancellationRequested();
-            await RunBoundedAsync(_client.LogoutAsync(), "logout");
-            cancellationToken.ThrowIfCancellationRequested();
-            await RunBoundedAsync(
-                _client.LoginAsync(TokenType.Bot, _botToken),
-                "login");
-            cancellationToken.ThrowIfCancellationRequested();
-            await RunBoundedAsync(_client.StartAsync(), "start");
-        }
-
-        private async Task RunBoundedAsync(
-            Task operation,
-            string operationName)
-        {
-            try
+            if (!operation.IsCompleted)
             {
-                // Once a Discord lifecycle operation starts, let it finish (or time out)
-                // instead of abandoning it midway and racing normal shutdown cleanup.
-                await operation.WaitAsync(_operationTimeout);
+                ObserveLateFailure(operation, operationName);
             }
-            catch
-            {
-                if (!operation.IsCompleted)
-                {
-                    ObserveLateFailure(operation, operationName);
-                }
 
-                throw;
-            }
-        }
-
-        private void ObserveLateFailure(Task operation, string operationName)
-        {
-            _ = operation.ContinueWith(
-                completedTask => BeanBotLog.DiscordRecoveryLateFailure(
-                    _logger,
-                    operationName,
-                    completedTask.Exception),
-                CancellationToken.None,
-                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
-                TaskScheduler.Default);
+            throw;
         }
     }
 
-    internal sealed class DiscordGatewayRecoveryService : IAsyncDisposable
+    private void ObserveLateFailure(Task operation, string operationName)
     {
-        private readonly object _syncRoot = new();
-        private readonly Func<DiscordHealthSnapshot> _createHealthSnapshot;
-        private readonly IDiscordGatewayLifecycle _lifecycle;
-        private readonly IDiscordOutageStore _outageStore;
-        private readonly DiscordGatewayRecoveryOptions _options;
-        private readonly IRecoveryDelay _delay;
-        private readonly Action<int> _exitProcess;
-        private readonly ILogger<DiscordGatewayRecoveryService> _logger;
-        private readonly CancellationTokenSource _shutdown = new();
-        private TaskCompletionSource<bool>? _readySignal;
-        private Task? _monitorTask;
-        private bool _disposed;
-
-        public DiscordGatewayRecoveryService(
-            Func<DiscordHealthSnapshot> createHealthSnapshot,
-            IDiscordGatewayLifecycle lifecycle,
-            IDiscordOutageStore outageStore,
-            ILogger<DiscordGatewayRecoveryService> logger,
-            DiscordGatewayRecoveryOptions? options = null,
-            IRecoveryDelay? delay = null,
-            Action<int>? exitProcess = null)
-        {
-            _createHealthSnapshot = createHealthSnapshot ?? throw new ArgumentNullException(nameof(createHealthSnapshot));
-            _lifecycle = lifecycle ?? throw new ArgumentNullException(nameof(lifecycle));
-            _outageStore = outageStore ?? throw new ArgumentNullException(nameof(outageStore));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _options = options ?? DiscordGatewayRecoveryOptions.Default;
-            _delay = delay ?? new TaskRecoveryDelay();
-            _exitProcess = exitProcess ?? Environment.Exit;
-        }
-
-        public bool StartMonitoring()
-        {
-            lock (_syncRoot)
-            {
-                if (_disposed || _shutdown.IsCancellationRequested || (_monitorTask?.IsCompleted == false))
-                {
-                    return false;
-                }
-
-                var snapshot = _createHealthSnapshot();
-                if (snapshot.IsHealthy)
-                {
-                    return false;
-                }
-
-                _readySignal = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                _monitorTask = MonitorAsync(snapshot);
-                return true;
-            }
-        }
-
-        public void NotifyReady()
-        {
-            lock (_syncRoot)
-            {
-                _readySignal?.TrySetResult(true);
-            }
-        }
-
-        internal Task WaitForIdleAsync()
-        {
-            lock (_syncRoot)
-            {
-                return _monitorTask ?? Task.CompletedTask;
-            }
-        }
-
-        private async Task MonitorAsync(DiscordHealthSnapshot initialSnapshot)
-        {
-            var unhealthySince = initialSnapshot.UnhealthySinceAtUtc ?? DateTimeOffset.UtcNow;
-            BeanBotLog.DiscordRecoveryGraceStarted(
+        _ = operation.ContinueWith(
+            completedTask => BeanBotLog.DiscordRecoveryLateFailure(
                 _logger,
-                initialSnapshot.LoginState,
-                initialSnapshot.ConnectionState,
+                operationName,
+                completedTask.Exception),
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+}
+
+internal sealed class DiscordGatewayRecoveryService : IAsyncDisposable
+{
+    private readonly object _syncRoot = new();
+    private readonly Func<DiscordHealthSnapshot> _createHealthSnapshot;
+    private readonly IDiscordGatewayLifecycle _lifecycle;
+    private readonly IDiscordOutageStore _outageStore;
+    private readonly DiscordGatewayRecoveryOptions _options;
+    private readonly IRecoveryDelay _delay;
+    private readonly Action<int> _exitProcess;
+    private readonly ILogger<DiscordGatewayRecoveryService> _logger;
+    private readonly CancellationTokenSource _shutdown = new();
+    private TaskCompletionSource<bool>? _readySignal;
+    private Task? _monitorTask;
+    private bool _disposed;
+
+    public DiscordGatewayRecoveryService(
+        Func<DiscordHealthSnapshot> createHealthSnapshot,
+        IDiscordGatewayLifecycle lifecycle,
+        IDiscordOutageStore outageStore,
+        ILogger<DiscordGatewayRecoveryService> logger,
+        DiscordGatewayRecoveryOptions? options = null,
+        IRecoveryDelay? delay = null,
+        Action<int>? exitProcess = null)
+    {
+        _createHealthSnapshot = createHealthSnapshot ?? throw new ArgumentNullException(nameof(createHealthSnapshot));
+        _lifecycle = lifecycle ?? throw new ArgumentNullException(nameof(lifecycle));
+        _outageStore = outageStore ?? throw new ArgumentNullException(nameof(outageStore));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _options = options ?? DiscordGatewayRecoveryOptions.Default;
+        _delay = delay ?? new TaskRecoveryDelay();
+        _exitProcess = exitProcess ?? Environment.Exit;
+    }
+
+    public bool StartMonitoring()
+    {
+        lock (_syncRoot)
+        {
+            if (_disposed || _shutdown.IsCancellationRequested || (_monitorTask?.IsCompleted == false))
+            {
+                return false;
+            }
+
+            var snapshot = _createHealthSnapshot();
+            if (snapshot.IsHealthy)
+            {
+                return false;
+            }
+
+            _readySignal = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _monitorTask = MonitorAsync(snapshot);
+            return true;
+        }
+    }
+
+    public void NotifyReady()
+    {
+        lock (_syncRoot)
+        {
+            _readySignal?.TrySetResult(true);
+        }
+    }
+
+    internal Task WaitForIdleAsync()
+    {
+        lock (_syncRoot)
+        {
+            return _monitorTask ?? Task.CompletedTask;
+        }
+    }
+
+    private async Task MonitorAsync(DiscordHealthSnapshot initialSnapshot)
+    {
+        var unhealthySince = initialSnapshot.UnhealthySinceAtUtc ?? DateTimeOffset.UtcNow;
+        BeanBotLog.DiscordRecoveryGraceStarted(
+            _logger,
+            initialSnapshot.LoginState,
+            initialSnapshot.ConnectionState,
+            _options.BuiltInRecoveryGracePeriod,
+            initialSnapshot.MostRecentDisconnectReason);
+
+        try
+        {
+            if (await WaitForReadyAsync(
                 _options.BuiltInRecoveryGracePeriod,
-                initialSnapshot.MostRecentDisconnectReason);
+                _shutdown.Token))
+            {
+                LogNaturalRecovery(unhealthySince);
+                return;
+            }
+
+            if (_shutdown.IsCancellationRequested)
+            {
+                return;
+            }
+
+            var snapshot = _createHealthSnapshot();
+            if (snapshot.IsHealthy)
+            {
+                LogNaturalRecovery(unhealthySince);
+                return;
+            }
+
+            BeanBotLog.DiscordManualRecoveryStarting(
+                _logger,
+                DateTimeOffset.UtcNow - unhealthySince,
+                snapshot.LoginState,
+                snapshot.ConnectionState,
+                snapshot.MostRecentDisconnectReason);
+
+            await PersistManualRecoveryAttemptAsync(unhealthySince, snapshot);
 
             try
             {
-                if (await WaitForReadyAsync(
-                    _options.BuiltInRecoveryGracePeriod,
-                    _shutdown.Token))
-                {
-                    LogNaturalRecovery(unhealthySince);
-                    return;
-                }
-
-                if (_shutdown.IsCancellationRequested)
-                {
-                    return;
-                }
-
-                var snapshot = _createHealthSnapshot();
-                if (snapshot.IsHealthy)
-                {
-                    LogNaturalRecovery(unhealthySince);
-                    return;
-                }
-
-                BeanBotLog.DiscordManualRecoveryStarting(
-                    _logger,
-                    DateTimeOffset.UtcNow - unhealthySince,
-                    snapshot.LoginState,
-                    snapshot.ConnectionState,
-                    snapshot.MostRecentDisconnectReason);
-
-                await PersistManualRecoveryAttemptAsync(unhealthySince, snapshot);
-
-                try
-                {
-                    await _lifecycle.ReconnectAsync(_shutdown.Token);
-                }
-                catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
-                {
-                    return;
-                }
-                catch (Exception exception)
-                {
-                    snapshot = _createHealthSnapshot();
-                    BeanBotLog.DiscordManualRecoveryFailed(
-                        _logger,
-                        snapshot.LoginState,
-                        snapshot.ConnectionState,
-                        snapshot.MostRecentDisconnectReason,
-                        exception);
-                }
-
-                if (await WaitForReadyAsync(
-                    _options.ReadyTimeout,
-                    _shutdown.Token))
-                {
-                    snapshot = _createHealthSnapshot();
-                    BeanBotLog.DiscordManualRecoverySucceeded(
-                        _logger,
-                        DateTimeOffset.UtcNow - unhealthySince,
-                        snapshot.LoginState,
-                        snapshot.ConnectionState);
-                    return;
-                }
-
-                if (_shutdown.IsCancellationRequested)
-                {
-                    return;
-                }
-
+                await _lifecycle.ReconnectAsync(_shutdown.Token);
+            }
+            catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception exception)
+            {
                 snapshot = _createHealthSnapshot();
-                if (snapshot.IsHealthy)
-                {
-                    BeanBotLog.DiscordManualRecoverySucceeded(
-                        _logger,
-                        DateTimeOffset.UtcNow - unhealthySince,
-                        snapshot.LoginState,
-                        snapshot.ConnectionState);
-                    return;
-                }
+                BeanBotLog.DiscordManualRecoveryFailed(
+                    _logger,
+                    snapshot.LoginState,
+                    snapshot.ConnectionState,
+                    snapshot.MostRecentDisconnectReason,
+                    exception);
+            }
 
-                BeanBotLog.DiscordManualRecoveryNotReady(
+            if (await WaitForReadyAsync(
+                _options.ReadyTimeout,
+                _shutdown.Token))
+            {
+                snapshot = _createHealthSnapshot();
+                BeanBotLog.DiscordManualRecoverySucceeded(
                     _logger,
                     DateTimeOffset.UtcNow - unhealthySince,
                     snapshot.LoginState,
-                    snapshot.ConnectionState,
-                    snapshot.MostRecentDisconnectReason);
+                    snapshot.ConnectionState);
+                return;
+            }
 
-                if (_shutdown.IsCancellationRequested)
-                {
-                    return;
-                }
+            if (_shutdown.IsCancellationRequested)
+            {
+                return;
+            }
 
-                BeanBotLog.DiscordRecoveryExhausted(_logger);
-                await PersistRestartRequestAsync(unhealthySince, snapshot);
+            snapshot = _createHealthSnapshot();
+            if (snapshot.IsHealthy)
+            {
+                BeanBotLog.DiscordManualRecoverySucceeded(
+                    _logger,
+                    DateTimeOffset.UtcNow - unhealthySince,
+                    snapshot.LoginState,
+                    snapshot.ConnectionState);
+                return;
+            }
+
+            BeanBotLog.DiscordManualRecoveryNotReady(
+                _logger,
+                DateTimeOffset.UtcNow - unhealthySince,
+                snapshot.LoginState,
+                snapshot.ConnectionState,
+                snapshot.MostRecentDisconnectReason);
+
+            if (_shutdown.IsCancellationRequested)
+            {
+                return;
+            }
+
+            BeanBotLog.DiscordRecoveryExhausted(_logger);
+            await PersistRestartRequestAsync(unhealthySince, snapshot);
+
+            if (_shutdown.IsCancellationRequested)
+            {
+                return;
+            }
+
+            _exitProcess(1);
+        }
+        catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            BeanBotLog.DiscordRecoveryMonitorFailed(_logger, exception);
+            if (!_shutdown.IsCancellationRequested)
+            {
+                BeanBotLog.DiscordRecoveryMonitorExiting(_logger);
+                var snapshot = _createHealthSnapshot();
+                await PersistRestartRequestAsync(
+                    snapshot.UnhealthySinceAtUtc ?? unhealthySince,
+                    snapshot);
 
                 if (_shutdown.IsCancellationRequested)
                 {
@@ -297,165 +313,143 @@ namespace BeanBot.Services
 
                 _exitProcess(1);
             }
-            catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
-            {
-            }
-            catch (Exception exception)
-            {
-                BeanBotLog.DiscordRecoveryMonitorFailed(_logger, exception);
-                if (!_shutdown.IsCancellationRequested)
-                {
-                    BeanBotLog.DiscordRecoveryMonitorExiting(_logger);
-                    var snapshot = _createHealthSnapshot();
-                    await PersistRestartRequestAsync(
-                        snapshot.UnhealthySinceAtUtc ?? unhealthySince,
-                        snapshot);
-
-                    if (_shutdown.IsCancellationRequested)
-                    {
-                        return;
-                    }
-
-                    _exitProcess(1);
-                }
-            }
         }
+    }
 
-        private async Task PersistManualRecoveryAttemptAsync(
-            DateTimeOffset unhealthySince,
-            DiscordHealthSnapshot snapshot)
+    private async Task PersistManualRecoveryAttemptAsync(
+        DateTimeOffset unhealthySince,
+        DiscordHealthSnapshot snapshot)
+    {
+        try
         {
-            try
-            {
-                await _outageStore.MarkManualRecoveryAttemptedAsync(
-                    unhealthySince,
-                    snapshot.MostRecentDisconnectReason,
-                    _shutdown.Token);
-            }
-            catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
-            {
-                return;
-            }
-            catch (Exception exception)
-            {
-                // Recovery must still proceed if the durable incident record cannot be written.
-                BeanBotLog.DiscordOutagePersistBeforeRecoveryFailed(_logger, unhealthySince, exception);
-            }
+            await _outageStore.MarkManualRecoveryAttemptedAsync(
+                unhealthySince,
+                snapshot.MostRecentDisconnectReason,
+                _shutdown.Token);
         }
-
-        private async Task PersistRestartRequestAsync(
-            DateTimeOffset unhealthySince,
-            DiscordHealthSnapshot snapshot)
+        catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
         {
-            try
-            {
-                await _outageStore.MarkProcessRestartRequestedAsync(
-                    unhealthySince,
-                    snapshot.MostRecentDisconnectReason,
-                    _shutdown.Token);
-            }
-            catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
-            {
-                return;
-            }
-            catch (Exception exception)
-            {
-                // The process must still exit so Docker can restore service even if persistence is unavailable.
-                BeanBotLog.DiscordOutageRestartPersistFailed(_logger, exception);
-            }
+            return;
         }
-
-        private async Task<bool> WaitForReadyAsync(
-            TimeSpan timeout,
-            CancellationToken cancellationToken)
+        catch (Exception exception)
         {
-            var stopwatch = Stopwatch.StartNew();
-            while (true)
+            // Recovery must still proceed if the durable incident record cannot be written.
+            BeanBotLog.DiscordOutagePersistBeforeRecoveryFailed(_logger, unhealthySince, exception);
+        }
+    }
+
+    private async Task PersistRestartRequestAsync(
+        DateTimeOffset unhealthySince,
+        DiscordHealthSnapshot snapshot)
+    {
+        try
+        {
+            await _outageStore.MarkProcessRestartRequestedAsync(
+                unhealthySince,
+                snapshot.MostRecentDisconnectReason,
+                _shutdown.Token);
+        }
+        catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (Exception exception)
+        {
+            // The process must still exit so Docker can restore service even if persistence is unavailable.
+            BeanBotLog.DiscordOutageRestartPersistFailed(_logger, exception);
+        }
+    }
+
+    private async Task<bool> WaitForReadyAsync(
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (true)
+        {
+            if (_createHealthSnapshot().IsHealthy)
             {
-                if (_createHealthSnapshot().IsHealthy)
-                {
-                    return true;
-                }
-
-                TaskCompletionSource<bool> readySignal;
-                lock (_syncRoot)
-                {
-                    readySignal = _readySignal
-                        ?? throw new InvalidOperationException("Discord gateway recovery has no Ready signal.");
-                }
-
-                var remaining = timeout - stopwatch.Elapsed;
-                if (remaining <= TimeSpan.Zero)
-                {
-                    return false;
-                }
-
-                using var delayCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                var timeoutTask = _delay.DelayAsync(remaining, delayCancellation.Token);
-                var completedTask = await Task.WhenAny(readySignal.Task, timeoutTask);
-                delayCancellation.Cancel();
-
-                try
-                {
-                    await completedTask;
-                }
-                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-                {
-                    throw;
-                }
-
-                if (completedTask == timeoutTask)
-                {
-                    return _createHealthSnapshot().IsHealthy;
-                }
-
-                if (_createHealthSnapshot().IsHealthy)
-                {
-                    return true;
-                }
-
-                lock (_syncRoot)
-                {
-                    if (ReferenceEquals(_readySignal, readySignal))
-                    {
-                        _readySignal = new TaskCompletionSource<bool>(
-                            TaskCreationOptions.RunContinuationsAsynchronously);
-                    }
-                }
+                return true;
             }
-        }
 
-        private void LogNaturalRecovery(DateTimeOffset unhealthySince)
-        {
-            var snapshot = _createHealthSnapshot();
-            BeanBotLog.DiscordNaturalRecovery(
-                _logger,
-                DateTimeOffset.UtcNow - unhealthySince,
-                snapshot.LoginState,
-                snapshot.ConnectionState);
-        }
-
-        public async ValueTask DisposeAsync()
-        {
-            Task? monitorTask;
+            TaskCompletionSource<bool> readySignal;
             lock (_syncRoot)
             {
-                if (_disposed)
-                {
-                    return;
-                }
-
-                _disposed = true;
-                _shutdown.Cancel();
-                monitorTask = _monitorTask;
+                readySignal = _readySignal
+                    ?? throw new InvalidOperationException("Discord gateway recovery has no Ready signal.");
             }
 
-            if (monitorTask is not null)
+            var remaining = timeout - stopwatch.Elapsed;
+            if (remaining <= TimeSpan.Zero)
             {
-                await monitorTask;
+                return false;
             }
 
-            _shutdown.Dispose();
+            using var delayCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var timeoutTask = _delay.DelayAsync(remaining, delayCancellation.Token);
+            var completedTask = await Task.WhenAny(readySignal.Task, timeoutTask);
+            delayCancellation.Cancel();
+
+            try
+            {
+                await completedTask;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+
+            if (completedTask == timeoutTask)
+            {
+                return _createHealthSnapshot().IsHealthy;
+            }
+
+            if (_createHealthSnapshot().IsHealthy)
+            {
+                return true;
+            }
+
+            lock (_syncRoot)
+            {
+                if (ReferenceEquals(_readySignal, readySignal))
+                {
+                    _readySignal = new TaskCompletionSource<bool>(
+                        TaskCreationOptions.RunContinuationsAsynchronously);
+                }
+            }
         }
+    }
+
+    private void LogNaturalRecovery(DateTimeOffset unhealthySince)
+    {
+        var snapshot = _createHealthSnapshot();
+        BeanBotLog.DiscordNaturalRecovery(
+            _logger,
+            DateTimeOffset.UtcNow - unhealthySince,
+            snapshot.LoginState,
+            snapshot.ConnectionState);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        Task? monitorTask;
+        lock (_syncRoot)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _shutdown.Cancel();
+            monitorTask = _monitorTask;
+        }
+
+        if (monitorTask is not null)
+        {
+            await monitorTask;
+        }
+
+        _shutdown.Dispose();
     }
 }

--- a/BeanBot/Services/DiscordMessageCleanupService.cs
+++ b/BeanBot/Services/DiscordMessageCleanupService.cs
@@ -1,121 +1,116 @@
 using BeanBot.Util;
 using Discord;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
-namespace BeanBot.Services
+namespace BeanBot.Services;
+
+public sealed class DiscordMessageCleanupService
 {
-    public sealed class DiscordMessageCleanupService
+    internal const int MaximumBulkDeleteCount = 100;
+    private static readonly TimeSpan MaximumBulkDeleteAge = TimeSpan.FromDays(14) - TimeSpan.FromMinutes(5);
+    private readonly Func<DateTimeOffset> _getUtcNow;
+    private readonly ILogger<DiscordMessageCleanupService> _logger;
+
+    public DiscordMessageCleanupService(ILogger<DiscordMessageCleanupService> logger)
+        : this(() => DateTimeOffset.UtcNow, logger)
     {
-        internal const int MaximumBulkDeleteCount = 100;
-        private static readonly TimeSpan MaximumBulkDeleteAge = TimeSpan.FromDays(14) - TimeSpan.FromMinutes(5);
-        private readonly Func<DateTimeOffset> _getUtcNow;
-        private readonly ILogger<DiscordMessageCleanupService> _logger;
+    }
 
-        public DiscordMessageCleanupService(ILogger<DiscordMessageCleanupService> logger)
-            : this(() => DateTimeOffset.UtcNow, logger)
+    internal DiscordMessageCleanupService(
+        Func<DateTimeOffset> getUtcNow,
+        ILogger<DiscordMessageCleanupService> logger)
+    {
+        _getUtcNow = getUtcNow ?? throw new ArgumentNullException(nameof(getUtcNow));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public Task DeleteAsync(ITextChannel channel, IReadOnlyCollection<IMessage> messages)
+    {
+        ArgumentNullException.ThrowIfNull(channel);
+
+        var plan = CreatePlan(messages, message => message.Timestamp, _getUtcNow());
+        return ExecutePlanAsync(
+            plan,
+            batch => channel.DeleteMessagesAsync(batch),
+            message => message.DeleteAsync(),
+            (exception, itemCount, isBatch) => BeanBotLog.MessageCleanupFailed(
+                _logger,
+                itemCount,
+                isBatch ? "bulk deletion" : "individual deletion",
+                exception));
+    }
+
+    internal static MessageCleanupPlan<T> CreatePlan<T>(
+        IReadOnlyCollection<T> messages,
+        Func<T, DateTimeOffset> getTimestamp,
+        DateTimeOffset now)
+    {
+        ArgumentNullException.ThrowIfNull(messages);
+        ArgumentNullException.ThrowIfNull(getTimestamp);
+
+        var oldestBulkDeleteTimestamp = now.Subtract(MaximumBulkDeleteAge);
+        var recent = messages.Where(message => getTimestamp(message) >= oldestBulkDeleteTimestamp).ToList();
+        var individual = messages.Where(message => getTimestamp(message) < oldestBulkDeleteTimestamp).ToList();
+        var batches = new List<IReadOnlyCollection<T>>();
+
+        for (var offset = 0; offset < recent.Count; offset += MaximumBulkDeleteCount)
         {
-        }
-
-        internal DiscordMessageCleanupService(
-            Func<DateTimeOffset> getUtcNow,
-            ILogger<DiscordMessageCleanupService> logger)
-        {
-            _getUtcNow = getUtcNow ?? throw new ArgumentNullException(nameof(getUtcNow));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        }
-
-        public Task DeleteAsync(ITextChannel channel, IReadOnlyCollection<IMessage> messages)
-        {
-            ArgumentNullException.ThrowIfNull(channel);
-
-            var plan = CreatePlan(messages, message => message.Timestamp, _getUtcNow());
-            return ExecutePlanAsync(
-                plan,
-                batch => channel.DeleteMessagesAsync(batch),
-                message => message.DeleteAsync(),
-                (exception, itemCount, isBatch) => BeanBotLog.MessageCleanupFailed(
-                    _logger,
-                    itemCount,
-                    isBatch ? "bulk deletion" : "individual deletion",
-                    exception));
-        }
-
-        internal static MessageCleanupPlan<T> CreatePlan<T>(
-            IReadOnlyCollection<T> messages,
-            Func<T, DateTimeOffset> getTimestamp,
-            DateTimeOffset now)
-        {
-            ArgumentNullException.ThrowIfNull(messages);
-            ArgumentNullException.ThrowIfNull(getTimestamp);
-
-            var oldestBulkDeleteTimestamp = now.Subtract(MaximumBulkDeleteAge);
-            var recent = messages.Where(message => getTimestamp(message) >= oldestBulkDeleteTimestamp).ToList();
-            var individual = messages.Where(message => getTimestamp(message) < oldestBulkDeleteTimestamp).ToList();
-            var batches = new List<IReadOnlyCollection<T>>();
-
-            for (var offset = 0; offset < recent.Count; offset += MaximumBulkDeleteCount)
+            var batch = recent.Skip(offset).Take(MaximumBulkDeleteCount).ToList();
+            if (batch.Count == 1)
             {
-                var batch = recent.Skip(offset).Take(MaximumBulkDeleteCount).ToList();
-                if (batch.Count == 1)
-                {
-                    individual.Add(batch[0]);
-                }
-                else if (batch.Count > 1)
-                {
-                    batches.Add(batch);
-                }
+                individual.Add(batch[0]);
             }
-
-            return new MessageCleanupPlan<T>(batches, individual);
+            else if (batch.Count > 1)
+            {
+                batches.Add(batch);
+            }
         }
 
-        internal static async Task ExecutePlanAsync<T>(
-            MessageCleanupPlan<T> plan,
-            Func<IReadOnlyCollection<T>, Task> deleteBatch,
-            Func<T, Task> deleteIndividual,
-            Action<Exception, int, bool> onFailure)
-        {
-            foreach (var batch in plan.Batches)
-            {
-                try
-                {
-                    await deleteBatch(batch);
-                }
-                catch (Exception exception)
-                {
-                    onFailure(exception, batch.Count, true);
-                }
-            }
+        return new MessageCleanupPlan<T>(batches, individual);
+    }
 
-            foreach (var item in plan.IndividualItems)
+    internal static async Task ExecutePlanAsync<T>(
+        MessageCleanupPlan<T> plan,
+        Func<IReadOnlyCollection<T>, Task> deleteBatch,
+        Func<T, Task> deleteIndividual,
+        Action<Exception, int, bool> onFailure)
+    {
+        foreach (var batch in plan.Batches)
+        {
+            try
             {
-                try
-                {
-                    await deleteIndividual(item);
-                }
-                catch (Exception exception)
-                {
-                    onFailure(exception, 1, false);
-                }
+                await deleteBatch(batch);
+            }
+            catch (Exception exception)
+            {
+                onFailure(exception, batch.Count, true);
+            }
+        }
+
+        foreach (var item in plan.IndividualItems)
+        {
+            try
+            {
+                await deleteIndividual(item);
+            }
+            catch (Exception exception)
+            {
+                onFailure(exception, 1, false);
             }
         }
     }
+}
 
-    internal sealed class MessageCleanupPlan<T>
+internal sealed class MessageCleanupPlan<T>
+{
+    public MessageCleanupPlan(
+        IReadOnlyCollection<IReadOnlyCollection<T>> batches,
+        IReadOnlyCollection<T> individualItems)
     {
-        public MessageCleanupPlan(
-            IReadOnlyCollection<IReadOnlyCollection<T>> batches,
-            IReadOnlyCollection<T> individualItems)
-        {
-            Batches = batches;
-            IndividualItems = individualItems;
-        }
-
-        public IReadOnlyCollection<IReadOnlyCollection<T>> Batches { get; }
-        public IReadOnlyCollection<T> IndividualItems { get; }
+        Batches = batches;
+        IndividualItems = individualItems;
     }
+
+    public IReadOnlyCollection<IReadOnlyCollection<T>> Batches { get; }
+    public IReadOnlyCollection<T> IndividualItems { get; }
 }

--- a/BeanBot/Services/DiscordMessageWaiter.cs
+++ b/BeanBot/Services/DiscordMessageWaiter.cs
@@ -1,165 +1,159 @@
+using System.Collections.Concurrent;
 using Discord.Commands;
 using Discord.WebSocket;
 
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
+namespace BeanBot.Services;
 
-namespace BeanBot.Services
+public sealed class DiscordMessageWaiter : IDisposable
 {
-    public sealed class DiscordMessageWaiter : IDisposable
+    internal const int MaximumPendingWaits = 64;
+    private readonly BoundedMessageWaiter<SocketMessage> _waiter = new(MaximumPendingWaits);
+
+    public Task<SocketMessage?> WaitForNextMessageAsync(
+        SocketCommandContext context,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
     {
-        internal const int MaximumPendingWaits = 64;
-        private readonly BoundedMessageWaiter<SocketMessage> _waiter = new(MaximumPendingWaits);
+        ArgumentNullException.ThrowIfNull(context);
 
-        public Task<SocketMessage?> WaitForNextMessageAsync(
-            SocketCommandContext context,
-            TimeSpan timeout,
-            CancellationToken cancellationToken = default)
-        {
-            ArgumentNullException.ThrowIfNull(context);
-
-            return _waiter.WaitAsync(
-                context.User.Id,
-                context.Channel.Id,
-                timeout,
-                cancellationToken);
-        }
-
-        public bool TryPublish(SocketMessage message)
-        {
-            if (message == null)
-            {
-                return false;
-            }
-
-            return _waiter.TryPublish(
-                message.Author.Id,
-                message.Channel.Id,
-                message.Author.IsBot,
-                message);
-        }
-
-        public void Dispose() => _waiter.Dispose();
+        return _waiter.WaitAsync(
+            context.User.Id,
+            context.Channel.Id,
+            timeout,
+            cancellationToken);
     }
 
-    internal sealed class BoundedMessageWaiter<TMessage> : IDisposable
+    public bool TryPublish(SocketMessage message)
     {
-        private readonly ConcurrentDictionary<MessageWaitKey, PendingWait> _pending = new();
-        private readonly SemaphoreSlim _availableSlots;
-        private readonly object _syncRoot = new();
-        private int _disposed;
-
-        public BoundedMessageWaiter(int maximumPendingWaits)
+        if (message == null)
         {
-            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumPendingWaits);
-
-            _availableSlots = new SemaphoreSlim(maximumPendingWaits, maximumPendingWaits);
+            return false;
         }
 
-        internal int PendingCount => _pending.Count;
+        return _waiter.TryPublish(
+            message.Author.Id,
+            message.Channel.Id,
+            message.Author.IsBot,
+            message);
+    }
 
-        public async Task<TMessage?> WaitAsync(
-            ulong userId,
-            ulong channelId,
-            TimeSpan timeout,
-            CancellationToken cancellationToken = default)
+    public void Dispose() => _waiter.Dispose();
+}
+
+internal sealed class BoundedMessageWaiter<TMessage> : IDisposable
+{
+    private readonly ConcurrentDictionary<MessageWaitKey, PendingWait> _pending = new();
+    private readonly SemaphoreSlim _availableSlots;
+    private readonly object _syncRoot = new();
+    private int _disposed;
+
+    public BoundedMessageWaiter(int maximumPendingWaits)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumPendingWaits);
+
+        _availableSlots = new SemaphoreSlim(maximumPendingWaits, maximumPendingWaits);
+    }
+
+    internal int PendingCount => _pending.Count;
+
+    public async Task<TMessage?> WaitAsync(
+        ulong userId,
+        ulong channelId,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(timeout, TimeSpan.Zero);
+
+        if (!_availableSlots.Wait(0, cancellationToken))
         {
-            ThrowIfDisposed();
-            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(timeout, TimeSpan.Zero);
+            throw new InvalidOperationException("Too many Discord message waits are already active.");
+        }
 
-            if (!_availableSlots.Wait(0, cancellationToken))
+        var key = new MessageWaitKey(userId, channelId);
+        var pending = new PendingWait();
+        lock (_syncRoot)
+        {
+            if (Volatile.Read(ref _disposed) != 0)
             {
-                throw new InvalidOperationException("Too many Discord message waits are already active.");
+                _availableSlots.Release();
+                throw new ObjectDisposedException(nameof(BoundedMessageWaiter<TMessage>));
             }
 
-            var key = new MessageWaitKey(userId, channelId);
-            var pending = new PendingWait();
-            lock (_syncRoot)
+            if (!_pending.TryAdd(key, pending))
             {
-                if (Volatile.Read(ref _disposed) != 0)
-                {
-                    _availableSlots.Release();
-                    throw new ObjectDisposedException(nameof(BoundedMessageWaiter<TMessage>));
-                }
-
-                if (!_pending.TryAdd(key, pending))
-                {
-                    _availableSlots.Release();
-                    throw new InvalidOperationException("A Discord message wait is already active for this user and channel.");
-                }
+                _availableSlots.Release();
+                throw new InvalidOperationException("A Discord message wait is already active for this user and channel.");
             }
+        }
 
+        try
+        {
             try
             {
-                try
-                {
-                    return await pending.Completion.Task.WaitAsync(timeout, cancellationToken);
-                }
-                catch (TimeoutException)
-                {
-                    return default;
-                }
+                return await pending.Completion.Task.WaitAsync(timeout, cancellationToken);
             }
-            finally
+            catch (TimeoutException)
             {
-                RemovePendingWait(key, pending);
-                _availableSlots.Release();
+                return default;
             }
         }
-
-        public bool TryPublish(
-            ulong userId,
-            ulong channelId,
-            bool isBot,
-            TMessage message)
+        finally
         {
-            if (isBot || Volatile.Read(ref _disposed) != 0)
+            RemovePendingWait(key, pending);
+            _availableSlots.Release();
+        }
+    }
+
+    public bool TryPublish(
+        ulong userId,
+        ulong channelId,
+        bool isBot,
+        TMessage message)
+    {
+        if (isBot || Volatile.Read(ref _disposed) != 0)
+        {
+            return false;
+        }
+
+        return _pending.TryGetValue(new MessageWaitKey(userId, channelId), out var pending)
+            && pending.Completion.TrySetResult(message);
+    }
+
+    public void Dispose()
+    {
+        lock (_syncRoot)
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
             {
-                return false;
+                return;
             }
 
-            return _pending.TryGetValue(new MessageWaitKey(userId, channelId), out var pending)
-                && pending.Completion.TrySetResult(message);
-        }
-
-        public void Dispose()
-        {
-            lock (_syncRoot)
+            foreach (var pending in _pending.Values)
             {
-                if (Interlocked.Exchange(ref _disposed, 1) != 0)
-                {
-                    return;
-                }
-
-                foreach (var pending in _pending.Values)
-                {
-                    pending.Completion.TrySetException(new ObjectDisposedException(nameof(BoundedMessageWaiter<TMessage>)));
-                }
+                pending.Completion.TrySetException(new ObjectDisposedException(nameof(BoundedMessageWaiter<TMessage>)));
             }
         }
+    }
 
-        private void ThrowIfDisposed()
-        {
-            ObjectDisposedException.ThrowIf(
-                Volatile.Read(ref _disposed) != 0,
-                this);
-        }
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(
+            Volatile.Read(ref _disposed) != 0,
+            this);
+    }
 
-        private void RemovePendingWait(MessageWaitKey key, PendingWait pending)
-        {
-            var pair = new KeyValuePair<MessageWaitKey, PendingWait>(key, pending);
-            ((ICollection<KeyValuePair<MessageWaitKey, PendingWait>>)_pending).Remove(pair);
-        }
+    private void RemovePendingWait(MessageWaitKey key, PendingWait pending)
+    {
+        var pair = new KeyValuePair<MessageWaitKey, PendingWait>(key, pending);
+        ((ICollection<KeyValuePair<MessageWaitKey, PendingWait>>)_pending).Remove(pair);
+    }
 
-        private readonly record struct MessageWaitKey(ulong UserId, ulong ChannelId);
+    private readonly record struct MessageWaitKey(ulong UserId, ulong ChannelId);
 
-        private sealed class PendingWait
-        {
-            public TaskCompletionSource<TMessage> Completion { get; } = new(
-                TaskCreationOptions.RunContinuationsAsynchronously);
-        }
+    private sealed class PendingWait
+    {
+        public TaskCompletionSource<TMessage> Completion { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
     }
 }

--- a/BeanBot/Services/DiscordOutageRecoveryNotifier.cs
+++ b/BeanBot/Services/DiscordOutageRecoveryNotifier.cs
@@ -1,176 +1,170 @@
-using BeanBot.Util;
-
-using Microsoft.Extensions.Logging;
-
-using System;
 using System.Globalization;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
+using BeanBot.Util;
+using Microsoft.Extensions.Logging;
 
-namespace BeanBot.Services
+namespace BeanBot.Services;
+
+internal sealed class DiscordOutageRecoveryNotifier : IDisposable
 {
-    internal sealed class DiscordOutageRecoveryNotifier : IDisposable
-    {
-        internal const int MaximumDeliveryAttempts = 3;
-        private const int MaximumDiscordMessageLength = 1900;
-        private static readonly TimeSpan DefaultDeliveryTimeout = TimeSpan.FromSeconds(30);
-        private readonly IDiscordOutageStore _outageStore;
-        private readonly IOwnerAlertDelivery _ownerAlertDelivery;
-        private readonly Func<int, TimeSpan> _retryDelay;
-        private readonly TimeSpan _deliveryTimeout;
-        private readonly ILogger<DiscordOutageRecoveryNotifier> _logger;
-        private readonly SemaphoreSlim _notificationAccess = new(1, 1);
+    internal const int MaximumDeliveryAttempts = 3;
+    private const int MaximumDiscordMessageLength = 1900;
+    private static readonly TimeSpan DefaultDeliveryTimeout = TimeSpan.FromSeconds(30);
+    private readonly IDiscordOutageStore _outageStore;
+    private readonly IOwnerAlertDelivery _ownerAlertDelivery;
+    private readonly Func<int, TimeSpan> _retryDelay;
+    private readonly TimeSpan _deliveryTimeout;
+    private readonly ILogger<DiscordOutageRecoveryNotifier> _logger;
+    private readonly SemaphoreSlim _notificationAccess = new(1, 1);
 
-        public DiscordOutageRecoveryNotifier(
-            IDiscordOutageStore outageStore,
-            IOwnerAlertDelivery ownerAlertDelivery,
-            ILogger<DiscordOutageRecoveryNotifier> logger,
-            Func<int, TimeSpan>? retryDelay = null,
-            TimeSpan? deliveryTimeout = null)
+    public DiscordOutageRecoveryNotifier(
+        IDiscordOutageStore outageStore,
+        IOwnerAlertDelivery ownerAlertDelivery,
+        ILogger<DiscordOutageRecoveryNotifier> logger,
+        Func<int, TimeSpan>? retryDelay = null,
+        TimeSpan? deliveryTimeout = null)
+    {
+        _outageStore = outageStore ?? throw new ArgumentNullException(nameof(outageStore));
+        _ownerAlertDelivery = ownerAlertDelivery ?? throw new ArgumentNullException(nameof(ownerAlertDelivery));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _retryDelay = retryDelay ?? (attempt => TimeSpan.FromSeconds(attempt));
+        _deliveryTimeout = deliveryTimeout ?? DefaultDeliveryTimeout;
+    }
+
+    public async Task NotifyIfOutageRecoveredAsync(
+        DateTimeOffset recoveredAtUtc,
+        CancellationToken cancellationToken = default)
+    {
+        await _notificationAccess.WaitAsync(cancellationToken);
+        try
         {
-            _outageStore = outageStore ?? throw new ArgumentNullException(nameof(outageStore));
-            _ownerAlertDelivery = ownerAlertDelivery ?? throw new ArgumentNullException(nameof(ownerAlertDelivery));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _retryDelay = retryDelay ?? (attempt => TimeSpan.FromSeconds(attempt));
-            _deliveryTimeout = deliveryTimeout ?? DefaultDeliveryTimeout;
+            var outage = await _outageStore.ReadAsync(cancellationToken);
+            if (outage is null)
+            {
+                return;
+            }
+
+            BeanBotLog.OutageNotificationAttempting(
+                _logger,
+                outage.DisconnectedAtUtc,
+                outage.ProcessRestartRequested);
+
+            var recoveryMessage = FormatRecoveryMessage(outage, recoveredAtUtc);
+            if (!await DeliverWithRetryAsync(recoveryMessage, cancellationToken))
+            {
+                BeanBotLog.OutageNotificationFailed(
+                    _logger,
+                    MaximumDeliveryAttempts,
+                    outage.DisconnectedAtUtc);
+                return;
+            }
+
+            BeanBotLog.OutageNotificationDelivered(
+                _logger,
+                outage.DisconnectedAtUtc);
+            await _outageStore.ClearAsync(cancellationToken);
+        }
+        finally
+        {
+            _notificationAccess.Release();
+        }
+    }
+
+    internal static string FormatRecoveryMessage(
+        DiscordOutage outage,
+        DateTimeOffset recoveredAtUtc)
+    {
+        var downtime = recoveredAtUtc.ToUniversalTime() - outage.DisconnectedAtUtc.ToUniversalTime();
+        if (downtime < TimeSpan.Zero)
+        {
+            downtime = TimeSpan.Zero;
         }
 
-        public async Task NotifyIfOutageRecoveredAsync(
-            DateTimeOffset recoveredAtUtc,
-            CancellationToken cancellationToken = default)
+        var message = new StringBuilder()
+            .AppendLine("BeanBot recovered from a Discord outage.")
+            .AppendLine();
+        message.AppendLine(
+            CultureInfo.InvariantCulture,
+            $"Disconnected: {outage.DisconnectedAtUtc.UtcDateTime:yyyy-MM-dd HH:mm:ss} UTC");
+        message.AppendLine(
+            CultureInfo.InvariantCulture,
+            $"Approximate downtime: {FormatDuration(downtime)}");
+        message.AppendLine(CultureInfo.InvariantCulture, $"Reason: {outage.MostRecentDisconnectReason}");
+        message.AppendLine(
+            CultureInfo.InvariantCulture,
+            $"Manual recovery attempted: {FormatBoolean(outage.ManualRecoveryAttempted)}");
+        message.Append(
+            CultureInfo.InvariantCulture,
+            $"Container restart requested: {FormatBoolean(outage.ProcessRestartRequested)}");
+
+        if (outage.ProcessRestartRequested)
         {
-            await _notificationAccess.WaitAsync(cancellationToken);
+            message.AppendLine().Append("This outage persisted across a requested process/container restart.");
+        }
+
+        var recoveryMessage = message.ToString();
+        return recoveryMessage.Length <= MaximumDiscordMessageLength
+            ? recoveryMessage
+            : string.Concat(
+                recoveryMessage.AsSpan(0, MaximumDiscordMessageLength - 15),
+                "\n...(truncated)");
+    }
+
+    private async Task<bool> DeliverWithRetryAsync(
+        string recoveryMessage,
+        CancellationToken cancellationToken)
+    {
+        for (var attempt = 1; attempt <= MaximumDeliveryAttempts; attempt++)
+        {
             try
             {
-                var outage = await _outageStore.ReadAsync(cancellationToken);
-                if (outage is null)
-                {
-                    return;
-                }
-
-                BeanBotLog.OutageNotificationAttempting(
+                await _ownerAlertDelivery
+                    .DeliverAsync(recoveryMessage, cancellationToken)
+                    .WaitAsync(_deliveryTimeout, cancellationToken);
+                return true;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                BeanBotLog.OutageNotificationDeliveryFailed(
                     _logger,
-                    outage.DisconnectedAtUtc,
-                    outage.ProcessRestartRequested);
+                    attempt,
+                    MaximumDeliveryAttempts,
+                    exception);
 
-                var recoveryMessage = FormatRecoveryMessage(outage, recoveredAtUtc);
-                if (!await DeliverWithRetryAsync(recoveryMessage, cancellationToken))
+                if (attempt < MaximumDeliveryAttempts)
                 {
-                    BeanBotLog.OutageNotificationFailed(
-                        _logger,
-                        MaximumDeliveryAttempts,
-                        outage.DisconnectedAtUtc);
-                    return;
+                    await Task.Delay(_retryDelay(attempt), cancellationToken);
                 }
-
-                BeanBotLog.OutageNotificationDelivered(
-                    _logger,
-                    outage.DisconnectedAtUtc);
-                await _outageStore.ClearAsync(cancellationToken);
-            }
-            finally
-            {
-                _notificationAccess.Release();
             }
         }
 
-        internal static string FormatRecoveryMessage(
-            DiscordOutage outage,
-            DateTimeOffset recoveredAtUtc)
-        {
-            var downtime = recoveredAtUtc.ToUniversalTime() - outage.DisconnectedAtUtc.ToUniversalTime();
-            if (downtime < TimeSpan.Zero)
-            {
-                downtime = TimeSpan.Zero;
-            }
-
-            var message = new StringBuilder()
-                .AppendLine("BeanBot recovered from a Discord outage.")
-                .AppendLine();
-            message.AppendLine(
-                CultureInfo.InvariantCulture,
-                $"Disconnected: {outage.DisconnectedAtUtc.UtcDateTime:yyyy-MM-dd HH:mm:ss} UTC");
-            message.AppendLine(
-                CultureInfo.InvariantCulture,
-                $"Approximate downtime: {FormatDuration(downtime)}");
-            message.AppendLine(CultureInfo.InvariantCulture, $"Reason: {outage.MostRecentDisconnectReason}");
-            message.AppendLine(
-                CultureInfo.InvariantCulture,
-                $"Manual recovery attempted: {FormatBoolean(outage.ManualRecoveryAttempted)}");
-            message.Append(
-                CultureInfo.InvariantCulture,
-                $"Container restart requested: {FormatBoolean(outage.ProcessRestartRequested)}");
-
-            if (outage.ProcessRestartRequested)
-            {
-                message.AppendLine().Append("This outage persisted across a requested process/container restart.");
-            }
-
-            var recoveryMessage = message.ToString();
-            return recoveryMessage.Length <= MaximumDiscordMessageLength
-                ? recoveryMessage
-                : string.Concat(
-                    recoveryMessage.AsSpan(0, MaximumDiscordMessageLength - 15),
-                    "\n...(truncated)");
-        }
-
-        private async Task<bool> DeliverWithRetryAsync(
-            string recoveryMessage,
-            CancellationToken cancellationToken)
-        {
-            for (var attempt = 1; attempt <= MaximumDeliveryAttempts; attempt++)
-            {
-                try
-                {
-                    await _ownerAlertDelivery
-                        .DeliverAsync(recoveryMessage, cancellationToken)
-                        .WaitAsync(_deliveryTimeout, cancellationToken);
-                    return true;
-                }
-                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-                {
-                    throw;
-                }
-                catch (Exception exception)
-                {
-                    BeanBotLog.OutageNotificationDeliveryFailed(
-                        _logger,
-                        attempt,
-                        MaximumDeliveryAttempts,
-                        exception);
-
-                    if (attempt < MaximumDeliveryAttempts)
-                    {
-                        await Task.Delay(_retryDelay(attempt), cancellationToken);
-                    }
-                }
-            }
-
-            return false;
-        }
-
-        private static string FormatDuration(TimeSpan duration)
-        {
-            var parts = new StringBuilder();
-            if (duration.Days > 0)
-            {
-                parts.Append(CultureInfo.InvariantCulture, $"{duration.Days}d ");
-            }
-            if (duration.Hours > 0 || duration.Days > 0)
-            {
-                parts.Append(CultureInfo.InvariantCulture, $"{duration.Hours}h ");
-            }
-            if (duration.Minutes > 0 || duration.Hours > 0 || duration.Days > 0)
-            {
-                parts.Append(CultureInfo.InvariantCulture, $"{duration.Minutes}m ");
-            }
-            parts.Append(CultureInfo.InvariantCulture, $"{duration.Seconds}s");
-            return parts.ToString();
-        }
-
-        private static string FormatBoolean(bool value) => value ? "yes" : "no";
-
-        public void Dispose() => _notificationAccess.Dispose();
+        return false;
     }
+
+    private static string FormatDuration(TimeSpan duration)
+    {
+        var parts = new StringBuilder();
+        if (duration.Days > 0)
+        {
+            parts.Append(CultureInfo.InvariantCulture, $"{duration.Days}d ");
+        }
+        if (duration.Hours > 0 || duration.Days > 0)
+        {
+            parts.Append(CultureInfo.InvariantCulture, $"{duration.Hours}h ");
+        }
+        if (duration.Minutes > 0 || duration.Hours > 0 || duration.Days > 0)
+        {
+            parts.Append(CultureInfo.InvariantCulture, $"{duration.Minutes}m ");
+        }
+        parts.Append(CultureInfo.InvariantCulture, $"{duration.Seconds}s");
+        return parts.ToString();
+    }
+
+    private static string FormatBoolean(bool value) => value ? "yes" : "no";
+
+    public void Dispose() => _notificationAccess.Dispose();
 }

--- a/BeanBot/Services/DiscordOutageStore.cs
+++ b/BeanBot/Services/DiscordOutageStore.cs
@@ -1,269 +1,263 @@
+using System.Text.Json;
 using BeanBot.Util;
 using Microsoft.Extensions.Logging;
 
-using System;
-using System.IO;
-using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
+namespace BeanBot.Services;
 
-namespace BeanBot.Services
+internal sealed class DiscordOutage
 {
-    internal sealed class DiscordOutage
+    public DateTimeOffset DisconnectedAtUtc { get; set; }
+    public string MostRecentDisconnectReason { get; set; } = "Discord gateway disconnected.";
+    public bool ManualRecoveryAttempted { get; set; }
+    public bool ProcessRestartRequested { get; set; }
+}
+
+internal interface IDiscordOutageStore
+{
+    Task<DiscordOutage?> ReadAsync(CancellationToken cancellationToken = default);
+    Task OpenAsync(
+        DateTimeOffset disconnectedAtUtc,
+        string? mostRecentDisconnectReason,
+        CancellationToken cancellationToken = default);
+    Task MarkManualRecoveryAttemptedAsync(
+        DateTimeOffset disconnectedAtUtc,
+        string? mostRecentDisconnectReason,
+        CancellationToken cancellationToken = default);
+    Task MarkProcessRestartRequestedAsync(
+        DateTimeOffset disconnectedAtUtc,
+        string? mostRecentDisconnectReason,
+        CancellationToken cancellationToken = default);
+    Task ClearAsync(CancellationToken cancellationToken = default);
+}
+
+internal sealed class DiscordOutageStore : IDiscordOutageStore, IDisposable
+{
+    internal const string OutageFileName = "discord-outage.json";
+    private readonly string _outageFilePath;
+    private readonly SemaphoreSlim _fileAccess = new(1, 1);
+    private readonly ILogger<DiscordOutageStore> _logger;
+
+    public DiscordOutageStore(
+        string persistentDataDirectory,
+        ILogger<DiscordOutageStore> logger)
     {
-        public DateTimeOffset DisconnectedAtUtc { get; set; }
-        public string MostRecentDisconnectReason { get; set; } = "Discord gateway disconnected.";
-        public bool ManualRecoveryAttempted { get; set; }
-        public bool ProcessRestartRequested { get; set; }
+        if (string.IsNullOrWhiteSpace(persistentDataDirectory))
+        {
+            throw new ArgumentException("A persistent data directory is required.", nameof(persistentDataDirectory));
+        }
+
+        Directory.CreateDirectory(persistentDataDirectory);
+        _outageFilePath = Path.Combine(persistentDataDirectory, OutageFileName);
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    internal interface IDiscordOutageStore
+    public async Task<DiscordOutage?> ReadAsync(CancellationToken cancellationToken = default)
     {
-        Task<DiscordOutage?> ReadAsync(CancellationToken cancellationToken = default);
-        Task OpenAsync(
-            DateTimeOffset disconnectedAtUtc,
-            string? mostRecentDisconnectReason,
-            CancellationToken cancellationToken = default);
-        Task MarkManualRecoveryAttemptedAsync(
-            DateTimeOffset disconnectedAtUtc,
-            string? mostRecentDisconnectReason,
-            CancellationToken cancellationToken = default);
-        Task MarkProcessRestartRequestedAsync(
-            DateTimeOffset disconnectedAtUtc,
-            string? mostRecentDisconnectReason,
-            CancellationToken cancellationToken = default);
-        Task ClearAsync(CancellationToken cancellationToken = default);
+        await _fileAccess.WaitAsync(cancellationToken);
+        try
+        {
+            return await ReadWithoutLockAsync(cancellationToken);
+        }
+        finally
+        {
+            _fileAccess.Release();
+        }
     }
 
-    internal sealed class DiscordOutageStore : IDiscordOutageStore, IDisposable
+    public async Task OpenAsync(
+        DateTimeOffset disconnectedAtUtc,
+        string? mostRecentDisconnectReason,
+        CancellationToken cancellationToken = default)
     {
-        internal const string OutageFileName = "discord-outage.json";
-        private readonly string _outageFilePath;
-        private readonly SemaphoreSlim _fileAccess = new(1, 1);
-        private readonly ILogger<DiscordOutageStore> _logger;
-
-        public DiscordOutageStore(
-            string persistentDataDirectory,
-            ILogger<DiscordOutageStore> logger)
-        {
-            if (string.IsNullOrWhiteSpace(persistentDataDirectory))
+        await UpdateAsync(
+            existingOutage =>
             {
-                throw new ArgumentException("A persistent data directory is required.", nameof(persistentDataDirectory));
-            }
-
-            Directory.CreateDirectory(persistentDataDirectory);
-            _outageFilePath = Path.Combine(persistentDataDirectory, OutageFileName);
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        }
-
-        public async Task<DiscordOutage?> ReadAsync(CancellationToken cancellationToken = default)
-        {
-            await _fileAccess.WaitAsync(cancellationToken);
-            try
-            {
-                return await ReadWithoutLockAsync(cancellationToken);
-            }
-            finally
-            {
-                _fileAccess.Release();
-            }
-        }
-
-        public async Task OpenAsync(
-            DateTimeOffset disconnectedAtUtc,
-            string? mostRecentDisconnectReason,
-            CancellationToken cancellationToken = default)
-        {
-            await UpdateAsync(
-                existingOutage =>
-                {
-                    var outage = existingOutage ?? CreateOutage(disconnectedAtUtc, mostRecentDisconnectReason);
-                    outage.MostRecentDisconnectReason = NormalizeReason(mostRecentDisconnectReason);
-                    return outage;
-                },
-                cancellationToken);
-        }
-
-        public async Task MarkManualRecoveryAttemptedAsync(
-            DateTimeOffset disconnectedAtUtc,
-            string? mostRecentDisconnectReason,
-            CancellationToken cancellationToken = default)
-        {
-            await UpdateAsync(
-                existingOutage =>
-                {
-                    var outage = existingOutage ?? CreateOutage(disconnectedAtUtc, mostRecentDisconnectReason);
-                    outage.MostRecentDisconnectReason = NormalizeReason(mostRecentDisconnectReason);
-                    outage.ManualRecoveryAttempted = true;
-                    return outage;
-                },
-                cancellationToken);
-
-            BeanBotLog.OutageManualRecoveryPersisted(_logger, disconnectedAtUtc);
-        }
-
-        public async Task MarkProcessRestartRequestedAsync(
-            DateTimeOffset disconnectedAtUtc,
-            string? mostRecentDisconnectReason,
-            CancellationToken cancellationToken = default)
-        {
-            await UpdateAsync(
-                existingOutage =>
-                {
-                    var outage = existingOutage ?? CreateOutage(disconnectedAtUtc, mostRecentDisconnectReason);
-                    outage.MostRecentDisconnectReason = NormalizeReason(mostRecentDisconnectReason);
-                    outage.ProcessRestartRequested = true;
-                    return outage;
-                },
-                cancellationToken);
-
-            BeanBotLog.OutageRestartPersisted(_logger);
-        }
-
-        public async Task ClearAsync(CancellationToken cancellationToken = default)
-        {
-            await _fileAccess.WaitAsync(cancellationToken);
-            try
-            {
-                if (File.Exists(_outageFilePath))
-                {
-                    File.Delete(_outageFilePath);
-                    BeanBotLog.OutageCleared(_logger);
-                }
-            }
-            finally
-            {
-                _fileAccess.Release();
-            }
-        }
-
-        private async Task UpdateAsync(
-            Func<DiscordOutage?, DiscordOutage> updateOutage,
-            CancellationToken cancellationToken)
-        {
-            await _fileAccess.WaitAsync(cancellationToken);
-            try
-            {
-                var existingOutage = await ReadWithoutLockAsync(cancellationToken);
-                var updatedOutage = updateOutage(existingOutage);
-                if (updatedOutage is not null)
-                {
-                    await WriteAtomicallyAsync(updatedOutage, cancellationToken);
-                }
-            }
-            finally
-            {
-                _fileAccess.Release();
-            }
-        }
-
-        private async Task<DiscordOutage?> ReadWithoutLockAsync(CancellationToken cancellationToken)
-        {
-            if (!File.Exists(_outageFilePath))
-            {
-                return null;
-            }
-
-            try
-            {
-                await using var outageFile = new FileStream(
-                    _outageFilePath,
-                    FileMode.Open,
-                    FileAccess.Read,
-                    FileShare.Read,
-                    4096,
-                    FileOptions.Asynchronous);
-                var outage = await JsonSerializer.DeserializeAsync<DiscordOutage>(
-                    outageFile,
-                    cancellationToken: cancellationToken);
-                if (outage is null || outage.DisconnectedAtUtc == default)
-                {
-                    throw new JsonException("The persisted Discord outage is missing required data.");
-                }
-
-                outage.MostRecentDisconnectReason = NormalizeReason(outage.MostRecentDisconnectReason);
-
-                BeanBotLog.OutageLoaded(
-                    _logger,
-                    outage.DisconnectedAtUtc,
-                    outage.ManualRecoveryAttempted,
-                    outage.ProcessRestartRequested);
+                var outage = existingOutage ?? CreateOutage(disconnectedAtUtc, mostRecentDisconnectReason);
+                outage.MostRecentDisconnectReason = NormalizeReason(mostRecentDisconnectReason);
                 return outage;
-            }
-            catch (JsonException exception)
-            {
-                QuarantineCorruptOutageFile(exception);
-                return null;
-            }
-        }
-
-        private async Task WriteAtomicallyAsync(
-            DiscordOutage outage,
-            CancellationToken cancellationToken)
-        {
-            var temporaryFilePath = $"{_outageFilePath}.{Guid.NewGuid():N}.tmp";
-            try
-            {
-                await using (var temporaryFile = new FileStream(
-                    temporaryFilePath,
-                    FileMode.CreateNew,
-                    FileAccess.Write,
-                    FileShare.None,
-                    4096,
-                    FileOptions.Asynchronous | FileOptions.WriteThrough))
-                {
-                    await JsonSerializer.SerializeAsync(
-                        temporaryFile,
-                        outage,
-                        cancellationToken: cancellationToken);
-                    await temporaryFile.FlushAsync(cancellationToken);
-                    temporaryFile.Flush(flushToDisk: true);
-                }
-
-                File.Move(temporaryFilePath, _outageFilePath, overwrite: true);
-                BeanBotLog.OutagePersisted(
-                    _logger,
-                    outage.DisconnectedAtUtc,
-                    outage.ManualRecoveryAttempted,
-                    outage.ProcessRestartRequested);
-            }
-            finally
-            {
-                if (File.Exists(temporaryFilePath))
-                {
-                    File.Delete(temporaryFilePath);
-                }
-            }
-        }
-
-        private void QuarantineCorruptOutageFile(JsonException exception)
-        {
-            var quarantinePath = $"{_outageFilePath}.corrupt-{DateTimeOffset.UtcNow:yyyyMMddHHmmssfff}";
-            try
-            {
-                File.Move(_outageFilePath, quarantinePath);
-                BeanBotLog.OutageQuarantined(_logger, quarantinePath, exception);
-            }
-            catch (Exception quarantineException)
-            {
-                BeanBotLog.OutageQuarantineFailed(_logger, _outageFilePath, quarantineException);
-            }
-        }
-
-        private static DiscordOutage CreateOutage(
-            DateTimeOffset disconnectedAtUtc,
-            string? mostRecentDisconnectReason)
-            => new()
-            {
-                DisconnectedAtUtc = disconnectedAtUtc.ToUniversalTime(),
-                MostRecentDisconnectReason = NormalizeReason(mostRecentDisconnectReason)
-            };
-
-        private static string NormalizeReason(string? disconnectReason)
-            => string.IsNullOrWhiteSpace(disconnectReason)
-                ? "Discord gateway disconnected."
-                : disconnectReason;
-
-        public void Dispose() => _fileAccess.Dispose();
+            },
+            cancellationToken);
     }
+
+    public async Task MarkManualRecoveryAttemptedAsync(
+        DateTimeOffset disconnectedAtUtc,
+        string? mostRecentDisconnectReason,
+        CancellationToken cancellationToken = default)
+    {
+        await UpdateAsync(
+            existingOutage =>
+            {
+                var outage = existingOutage ?? CreateOutage(disconnectedAtUtc, mostRecentDisconnectReason);
+                outage.MostRecentDisconnectReason = NormalizeReason(mostRecentDisconnectReason);
+                outage.ManualRecoveryAttempted = true;
+                return outage;
+            },
+            cancellationToken);
+
+        BeanBotLog.OutageManualRecoveryPersisted(_logger, disconnectedAtUtc);
+    }
+
+    public async Task MarkProcessRestartRequestedAsync(
+        DateTimeOffset disconnectedAtUtc,
+        string? mostRecentDisconnectReason,
+        CancellationToken cancellationToken = default)
+    {
+        await UpdateAsync(
+            existingOutage =>
+            {
+                var outage = existingOutage ?? CreateOutage(disconnectedAtUtc, mostRecentDisconnectReason);
+                outage.MostRecentDisconnectReason = NormalizeReason(mostRecentDisconnectReason);
+                outage.ProcessRestartRequested = true;
+                return outage;
+            },
+            cancellationToken);
+
+        BeanBotLog.OutageRestartPersisted(_logger);
+    }
+
+    public async Task ClearAsync(CancellationToken cancellationToken = default)
+    {
+        await _fileAccess.WaitAsync(cancellationToken);
+        try
+        {
+            if (File.Exists(_outageFilePath))
+            {
+                File.Delete(_outageFilePath);
+                BeanBotLog.OutageCleared(_logger);
+            }
+        }
+        finally
+        {
+            _fileAccess.Release();
+        }
+    }
+
+    private async Task UpdateAsync(
+        Func<DiscordOutage?, DiscordOutage> updateOutage,
+        CancellationToken cancellationToken)
+    {
+        await _fileAccess.WaitAsync(cancellationToken);
+        try
+        {
+            var existingOutage = await ReadWithoutLockAsync(cancellationToken);
+            var updatedOutage = updateOutage(existingOutage);
+            if (updatedOutage is not null)
+            {
+                await WriteAtomicallyAsync(updatedOutage, cancellationToken);
+            }
+        }
+        finally
+        {
+            _fileAccess.Release();
+        }
+    }
+
+    private async Task<DiscordOutage?> ReadWithoutLockAsync(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(_outageFilePath))
+        {
+            return null;
+        }
+
+        try
+        {
+            await using var outageFile = new FileStream(
+                _outageFilePath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read,
+                4096,
+                FileOptions.Asynchronous);
+            var outage = await JsonSerializer.DeserializeAsync<DiscordOutage>(
+                outageFile,
+                cancellationToken: cancellationToken);
+            if (outage is null || outage.DisconnectedAtUtc == default)
+            {
+                throw new JsonException("The persisted Discord outage is missing required data.");
+            }
+
+            outage.MostRecentDisconnectReason = NormalizeReason(outage.MostRecentDisconnectReason);
+
+            BeanBotLog.OutageLoaded(
+                _logger,
+                outage.DisconnectedAtUtc,
+                outage.ManualRecoveryAttempted,
+                outage.ProcessRestartRequested);
+            return outage;
+        }
+        catch (JsonException exception)
+        {
+            QuarantineCorruptOutageFile(exception);
+            return null;
+        }
+    }
+
+    private async Task WriteAtomicallyAsync(
+        DiscordOutage outage,
+        CancellationToken cancellationToken)
+    {
+        var temporaryFilePath = $"{_outageFilePath}.{Guid.NewGuid():N}.tmp";
+        try
+        {
+            await using (var temporaryFile = new FileStream(
+                temporaryFilePath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                4096,
+                FileOptions.Asynchronous | FileOptions.WriteThrough))
+            {
+                await JsonSerializer.SerializeAsync(
+                    temporaryFile,
+                    outage,
+                    cancellationToken: cancellationToken);
+                await temporaryFile.FlushAsync(cancellationToken);
+                temporaryFile.Flush(flushToDisk: true);
+            }
+
+            File.Move(temporaryFilePath, _outageFilePath, overwrite: true);
+            BeanBotLog.OutagePersisted(
+                _logger,
+                outage.DisconnectedAtUtc,
+                outage.ManualRecoveryAttempted,
+                outage.ProcessRestartRequested);
+        }
+        finally
+        {
+            if (File.Exists(temporaryFilePath))
+            {
+                File.Delete(temporaryFilePath);
+            }
+        }
+    }
+
+    private void QuarantineCorruptOutageFile(JsonException exception)
+    {
+        var quarantinePath = $"{_outageFilePath}.corrupt-{DateTimeOffset.UtcNow:yyyyMMddHHmmssfff}";
+        try
+        {
+            File.Move(_outageFilePath, quarantinePath);
+            BeanBotLog.OutageQuarantined(_logger, quarantinePath, exception);
+        }
+        catch (Exception quarantineException)
+        {
+            BeanBotLog.OutageQuarantineFailed(_logger, _outageFilePath, quarantineException);
+        }
+    }
+
+    private static DiscordOutage CreateOutage(
+        DateTimeOffset disconnectedAtUtc,
+        string? mostRecentDisconnectReason)
+        => new()
+        {
+            DisconnectedAtUtc = disconnectedAtUtc.ToUniversalTime(),
+            MostRecentDisconnectReason = NormalizeReason(mostRecentDisconnectReason)
+        };
+
+    private static string NormalizeReason(string? disconnectReason)
+        => string.IsNullOrWhiteSpace(disconnectReason)
+            ? "Discord gateway disconnected."
+            : disconnectReason;
+
+    public void Dispose() => _fileAccess.Dispose();
 }

--- a/BeanBot/Services/DiscordPaginatorService.cs
+++ b/BeanBot/Services/DiscordPaginatorService.cs
@@ -1,606 +1,598 @@
+using System.Collections.Concurrent;
 using BeanBot.Util;
 using Discord;
 using Discord.Commands;
 using Discord.Rest;
 using Discord.WebSocket;
-
 using Microsoft.Extensions.Logging;
 
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
+namespace BeanBot.Services;
 
-namespace BeanBot.Services
+public sealed class DiscordPaginatorService : IDisposable
 {
-    public sealed class DiscordPaginatorService : IDisposable
+    internal const int MaximumActivePaginators = 64;
+    internal static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(5);
+    internal static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(5);
+    private static readonly Emoji FirstPage = new("⏮");
+    private static readonly Emoji PreviousPage = new("◀");
+    private static readonly Emoji NextPage = new("▶");
+    private static readonly Emoji LastPage = new("⏭");
+    private static readonly Emoji Stop = new("⏹");
+    private static readonly IReadOnlyCollection<IEmote> Controls = new IEmote[]
     {
-        internal const int MaximumActivePaginators = 64;
-        internal static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(5);
-        internal static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(5);
-        private static readonly Emoji FirstPage = new("⏮");
-        private static readonly Emoji PreviousPage = new("◀");
-        private static readonly Emoji NextPage = new("▶");
-        private static readonly Emoji LastPage = new("⏭");
-        private static readonly Emoji Stop = new("⏹");
-        private static readonly IReadOnlyCollection<IEmote> Controls = new IEmote[]
-        {
-            FirstPage,
-            PreviousPage,
-            NextPage,
-            LastPage,
-            Stop
-        };
+        FirstPage,
+        PreviousPage,
+        NextPage,
+        LastPage,
+        Stop
+    };
 
-        private readonly DiscordSocketClient _discordClient;
-        private readonly ConcurrentDictionary<ulong, PaginationSession> _sessions = new();
-        private readonly SemaphoreSlim _availableSlots = new(MaximumActivePaginators, MaximumActivePaginators);
-        private readonly CancellationTokenSource _shutdown = new();
-        private readonly object _syncRoot = new();
-        private readonly ILogger<DiscordPaginatorService> _logger;
-        private int _disposed;
+    private readonly DiscordSocketClient _discordClient;
+    private readonly ConcurrentDictionary<ulong, PaginationSession> _sessions = new();
+    private readonly SemaphoreSlim _availableSlots = new(MaximumActivePaginators, MaximumActivePaginators);
+    private readonly CancellationTokenSource _shutdown = new();
+    private readonly object _syncRoot = new();
+    private readonly ILogger<DiscordPaginatorService> _logger;
+    private int _disposed;
 
-        public DiscordPaginatorService(
-            DiscordSocketClient discordClient,
-            ILogger<DiscordPaginatorService> logger)
+    public DiscordPaginatorService(
+        DiscordSocketClient discordClient,
+        ILogger<DiscordPaginatorService> logger)
+    {
+        _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _discordClient.ReactionAdded += HandleReactionAsync;
+    }
+
+    public async Task<IUserMessage> SendAsync(
+        SocketCommandContext context,
+        IReadOnlyCollection<string> pages,
+        TimeSpan? timeout = null)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(context);
+
+        var pageList = pages?.Where(page => page != null).ToList()
+            ?? throw new ArgumentNullException(nameof(pages));
+        if (pageList.Count == 0)
         {
-            _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _discordClient.ReactionAdded += HandleReactionAsync;
+            throw new ArgumentException("At least one pagination page is required.", nameof(pages));
         }
 
-        public async Task<IUserMessage> SendAsync(
-            SocketCommandContext context,
-            IReadOnlyCollection<string> pages,
-            TimeSpan? timeout = null)
+        var paginationTimeout = timeout ?? DefaultTimeout;
+        if (paginationTimeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(timeout));
+        }
+
+        lock (_syncRoot)
         {
             ThrowIfDisposed();
-            ArgumentNullException.ThrowIfNull(context);
-
-            var pageList = pages?.Where(page => page != null).ToList()
-                ?? throw new ArgumentNullException(nameof(pages));
-            if (pageList.Count == 0)
+            if (!_availableSlots.Wait(0))
             {
-                throw new ArgumentException("At least one pagination page is required.", nameof(pages));
+                throw new InvalidOperationException("Too many Discord paginators are already active.");
             }
+        }
 
-            var paginationTimeout = timeout ?? DefaultTimeout;
-            if (paginationTimeout <= TimeSpan.Zero)
-            {
-                throw new ArgumentOutOfRangeException(nameof(timeout));
-            }
-
+        RestUserMessage? message = null;
+        PaginationSession? session = null;
+        var sessionRegistered = false;
+        var sessionAccessHeld = false;
+        try
+        {
+            var cursor = new PaginationCursor(pageList.Count);
+            message = await context.Channel.SendMessageAsync(
+                embed: BuildEmbed(pageList, cursor),
+                options: CreateRequestOptions(_shutdown.Token));
+            session = new PaginationSession(message, context.User.Id, pageList, cursor, _shutdown.Token);
+            await session.Access.WaitAsync();
+            sessionAccessHeld = true;
             lock (_syncRoot)
             {
                 ThrowIfDisposed();
-                if (!_availableSlots.Wait(0))
+                if (!_sessions.TryAdd(message.Id, session))
                 {
-                    throw new InvalidOperationException("Too many Discord paginators are already active.");
+                    throw new InvalidOperationException("The Discord paginator message is already registered.");
                 }
+                sessionRegistered = true;
+                session.ExpirationTask = ExpireAsync(message.Id, session, paginationTimeout);
             }
 
-            RestUserMessage? message = null;
-            PaginationSession? session = null;
-            var sessionRegistered = false;
-            var sessionAccessHeld = false;
-            try
+            foreach (var control in Controls)
             {
-                var cursor = new PaginationCursor(pageList.Count);
-                message = await context.Channel.SendMessageAsync(
-                    embed: BuildEmbed(pageList, cursor),
-                    options: CreateRequestOptions(_shutdown.Token));
-                session = new PaginationSession(message, context.User.Id, pageList, cursor, _shutdown.Token);
-                await session.Access.WaitAsync();
-                sessionAccessHeld = true;
-                lock (_syncRoot)
-                {
-                    ThrowIfDisposed();
-                    if (!_sessions.TryAdd(message.Id, session))
-                    {
-                        throw new InvalidOperationException("The Discord paginator message is already registered.");
-                    }
-                    sessionRegistered = true;
-                    session.ExpirationTask = ExpireAsync(message.Id, session, paginationTimeout);
-                }
-
-                foreach (var control in Controls)
-                {
-                    await message.AddReactionAsync(control, CreateRequestOptions(_shutdown.Token));
-                }
-
-                ObjectDisposedException.ThrowIf(
-                    !_sessions.TryGetValue(message.Id, out var currentSession)
-                        || !ReferenceEquals(currentSession, session)
-                        || session.CompletionStarted,
-                    this);
-
-                return message;
+                await message.AddReactionAsync(control, CreateRequestOptions(_shutdown.Token));
             }
-            catch
+
+            ObjectDisposedException.ThrowIf(
+                !_sessions.TryGetValue(message.Id, out var currentSession)
+                    || !ReferenceEquals(currentSession, session)
+                    || session.CompletionStarted,
+                this);
+
+            return message;
+        }
+        catch
+        {
+            if (!sessionRegistered)
             {
-                if (!sessionRegistered)
-                {
-                    ReleaseAvailableSlot();
-                }
-                else if (message is not null && session is not null)
-                {
-                    if (sessionAccessHeld)
-                    {
-                        session.Access.Release();
-                        sessionAccessHeld = false;
-                    }
-                    await StopSessionAsync(message.Id, session, deleteMessage: false);
-                }
-
-                throw;
+                ReleaseAvailableSlot();
             }
-            finally
+            else if (message is not null && session is not null)
             {
                 if (sessionAccessHeld)
                 {
-                    session?.Access.Release();
-                }
-            }
-        }
-
-        private async Task HandleReactionAsync(
-            Cacheable<IUserMessage, ulong> message,
-            Cacheable<IMessageChannel, ulong> channel,
-            SocketReaction reaction)
-        {
-            if (Volatile.Read(ref _disposed) != 0
-                || reaction.UserId == _discordClient.CurrentUser?.Id
-                || !_sessions.TryGetValue(message.Id, out var session)
-                || reaction.UserId != session.UserId)
-            {
-                return;
-            }
-
-            var action = GetAction(reaction.Emote);
-            if (action == PaginationAction.None)
-            {
-                return;
-            }
-
-            try
-            {
-                var stopRequested = false;
-                await session.Access.WaitAsync(_shutdown.Token);
-                try
-                {
-                    if (!_sessions.TryGetValue(message.Id, out var currentSession)
-                        || !ReferenceEquals(currentSession, session)
-                        || session.CompletionStarted)
-                    {
-                        return;
-                    }
-
-                    if (action == PaginationAction.Stop)
-                    {
-                        stopRequested = true;
-                    }
-                    else
-                    {
-                        if (session.Cursor.Move(action))
-                        {
-                            await session.Message.ModifyAsync(
-                                properties => properties.Embed = BuildEmbed(session.Pages, session.Cursor),
-                                options: CreateRequestOptions(_shutdown.Token));
-                        }
-
-                        await TryRemoveUserReactionAsync(
-                            session.Message,
-                            reaction.Emote,
-                            reaction.UserId,
-                            _logger,
-                            _shutdown.Token);
-                    }
-                }
-                finally
-                {
                     session.Access.Release();
+                    sessionAccessHeld = false;
                 }
+                await StopSessionAsync(message.Id, session, deleteMessage: false);
+            }
 
-                if (stopRequested)
-                {
-                    await StopSessionAsync(message.Id, session, deleteMessage: true);
-                }
-            }
-            catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
+            throw;
+        }
+        finally
+        {
+            if (sessionAccessHeld)
             {
-            }
-            catch (Exception exception)
-            {
-                BeanBotLog.PaginatorReactionFailed(_logger, message.Id, exception);
+                session?.Access.Release();
             }
         }
+    }
 
-        private async Task ExpireAsync(
-            ulong messageId,
-            PaginationSession session,
-            TimeSpan timeout)
+    private async Task HandleReactionAsync(
+        Cacheable<IUserMessage, ulong> message,
+        Cacheable<IMessageChannel, ulong> channel,
+        SocketReaction reaction)
+    {
+        if (Volatile.Read(ref _disposed) != 0
+            || reaction.UserId == _discordClient.CurrentUser?.Id
+            || !_sessions.TryGetValue(message.Id, out var session)
+            || reaction.UserId != session.UserId)
         {
-            var ownsCompletion = false;
-            var ownsAccess = false;
-            var expirationCancellation = session.ExpirationCancellation;
+            return;
+        }
+
+        var action = GetAction(reaction.Emote);
+        if (action == PaginationAction.None)
+        {
+            return;
+        }
+
+        try
+        {
+            var stopRequested = false;
+            await session.Access.WaitAsync(_shutdown.Token);
             try
             {
-                await Task.Delay(timeout, expirationCancellation);
-                if (!session.TryBeginCompletion())
+                if (!_sessions.TryGetValue(message.Id, out var currentSession)
+                    || !ReferenceEquals(currentSession, session)
+                    || session.CompletionStarted)
                 {
                     return;
                 }
 
-                ownsCompletion = true;
-                await session.Access.WaitAsync();
-                ownsAccess = true;
-
-                var currentUser = _discordClient.CurrentUser;
-                if (currentUser == null)
+                if (action == PaginationAction.Stop)
                 {
-                    return;
+                    stopRequested = true;
                 }
-
-                foreach (var control in Controls)
+                else
                 {
-                    if (_shutdown.IsCancellationRequested)
+                    if (session.Cursor.Move(action))
                     {
-                        return;
+                        await session.Message.ModifyAsync(
+                            properties => properties.Embed = BuildEmbed(session.Pages, session.Cursor),
+                            options: CreateRequestOptions(_shutdown.Token));
                     }
 
-                    try
-                    {
-                        await session.Message.RemoveReactionAsync(
-                            control,
-                            currentUser,
-                            CreateRequestOptions(expirationCancellation));
-                    }
-                    catch (Exception exception)
-                    {
-                        BeanBotLog.PaginatorControlRemoveFailed(_logger, messageId, exception);
-                    }
+                    await TryRemoveUserReactionAsync(
+                        session.Message,
+                        reaction.Emote,
+                        reaction.UserId,
+                        _logger,
+                        _shutdown.Token);
                 }
-            }
-            catch (OperationCanceledException) when (expirationCancellation.IsCancellationRequested)
-            {
-            }
-            catch (Exception exception)
-            {
-                BeanBotLog.PaginatorExpirationFailed(_logger, messageId, exception);
-            }
-            finally
-            {
-                if (ownsCompletion)
-                {
-                    if (ownsAccess)
-                    {
-                        session.Access.Release();
-                    }
-                    CompleteSession(messageId, session);
-                }
-            }
-        }
-
-        private async Task StopSessionAsync(
-            ulong messageId,
-            PaginationSession session,
-            bool deleteMessage)
-        {
-            if (!session.TryBeginCompletion())
-            {
-                await session.CompletionTask;
-                return;
-            }
-
-            session.CancelExpiration();
-            try
-            {
-                await session.ExpirationTask;
-                if (deleteMessage && !_shutdown.IsCancellationRequested)
-                {
-                    await session.Message.DeleteAsync(CreateRequestOptions(_shutdown.Token));
-                }
-            }
-            finally
-            {
-                CompleteSession(messageId, session);
-            }
-        }
-
-        internal static async Task TryRemoveUserReactionAsync(
-            IUserMessage message,
-            IEmote emote,
-            ulong userId,
-            ILogger<DiscordPaginatorService> logger,
-            CancellationToken cancellationToken = default)
-        {
-            ArgumentNullException.ThrowIfNull(logger);
-            try
-            {
-                await message.RemoveReactionAsync(
-                    emote,
-                    userId,
-                    CreateRequestOptions(cancellationToken));
-            }
-            catch (Exception exception)
-            {
-                BeanBotLog.PaginatorUserReactionRemoveFailed(logger, userId, exception);
-            }
-        }
-
-        private bool RemoveSession(ulong messageId, PaginationSession session)
-            => ((ICollection<KeyValuePair<ulong, PaginationSession>>)_sessions)
-                .Remove(new KeyValuePair<ulong, PaginationSession>(messageId, session));
-
-        private void CompleteSession(ulong messageId, PaginationSession session)
-        {
-            try
-            {
-                RemoveSession(messageId, session);
-                ReleaseAvailableSlot(session);
-                session.Dispose();
-            }
-            finally
-            {
-                session.MarkCompletionFinished();
-            }
-        }
-
-        private void ReleaseAvailableSlot(PaginationSession? session = null)
-        {
-            lock (_syncRoot)
-            {
-                if (Volatile.Read(ref _disposed) == 0)
-                {
-                    if (session == null)
-                    {
-                        _availableSlots.Release();
-                    }
-                    else
-                    {
-                        session.ReleaseSlot(_availableSlots);
-                    }
-                }
-            }
-        }
-
-        private static RequestOptions CreateRequestOptions(CancellationToken cancellationToken)
-            => new() { CancelToken = cancellationToken };
-
-        private static PaginationAction GetAction(IEmote emote)
-        {
-            if (emote.Equals(FirstPage)) return PaginationAction.First;
-            if (emote.Equals(PreviousPage)) return PaginationAction.Previous;
-            if (emote.Equals(NextPage)) return PaginationAction.Next;
-            if (emote.Equals(LastPage)) return PaginationAction.Last;
-            if (emote.Equals(Stop)) return PaginationAction.Stop;
-            return PaginationAction.None;
-        }
-
-        private static Embed BuildEmbed(IReadOnlyList<string> pages, PaginationCursor cursor)
-            => new EmbedBuilder()
-                .WithDescription(pages[cursor.PageIndex])
-                .WithFooter($"Page {cursor.PageIndex + 1}/{cursor.PageCount}")
-                .Build();
-
-        public void Dispose()
-        {
-            List<Task> shutdownTasks;
-            lock (_syncRoot)
-            {
-                if (Interlocked.Exchange(ref _disposed, 1) != 0)
-                {
-                    return;
-                }
-
-                _discordClient.ReactionAdded -= HandleReactionAsync;
-                _shutdown.Cancel();
-                shutdownTasks = new List<Task>(_sessions.Count);
-                foreach (var session in _sessions)
-                {
-                    session.Value.CancelExpiration();
-                    if (session.Value.TryBeginCompletion())
-                    {
-                        shutdownTasks.Add(CompleteOwnedSessionAsync(session.Key, session.Value));
-                    }
-                    else
-                    {
-                        shutdownTasks.Add(session.Value.CompletionTask);
-                    }
-                }
-
-                _availableSlots.Dispose();
-            }
-
-            var shutdown = Task.WhenAll(shutdownTasks);
-            try
-            {
-                if (WaitForShutdown(shutdown, ShutdownTimeout))
-                {
-                    _shutdown.Dispose();
-                    return;
-                }
-
-                BeanBotLog.PaginatorShutdownTimedOut(_logger, ShutdownTimeout);
-            }
-            catch (Exception exception)
-            {
-                BeanBotLog.PaginatorShutdownFailed(_logger, exception);
-                _shutdown.Dispose();
-                return;
-            }
-
-            _ = ObserveDeferredShutdownAsync(shutdown);
-        }
-
-        internal static bool WaitForShutdown(Task shutdown, TimeSpan timeout)
-            => shutdown.Wait(timeout);
-
-        private async Task CompleteOwnedSessionAsync(
-            ulong messageId,
-            PaginationSession session)
-        {
-            await session.ExpirationTask;
-            await session.Access.WaitAsync();
-            try
-            {
-                CompleteSession(messageId, session);
             }
             finally
             {
                 session.Access.Release();
             }
+
+            if (stopRequested)
+            {
+                await StopSessionAsync(message.Id, session, deleteMessage: true);
+            }
+        }
+        catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            BeanBotLog.PaginatorReactionFailed(_logger, message.Id, exception);
+        }
+    }
+
+    private async Task ExpireAsync(
+        ulong messageId,
+        PaginationSession session,
+        TimeSpan timeout)
+    {
+        var ownsCompletion = false;
+        var ownsAccess = false;
+        var expirationCancellation = session.ExpirationCancellation;
+        try
+        {
+            await Task.Delay(timeout, expirationCancellation);
+            if (!session.TryBeginCompletion())
+            {
+                return;
+            }
+
+            ownsCompletion = true;
+            await session.Access.WaitAsync();
+            ownsAccess = true;
+
+            var currentUser = _discordClient.CurrentUser;
+            if (currentUser == null)
+            {
+                return;
+            }
+
+            foreach (var control in Controls)
+            {
+                if (_shutdown.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                try
+                {
+                    await session.Message.RemoveReactionAsync(
+                        control,
+                        currentUser,
+                        CreateRequestOptions(expirationCancellation));
+                }
+                catch (Exception exception)
+                {
+                    BeanBotLog.PaginatorControlRemoveFailed(_logger, messageId, exception);
+                }
+            }
+        }
+        catch (OperationCanceledException) when (expirationCancellation.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            BeanBotLog.PaginatorExpirationFailed(_logger, messageId, exception);
+        }
+        finally
+        {
+            if (ownsCompletion)
+            {
+                if (ownsAccess)
+                {
+                    session.Access.Release();
+                }
+                CompleteSession(messageId, session);
+            }
+        }
+    }
+
+    private async Task StopSessionAsync(
+        ulong messageId,
+        PaginationSession session,
+        bool deleteMessage)
+    {
+        if (!session.TryBeginCompletion())
+        {
+            await session.CompletionTask;
+            return;
         }
 
-        private async Task ObserveDeferredShutdownAsync(Task shutdown)
+        session.CancelExpiration();
+        try
         {
-            try
+            await session.ExpirationTask;
+            if (deleteMessage && !_shutdown.IsCancellationRequested)
             {
-                await shutdown;
+                await session.Message.DeleteAsync(CreateRequestOptions(_shutdown.Token));
             }
-            catch (Exception exception)
+        }
+        finally
+        {
+            CompleteSession(messageId, session);
+        }
+    }
+
+    internal static async Task TryRemoveUserReactionAsync(
+        IUserMessage message,
+        IEmote emote,
+        ulong userId,
+        ILogger<DiscordPaginatorService> logger,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        try
+        {
+            await message.RemoveReactionAsync(
+                emote,
+                userId,
+                CreateRequestOptions(cancellationToken));
+        }
+        catch (Exception exception)
+        {
+            BeanBotLog.PaginatorUserReactionRemoveFailed(logger, userId, exception);
+        }
+    }
+
+    private bool RemoveSession(ulong messageId, PaginationSession session)
+        => ((ICollection<KeyValuePair<ulong, PaginationSession>>)_sessions)
+            .Remove(new KeyValuePair<ulong, PaginationSession>(messageId, session));
+
+    private void CompleteSession(ulong messageId, PaginationSession session)
+    {
+        try
+        {
+            RemoveSession(messageId, session);
+            ReleaseAvailableSlot(session);
+            session.Dispose();
+        }
+        finally
+        {
+            session.MarkCompletionFinished();
+        }
+    }
+
+    private void ReleaseAvailableSlot(PaginationSession? session = null)
+    {
+        lock (_syncRoot)
+        {
+            if (Volatile.Read(ref _disposed) == 0)
             {
-                BeanBotLog.PaginatorDeferredCleanupFailed(_logger, exception);
+                if (session == null)
+                {
+                    _availableSlots.Release();
+                }
+                else
+                {
+                    session.ReleaseSlot(_availableSlots);
+                }
             }
-            finally
+        }
+    }
+
+    private static RequestOptions CreateRequestOptions(CancellationToken cancellationToken)
+        => new() { CancelToken = cancellationToken };
+
+    private static PaginationAction GetAction(IEmote emote)
+    {
+        if (emote.Equals(FirstPage)) return PaginationAction.First;
+        if (emote.Equals(PreviousPage)) return PaginationAction.Previous;
+        if (emote.Equals(NextPage)) return PaginationAction.Next;
+        if (emote.Equals(LastPage)) return PaginationAction.Last;
+        if (emote.Equals(Stop)) return PaginationAction.Stop;
+        return PaginationAction.None;
+    }
+
+    private static Embed BuildEmbed(IReadOnlyList<string> pages, PaginationCursor cursor)
+        => new EmbedBuilder()
+            .WithDescription(pages[cursor.PageIndex])
+            .WithFooter($"Page {cursor.PageIndex + 1}/{cursor.PageCount}")
+            .Build();
+
+    public void Dispose()
+    {
+        List<Task> shutdownTasks;
+        lock (_syncRoot)
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
+            _discordClient.ReactionAdded -= HandleReactionAsync;
+            _shutdown.Cancel();
+            shutdownTasks = new List<Task>(_sessions.Count);
+            foreach (var session in _sessions)
+            {
+                session.Value.CancelExpiration();
+                if (session.Value.TryBeginCompletion())
+                {
+                    shutdownTasks.Add(CompleteOwnedSessionAsync(session.Key, session.Value));
+                }
+                else
+                {
+                    shutdownTasks.Add(session.Value.CompletionTask);
+                }
+            }
+
+            _availableSlots.Dispose();
+        }
+
+        var shutdown = Task.WhenAll(shutdownTasks);
+        try
+        {
+            if (WaitForShutdown(shutdown, ShutdownTimeout))
             {
                 _shutdown.Dispose();
+                return;
             }
+
+            BeanBotLog.PaginatorShutdownTimedOut(_logger, ShutdownTimeout);
+        }
+        catch (Exception exception)
+        {
+            BeanBotLog.PaginatorShutdownFailed(_logger, exception);
+            _shutdown.Dispose();
+            return;
         }
 
-        private void ThrowIfDisposed()
+        _ = ObserveDeferredShutdownAsync(shutdown);
+    }
+
+    internal static bool WaitForShutdown(Task shutdown, TimeSpan timeout)
+        => shutdown.Wait(timeout);
+
+    private async Task CompleteOwnedSessionAsync(
+        ulong messageId,
+        PaginationSession session)
+    {
+        await session.ExpirationTask;
+        await session.Access.WaitAsync();
+        try
         {
-            ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+            CompleteSession(messageId, session);
         }
-
-        private sealed class PaginationSession
+        finally
         {
-            public PaginationSession(
-                IUserMessage message,
-                ulong userId,
-                IReadOnlyList<string> pages,
-                PaginationCursor cursor,
-                CancellationToken shutdownCancellation)
-            {
-                Message = message;
-                UserId = userId;
-                Pages = pages;
-                Cursor = cursor;
-                Lifetime = new PaginatorSessionLifetime(shutdownCancellation);
-            }
-
-            public IUserMessage Message { get; }
-            public ulong UserId { get; }
-            public IReadOnlyList<string> Pages { get; }
-            public PaginationCursor Cursor { get; }
-            public SemaphoreSlim Access { get; } = new(1, 1);
-            public PaginatorSessionLifetime Lifetime { get; }
-            public Task ExpirationTask
-            {
-                get => Lifetime.ExpirationTask;
-                set => Lifetime.ExpirationTask = value;
-            }
-            public CancellationToken ExpirationCancellation => Lifetime.ExpirationCancellation;
-            public bool CompletionStarted => Lifetime.CompletionStarted;
-            public Task CompletionTask => Lifetime.CompletionTask;
-
-            public bool TryBeginCompletion()
-                => Lifetime.TryBeginCompletion();
-
-            public void CancelExpiration() => Lifetime.CancelExpiration();
-
-            public void ReleaseSlot(SemaphoreSlim availableSlots)
-                => Lifetime.ReleaseSlot(availableSlots);
-
-            public void MarkCompletionFinished() => Lifetime.MarkCompletionFinished();
-
-            public void Dispose()
-            {
-                Lifetime.Dispose();
-            }
+            session.Access.Release();
         }
     }
 
-    internal sealed class PaginatorSessionLifetime : IDisposable
+    private async Task ObserveDeferredShutdownAsync(Task shutdown)
     {
-        private readonly CancellationTokenSource _expiration;
-        private readonly TaskCompletionSource _completion = new(
-            TaskCreationOptions.RunContinuationsAsynchronously);
-        private int _completionStarted;
-        private int _slotReleased;
-
-        public PaginatorSessionLifetime(CancellationToken shutdownCancellation)
+        try
         {
-            _expiration = CancellationTokenSource.CreateLinkedTokenSource(shutdownCancellation);
+            await shutdown;
+        }
+        catch (Exception exception)
+        {
+            BeanBotLog.PaginatorDeferredCleanupFailed(_logger, exception);
+        }
+        finally
+        {
+            _shutdown.Dispose();
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+    }
+
+    private sealed class PaginationSession
+    {
+        public PaginationSession(
+            IUserMessage message,
+            ulong userId,
+            IReadOnlyList<string> pages,
+            PaginationCursor cursor,
+            CancellationToken shutdownCancellation)
+        {
+            Message = message;
+            UserId = userId;
+            Pages = pages;
+            Cursor = cursor;
+            Lifetime = new PaginatorSessionLifetime(shutdownCancellation);
         }
 
-        public Task ExpirationTask { get; set; } = Task.CompletedTask;
-        public CancellationToken ExpirationCancellation => _expiration.Token;
-        public bool CompletionStarted => Volatile.Read(ref _completionStarted) != 0;
-        public Task CompletionTask => _completion.Task;
+        public IUserMessage Message { get; }
+        public ulong UserId { get; }
+        public IReadOnlyList<string> Pages { get; }
+        public PaginationCursor Cursor { get; }
+        public SemaphoreSlim Access { get; } = new(1, 1);
+        public PaginatorSessionLifetime Lifetime { get; }
+        public Task ExpirationTask
+        {
+            get => Lifetime.ExpirationTask;
+            set => Lifetime.ExpirationTask = value;
+        }
+        public CancellationToken ExpirationCancellation => Lifetime.ExpirationCancellation;
+        public bool CompletionStarted => Lifetime.CompletionStarted;
+        public Task CompletionTask => Lifetime.CompletionTask;
 
         public bool TryBeginCompletion()
-            => Interlocked.CompareExchange(ref _completionStarted, 1, 0) == 0;
+            => Lifetime.TryBeginCompletion();
 
-        public void CancelExpiration() => _expiration.Cancel();
-
-        public void MarkCompletionFinished() => _completion.TrySetResult();
+        public void CancelExpiration() => Lifetime.CancelExpiration();
 
         public void ReleaseSlot(SemaphoreSlim availableSlots)
-        {
-            if (Interlocked.Exchange(ref _slotReleased, 1) == 0)
-            {
-                availableSlots.Release();
-            }
-        }
+            => Lifetime.ReleaseSlot(availableSlots);
 
-        public void Dispose() => _expiration.Dispose();
+        public void MarkCompletionFinished() => Lifetime.MarkCompletionFinished();
+
+        public void Dispose()
+        {
+            Lifetime.Dispose();
+        }
+    }
+}
+
+internal sealed class PaginatorSessionLifetime : IDisposable
+{
+    private readonly CancellationTokenSource _expiration;
+    private readonly TaskCompletionSource _completion = new(
+        TaskCreationOptions.RunContinuationsAsynchronously);
+    private int _completionStarted;
+    private int _slotReleased;
+
+    public PaginatorSessionLifetime(CancellationToken shutdownCancellation)
+    {
+        _expiration = CancellationTokenSource.CreateLinkedTokenSource(shutdownCancellation);
     }
 
-    internal enum PaginationAction
+    public Task ExpirationTask { get; set; } = Task.CompletedTask;
+    public CancellationToken ExpirationCancellation => _expiration.Token;
+    public bool CompletionStarted => Volatile.Read(ref _completionStarted) != 0;
+    public Task CompletionTask => _completion.Task;
+
+    public bool TryBeginCompletion()
+        => Interlocked.CompareExchange(ref _completionStarted, 1, 0) == 0;
+
+    public void CancelExpiration() => _expiration.Cancel();
+
+    public void MarkCompletionFinished() => _completion.TrySetResult();
+
+    public void ReleaseSlot(SemaphoreSlim availableSlots)
     {
-        None,
-        First,
-        Previous,
-        Next,
-        Last,
-        Stop
+        if (Interlocked.Exchange(ref _slotReleased, 1) == 0)
+        {
+            availableSlots.Release();
+        }
     }
 
-    internal sealed class PaginationCursor
+    public void Dispose() => _expiration.Dispose();
+}
+
+internal enum PaginationAction
+{
+    None,
+    First,
+    Previous,
+    Next,
+    Last,
+    Stop
+}
+
+internal sealed class PaginationCursor
+{
+    public PaginationCursor(int pageCount)
     {
-        public PaginationCursor(int pageCount)
-        {
-            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pageCount);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pageCount);
 
-            PageCount = pageCount;
+        PageCount = pageCount;
+    }
+
+    public int PageCount { get; }
+    public int PageIndex { get; private set; }
+
+    public bool Move(PaginationAction action)
+    {
+        var previousPage = PageIndex;
+        switch (action)
+        {
+            case PaginationAction.First:
+                PageIndex = 0;
+                break;
+            case PaginationAction.Previous when PageIndex > 0:
+                PageIndex--;
+                break;
+            case PaginationAction.Next when PageIndex < PageCount - 1:
+                PageIndex++;
+                break;
+            case PaginationAction.Last:
+                PageIndex = PageCount - 1;
+                break;
         }
 
-        public int PageCount { get; }
-        public int PageIndex { get; private set; }
-
-        public bool Move(PaginationAction action)
-        {
-            var previousPage = PageIndex;
-            switch (action)
-            {
-                case PaginationAction.First:
-                    PageIndex = 0;
-                    break;
-                case PaginationAction.Previous when PageIndex > 0:
-                    PageIndex--;
-                    break;
-                case PaginationAction.Next when PageIndex < PageCount - 1:
-                    PageIndex++;
-                    break;
-                case PaginationAction.Last:
-                    PageIndex = PageCount - 1;
-                    break;
-            }
-
-            return previousPage != PageIndex;
-        }
+        return previousPage != PageIndex;
     }
 }

--- a/BeanBot/Services/DiscordStartupService.cs
+++ b/BeanBot/Services/DiscordStartupService.cs
@@ -1,299 +1,293 @@
+using System.Net;
 using BeanBot.Util;
 using Discord;
 using Discord.WebSocket;
-
 using Microsoft.Extensions.Logging;
 
-using System;
-using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
+namespace BeanBot.Services;
 
-namespace BeanBot.Services
+internal sealed class DiscordStartupOptions
 {
-    internal sealed class DiscordStartupOptions
+    public static DiscordStartupOptions Default { get; } = new(
+        3,
+        TimeSpan.FromSeconds(30),
+        attempt => attempt == 1
+            ? TimeSpan.FromSeconds(5)
+            : TimeSpan.FromSeconds(15));
+
+    public DiscordStartupOptions(
+        int maximumAttempts,
+        TimeSpan lifecycleOperationTimeout,
+        Func<int, TimeSpan> retryDelay)
     {
-        public static DiscordStartupOptions Default { get; } = new(
-            3,
-            TimeSpan.FromSeconds(30),
-            attempt => attempt == 1
-                ? TimeSpan.FromSeconds(5)
-                : TimeSpan.FromSeconds(15));
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumAttempts);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(lifecycleOperationTimeout, TimeSpan.Zero);
 
-        public DiscordStartupOptions(
-            int maximumAttempts,
-            TimeSpan lifecycleOperationTimeout,
-            Func<int, TimeSpan> retryDelay)
-        {
-            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumAttempts);
-            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(lifecycleOperationTimeout, TimeSpan.Zero);
-
-            MaximumAttempts = maximumAttempts;
-            LifecycleOperationTimeout = lifecycleOperationTimeout;
-            RetryDelay = retryDelay ?? throw new ArgumentNullException(nameof(retryDelay));
-        }
-
-        public int MaximumAttempts { get; }
-        public TimeSpan LifecycleOperationTimeout { get; }
-        public Func<int, TimeSpan> RetryDelay { get; }
+        MaximumAttempts = maximumAttempts;
+        LifecycleOperationTimeout = lifecycleOperationTimeout;
+        RetryDelay = retryDelay ?? throw new ArgumentNullException(nameof(retryDelay));
     }
 
-    internal interface IDiscordStartupLifecycle
+    public int MaximumAttempts { get; }
+    public TimeSpan LifecycleOperationTimeout { get; }
+    public Func<int, TimeSpan> RetryDelay { get; }
+}
+
+internal interface IDiscordStartupLifecycle
+{
+    Task LoginAsync(CancellationToken cancellationToken);
+    Task StartAsync(CancellationToken cancellationToken);
+    Task SetPresenceAsync(CancellationToken cancellationToken);
+}
+
+internal interface IDiscordStartupDelay
+{
+    Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken);
+}
+
+internal sealed class DiscordStartupDelay : IDiscordStartupDelay
+{
+    public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+        => Task.Delay(delay, cancellationToken);
+}
+
+internal sealed class DiscordStartupLifecycle : IDiscordStartupLifecycle
+{
+    private const string GameStatus = "My purpose is to bully Hatate and succ the world dry";
+    private readonly object _syncRoot = new();
+    private readonly Func<Task> _login;
+    private readonly Func<Task> _start;
+    private readonly Func<Task> _setPresence;
+    private readonly TimeSpan _operationTimeout;
+    private readonly Action<Exception, string> _lateFailureObserver;
+    private readonly ILogger<DiscordStartupLifecycle> _logger;
+    private Task? _unfinishedOperation;
+
+    public DiscordStartupLifecycle(
+        DiscordSocketClient client,
+        string botToken,
+        TimeSpan operationTimeout,
+        ILogger<DiscordStartupLifecycle> logger)
     {
-        Task LoginAsync(CancellationToken cancellationToken);
-        Task StartAsync(CancellationToken cancellationToken);
-        Task SetPresenceAsync(CancellationToken cancellationToken);
+        ArgumentNullException.ThrowIfNull(client);
+        ArgumentNullException.ThrowIfNull(botToken);
+        _login = () => client.LoginAsync(TokenType.Bot, botToken);
+        _start = client.StartAsync;
+        _setPresence = () => client.SetGameAsync(GameStatus, null, ActivityType.Playing);
+        _operationTimeout = operationTimeout;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _lateFailureObserver = LogLateFailure;
     }
 
-    internal interface IDiscordStartupDelay
+    internal DiscordStartupLifecycle(
+        Func<Task> login,
+        Func<Task> start,
+        Func<Task> setPresence,
+        TimeSpan operationTimeout,
+        ILogger<DiscordStartupLifecycle> logger,
+        Action<Exception, string>? lateFailureObserver = null)
     {
-        Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken);
+        _login = login ?? throw new ArgumentNullException(nameof(login));
+        _start = start ?? throw new ArgumentNullException(nameof(start));
+        _setPresence = setPresence ?? throw new ArgumentNullException(nameof(setPresence));
+        _operationTimeout = operationTimeout;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _lateFailureObserver = lateFailureObserver ?? LogLateFailure;
     }
 
-    internal sealed class DiscordStartupDelay : IDiscordStartupDelay
+    internal bool HasUnfinishedOperation
     {
-        public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
-            => Task.Delay(delay, cancellationToken);
-    }
-
-    internal sealed class DiscordStartupLifecycle : IDiscordStartupLifecycle
-    {
-        private const string GameStatus = "My purpose is to bully Hatate and succ the world dry";
-        private readonly object _syncRoot = new();
-        private readonly Func<Task> _login;
-        private readonly Func<Task> _start;
-        private readonly Func<Task> _setPresence;
-        private readonly TimeSpan _operationTimeout;
-        private readonly Action<Exception, string> _lateFailureObserver;
-        private readonly ILogger<DiscordStartupLifecycle> _logger;
-        private Task? _unfinishedOperation;
-
-        public DiscordStartupLifecycle(
-            DiscordSocketClient client,
-            string botToken,
-            TimeSpan operationTimeout,
-            ILogger<DiscordStartupLifecycle> logger)
-        {
-            ArgumentNullException.ThrowIfNull(client);
-            ArgumentNullException.ThrowIfNull(botToken);
-            _login = () => client.LoginAsync(TokenType.Bot, botToken);
-            _start = client.StartAsync;
-            _setPresence = () => client.SetGameAsync(GameStatus, null, ActivityType.Playing);
-            _operationTimeout = operationTimeout;
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _lateFailureObserver = LogLateFailure;
-        }
-
-        internal DiscordStartupLifecycle(
-            Func<Task> login,
-            Func<Task> start,
-            Func<Task> setPresence,
-            TimeSpan operationTimeout,
-            ILogger<DiscordStartupLifecycle> logger,
-            Action<Exception, string>? lateFailureObserver = null)
-        {
-            _login = login ?? throw new ArgumentNullException(nameof(login));
-            _start = start ?? throw new ArgumentNullException(nameof(start));
-            _setPresence = setPresence ?? throw new ArgumentNullException(nameof(setPresence));
-            _operationTimeout = operationTimeout;
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _lateFailureObserver = lateFailureObserver ?? LogLateFailure;
-        }
-
-        internal bool HasUnfinishedOperation
-        {
-            get
-            {
-                lock (_syncRoot)
-                {
-                    return _unfinishedOperation?.IsCompleted == false;
-                }
-            }
-        }
-
-        public Task LoginAsync(CancellationToken cancellationToken)
-            => RunBoundedAsync(
-                _login,
-                "login",
-                cancellationToken);
-
-        public Task StartAsync(CancellationToken cancellationToken)
-            => RunBoundedAsync(
-                _start,
-                "start",
-                cancellationToken);
-
-        public Task SetPresenceAsync(CancellationToken cancellationToken)
-            => RunBoundedAsync(
-                _setPresence,
-                "presence",
-                cancellationToken);
-
-        private async Task RunBoundedAsync(
-            Func<Task> beginOperation,
-            string operationName,
-            CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            var operation = beginOperation();
-            try
-            {
-                // Discord.Net does not accept cancellation tokens for these operations,
-                // so BeanBot bounds its own wait and records an abandoned operation. The
-                // caller can then avoid racing teardown against the same client.
-                await operation.WaitAsync(_operationTimeout, cancellationToken);
-            }
-            catch
-            {
-                if (!operation.IsCompleted)
-                {
-                    TrackUnfinishedOperation(operation, operationName);
-                }
-
-                throw;
-            }
-        }
-
-        private void TrackUnfinishedOperation(Task operation, string operationName)
+        get
         {
             lock (_syncRoot)
             {
-                _unfinishedOperation = operation;
+                return _unfinishedOperation?.IsCompleted == false;
             }
-
-            _ = operation.ContinueWith(
-                completedTask =>
-                {
-                    if (completedTask.IsFaulted)
-                    {
-                        _lateFailureObserver(completedTask.Exception!, operationName);
-                    }
-
-                    lock (_syncRoot)
-                    {
-                        if (ReferenceEquals(_unfinishedOperation, completedTask))
-                        {
-                            _unfinishedOperation = null;
-                        }
-                    }
-                },
-                CancellationToken.None,
-                TaskContinuationOptions.ExecuteSynchronously,
-                TaskScheduler.Default);
         }
-
-        private void LogLateFailure(Exception exception, string operationName)
-            => BeanBotLog.DiscordStartupLateFailure(_logger, operationName, exception);
     }
 
-    internal sealed class DiscordStartupService
-    {
-        private readonly IDiscordStartupLifecycle _lifecycle;
-        private readonly DiscordStartupOptions _options;
-        private readonly IDiscordStartupDelay _delay;
-        private readonly ILogger<DiscordStartupService> _logger;
+    public Task LoginAsync(CancellationToken cancellationToken)
+        => RunBoundedAsync(
+            _login,
+            "login",
+            cancellationToken);
 
-        public DiscordStartupService(
-            IDiscordStartupLifecycle lifecycle,
-            ILogger<DiscordStartupService> logger,
-            DiscordStartupOptions? options = null,
-            IDiscordStartupDelay? delay = null)
+    public Task StartAsync(CancellationToken cancellationToken)
+        => RunBoundedAsync(
+            _start,
+            "start",
+            cancellationToken);
+
+    public Task SetPresenceAsync(CancellationToken cancellationToken)
+        => RunBoundedAsync(
+            _setPresence,
+            "presence",
+            cancellationToken);
+
+    private async Task RunBoundedAsync(
+        Func<Task> beginOperation,
+        string operationName,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var operation = beginOperation();
+        try
         {
-            _lifecycle = lifecycle ?? throw new ArgumentNullException(nameof(lifecycle));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _options = options ?? DiscordStartupOptions.Default;
-            _delay = delay ?? new DiscordStartupDelay();
+            // Discord.Net does not accept cancellation tokens for these operations,
+            // so BeanBot bounds its own wait and records an abandoned operation. The
+            // caller can then avoid racing teardown against the same client.
+            await operation.WaitAsync(_operationTimeout, cancellationToken);
+        }
+        catch
+        {
+            if (!operation.IsCompleted)
+            {
+                TrackUnfinishedOperation(operation, operationName);
+            }
+
+            throw;
+        }
+    }
+
+    private void TrackUnfinishedOperation(Task operation, string operationName)
+    {
+        lock (_syncRoot)
+        {
+            _unfinishedOperation = operation;
         }
 
-        public async Task StartAsync(CancellationToken cancellationToken)
+        _ = operation.ContinueWith(
+            completedTask =>
+            {
+                if (completedTask.IsFaulted)
+                {
+                    _lateFailureObserver(completedTask.Exception!, operationName);
+                }
+
+                lock (_syncRoot)
+                {
+                    if (ReferenceEquals(_unfinishedOperation, completedTask))
+                    {
+                        _unfinishedOperation = null;
+                    }
+                }
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    private void LogLateFailure(Exception exception, string operationName)
+        => BeanBotLog.DiscordStartupLateFailure(_logger, operationName, exception);
+}
+
+internal sealed class DiscordStartupService
+{
+    private readonly IDiscordStartupLifecycle _lifecycle;
+    private readonly DiscordStartupOptions _options;
+    private readonly IDiscordStartupDelay _delay;
+    private readonly ILogger<DiscordStartupService> _logger;
+
+    public DiscordStartupService(
+        IDiscordStartupLifecycle lifecycle,
+        ILogger<DiscordStartupService> logger,
+        DiscordStartupOptions? options = null,
+        IDiscordStartupDelay? delay = null)
+    {
+        _lifecycle = lifecycle ?? throw new ArgumentNullException(nameof(lifecycle));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _options = options ?? DiscordStartupOptions.Default;
+        _delay = delay ?? new DiscordStartupDelay();
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        await LoginWithRetryAsync(cancellationToken);
+        await _lifecycle.StartAsync(cancellationToken);
+
+        try
         {
-            await LoginWithRetryAsync(cancellationToken);
-            await _lifecycle.StartAsync(cancellationToken);
+            await _lifecycle.SetPresenceAsync(cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (TimeoutException)
+        {
+            // A timed-out presence task may still own the Discord client. Propagate
+            // so startup teardown can avoid racing it with runtime lifecycle work.
+            throw;
+        }
+        catch (Exception exception)
+        {
+            // A completed presence failure is cosmetic and must not fail an
+            // otherwise valid gateway lifecycle.
+            BeanBotLog.DiscordPresenceFailed(_logger, exception);
+        }
+    }
+
+    private async Task LoginWithRetryAsync(CancellationToken cancellationToken)
+    {
+        for (var attempt = 1; attempt <= _options.MaximumAttempts; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            BeanBotLog.DiscordLoginAttempting(
+                _logger,
+                attempt,
+                _options.MaximumAttempts);
 
             try
             {
-                await _lifecycle.SetPresenceAsync(cancellationToken);
+                await _lifecycle.LoginAsync(cancellationToken);
+                BeanBotLog.DiscordLoginSucceeded(
+                    _logger,
+                    attempt,
+                    _options.MaximumAttempts);
+                return;
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 throw;
             }
-            catch (TimeoutException)
+            catch (Discord.Net.HttpException exception) when (exception.HttpCode == HttpStatusCode.Unauthorized)
             {
-                // A timed-out presence task may still own the Discord client. Propagate
-                // so startup teardown can avoid racing it with runtime lifecycle work.
+                BeanBotLog.DiscordTokenRejected(
+                    _logger,
+                    attempt,
+                    _options.MaximumAttempts,
+                    exception);
                 throw;
+            }
+            catch (Discord.Net.HttpException exception)
+            {
+                if (attempt == _options.MaximumAttempts)
+                {
+                    BeanBotLog.DiscordLoginExhausted(
+                        _logger,
+                        attempt,
+                        _options.MaximumAttempts,
+                        exception);
+                    throw;
+                }
+
+                var retryDelay = _options.RetryDelay(attempt);
+                BeanBotLog.DiscordLoginRetrying(
+                    _logger,
+                    attempt,
+                    _options.MaximumAttempts,
+                    retryDelay,
+                    exception);
+                await _delay.DelayAsync(retryDelay, cancellationToken);
             }
             catch (Exception exception)
             {
-                // A completed presence failure is cosmetic and must not fail an
-                // otherwise valid gateway lifecycle.
-                BeanBotLog.DiscordPresenceFailed(_logger, exception);
-            }
-        }
-
-        private async Task LoginWithRetryAsync(CancellationToken cancellationToken)
-        {
-            for (var attempt = 1; attempt <= _options.MaximumAttempts; attempt++)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                BeanBotLog.DiscordLoginAttempting(
+                BeanBotLog.DiscordLoginFailed(
                     _logger,
                     attempt,
-                    _options.MaximumAttempts);
-
-                try
-                {
-                    await _lifecycle.LoginAsync(cancellationToken);
-                    BeanBotLog.DiscordLoginSucceeded(
-                        _logger,
-                        attempt,
-                        _options.MaximumAttempts);
-                    return;
-                }
-                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-                {
-                    throw;
-                }
-                catch (Discord.Net.HttpException exception) when (exception.HttpCode == HttpStatusCode.Unauthorized)
-                {
-                    BeanBotLog.DiscordTokenRejected(
-                        _logger,
-                        attempt,
-                        _options.MaximumAttempts,
-                        exception);
-                    throw;
-                }
-                catch (Discord.Net.HttpException exception)
-                {
-                    if (attempt == _options.MaximumAttempts)
-                    {
-                        BeanBotLog.DiscordLoginExhausted(
-                            _logger,
-                            attempt,
-                            _options.MaximumAttempts,
-                            exception);
-                        throw;
-                    }
-
-                    var retryDelay = _options.RetryDelay(attempt);
-                    BeanBotLog.DiscordLoginRetrying(
-                        _logger,
-                        attempt,
-                        _options.MaximumAttempts,
-                        retryDelay,
-                        exception);
-                    await _delay.DelayAsync(retryDelay, cancellationToken);
-                }
-                catch (Exception exception)
-                {
-                    BeanBotLog.DiscordLoginFailed(
-                        _logger,
-                        attempt,
-                        _options.MaximumAttempts,
-                        exception);
-                    throw;
-                }
+                    _options.MaximumAttempts,
+                    exception);
+                throw;
             }
         }
     }

--- a/BeanBot/Services/EditMessageEventServices.cs
+++ b/BeanBot/Services/EditMessageEventServices.cs
@@ -1,111 +1,107 @@
+using System.Buffers;
 using BeanBot.Util;
 using Discord;
 using Discord.WebSocket;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Buffers;
-using System.Linq;
-using System.Threading.Tasks;
 
-namespace BeanBot.Services
+namespace BeanBot.Services;
+
+public sealed class EditMessageEventServices
 {
-    public sealed class EditMessageEventServices
+    private const string EditWarning = "Do not edit your 8ball requests in my presence, mortal.";
+    private static readonly SearchValues<char> CommandSeparators = SearchValues.Create(" \t\r\n");
+    private readonly DiscordSocketClient _discordClient;
+    private readonly ILogger<EditMessageEventServices> _logger;
+
+    public EditMessageEventServices(
+        DiscordSocketClient discordClient,
+        ILogger<EditMessageEventServices> logger)
     {
-        private const string EditWarning = "Do not edit your 8ball requests in my presence, mortal.";
-        private static readonly SearchValues<char> CommandSeparators = SearchValues.Create(" \t\r\n");
-        private readonly DiscordSocketClient _discordClient;
-        private readonly ILogger<EditMessageEventServices> _logger;
+        _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
 
-        public EditMessageEventServices(
-            DiscordSocketClient discordClient,
-            ILogger<EditMessageEventServices> logger)
+    public async Task HandleUpdate(
+        Cacheable<IMessage, ulong> oldMessage,
+        SocketMessage newMessage,
+        ISocketMessageChannel messageChannel)
+    {
+        var previousMessage = await oldMessage.GetOrDownloadAsync();
+        if (previousMessage == null || _discordClient.CurrentUser == null ||
+            !IsFortuneCommand(previousMessage.Content, _discordClient.CurrentUser.Id))
         {
-            _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            return;
         }
 
-        public async Task HandleUpdate(
-            Cacheable<IMessage, ulong> oldMessage,
-            SocketMessage newMessage,
-            ISocketMessageChannel messageChannel)
+        var botResponse = messageChannel.CachedMessages
+            .OfType<SocketUserMessage>()
+            .Where(message => message.Author.Id == _discordClient.CurrentUser.Id)
+            .Where(message => message.Id > newMessage.Id)
+            .Where(message => message.Timestamp - newMessage.Timestamp <= TimeSpan.FromMinutes(2))
+            .OrderBy(message => message.Id)
+            .FirstOrDefault();
+
+        if (botResponse == null)
         {
-            var previousMessage = await oldMessage.GetOrDownloadAsync();
-            if (previousMessage == null || _discordClient.CurrentUser == null ||
-                !IsFortuneCommand(previousMessage.Content, _discordClient.CurrentUser.Id))
+            BeanBotLog.FortuneResponseMissing(_logger, newMessage.Id);
+            return;
+        }
+
+        await ReplaceResponseAsync(botResponse);
+    }
+
+    internal static bool IsFortuneCommand(string content, ulong botUserId = 0)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            return false;
+        }
+
+        var commandText = content.TrimStart();
+        if (commandText[0] == '%')
+        {
+            commandText = commandText.Substring(1).TrimStart();
+        }
+        else if (commandText.StartsWith("succ ", StringComparison.OrdinalIgnoreCase))
+        {
+            commandText = commandText.Substring("succ ".Length).TrimStart();
+        }
+        else if (botUserId != 0 &&
+                 (commandText.StartsWith($"<@{botUserId}> ", StringComparison.Ordinal) ||
+                  commandText.StartsWith($"<@!{botUserId}> ", StringComparison.Ordinal)))
+        {
+            var mentionEnd = commandText.IndexOf('>');
+            commandText = commandText.Substring(mentionEnd + 1).TrimStart();
+        }
+        else
+        {
+            return false;
+        }
+
+        var commandEnd = commandText.AsSpan().IndexOfAny(CommandSeparators);
+        var command = commandEnd < 0 ? commandText : commandText.Substring(0, commandEnd);
+        return string.Equals(command, "8ball", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(command, "fortune", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private async Task ReplaceResponseAsync(SocketUserMessage botResponse)
+    {
+        const int maxAttempts = 3;
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            try
             {
+                await botResponse.ModifyAsync(properties => properties.Content = EditWarning);
                 return;
             }
-
-            var botResponse = messageChannel.CachedMessages
-                .OfType<SocketUserMessage>()
-                .Where(message => message.Author.Id == _discordClient.CurrentUser.Id)
-                .Where(message => message.Id > newMessage.Id)
-                .Where(message => message.Timestamp - newMessage.Timestamp <= TimeSpan.FromMinutes(2))
-                .OrderBy(message => message.Id)
-                .FirstOrDefault();
-
-            if (botResponse == null)
+            catch (Exception exception) when (attempt < maxAttempts)
             {
-                BeanBotLog.FortuneResponseMissing(_logger, newMessage.Id);
-                return;
+                BeanBotLog.FortuneResponseReplaceAttemptFailed(_logger, attempt, exception);
+                await Task.Delay(TimeSpan.FromMilliseconds(100 * attempt));
             }
-
-            await ReplaceResponseAsync(botResponse);
-        }
-
-        internal static bool IsFortuneCommand(string content, ulong botUserId = 0)
-        {
-            if (string.IsNullOrWhiteSpace(content))
+            catch (Exception exception)
             {
-                return false;
-            }
-
-            var commandText = content.TrimStart();
-            if (commandText[0] == '%')
-            {
-                commandText = commandText.Substring(1).TrimStart();
-            }
-            else if (commandText.StartsWith("succ ", StringComparison.OrdinalIgnoreCase))
-            {
-                commandText = commandText.Substring("succ ".Length).TrimStart();
-            }
-            else if (botUserId != 0 &&
-                     (commandText.StartsWith($"<@{botUserId}> ", StringComparison.Ordinal) ||
-                      commandText.StartsWith($"<@!{botUserId}> ", StringComparison.Ordinal)))
-            {
-                var mentionEnd = commandText.IndexOf('>');
-                commandText = commandText.Substring(mentionEnd + 1).TrimStart();
-            }
-            else
-            {
-                return false;
-            }
-
-            var commandEnd = commandText.AsSpan().IndexOfAny(CommandSeparators);
-            var command = commandEnd < 0 ? commandText : commandText.Substring(0, commandEnd);
-            return string.Equals(command, "8ball", StringComparison.OrdinalIgnoreCase) ||
-                   string.Equals(command, "fortune", StringComparison.OrdinalIgnoreCase);
-        }
-
-        private async Task ReplaceResponseAsync(SocketUserMessage botResponse)
-        {
-            const int maxAttempts = 3;
-            for (var attempt = 1; attempt <= maxAttempts; attempt++)
-            {
-                try
-                {
-                    await botResponse.ModifyAsync(properties => properties.Content = EditWarning);
-                    return;
-                }
-                catch (Exception exception) when (attempt < maxAttempts)
-                {
-                    BeanBotLog.FortuneResponseReplaceAttemptFailed(_logger, attempt, exception);
-                    await Task.Delay(TimeSpan.FromMilliseconds(100 * attempt));
-                }
-                catch (Exception exception)
-                {
-                    BeanBotLog.FortuneResponseReplaceFailed(_logger, botResponse.Id, exception);
-                }
+                BeanBotLog.FortuneResponseReplaceFailed(_logger, botResponse.Id, exception);
             }
         }
     }

--- a/BeanBot/Services/HealthCheckServer.cs
+++ b/BeanBot/Services/HealthCheckServer.cs
@@ -1,8 +1,11 @@
+using System.Globalization;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
 using BeanBot.Configuration;
 using BeanBot.Util;
-
 using Discord.WebSocket;
-
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
@@ -10,412 +13,400 @@ using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-
 using Serilog;
 using Serilog.Extensions.Logging;
 
-using System;
-using System.Globalization;
-using System.Linq;
-using System.Net;
-using System.Security.Cryptography;
-using System.Text;
-using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
+namespace BeanBot.Services;
 
-namespace BeanBot.Services
+public sealed class HealthCheckServer : IAsyncDisposable
 {
-    public sealed class HealthCheckServer : IAsyncDisposable
+    internal const int MaxRequestLineLength = 2048;
+    internal const int MaxHeaderCount = 100;
+    internal const int MaxHeaderCharacters = 32 * 1024;
+    internal const int DefaultMaximumConcurrentClients = 64;
+    internal const int DefaultMaximumTrackedRateLimitClients = 4096;
+    private static readonly TimeSpan DefaultRequestHeadersTimeout = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan DefaultShutdownTimeout = TimeSpan.FromSeconds(1);
+    private static readonly JsonSerializerOptions JsonOptions = new()
     {
-        internal const int MaxRequestLineLength = 2048;
-        internal const int MaxHeaderCount = 100;
-        internal const int MaxHeaderCharacters = 32 * 1024;
-        internal const int DefaultMaximumConcurrentClients = 64;
-        internal const int DefaultMaximumTrackedRateLimitClients = 4096;
-        private static readonly TimeSpan DefaultRequestHeadersTimeout = TimeSpan.FromSeconds(5);
-        private static readonly TimeSpan DefaultShutdownTimeout = TimeSpan.FromSeconds(1);
-        private static readonly JsonSerializerOptions JsonOptions = new()
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private readonly object _syncRoot = new();
+    private readonly HealthCheckOptions _options;
+    private readonly Func<DiscordHealthSnapshot> _createHealthSnapshot;
+    private readonly TimeSpan _requestHeadersTimeout;
+    private readonly TimeSpan _shutdownTimeout;
+    private readonly int _maximumConcurrentClients;
+    private readonly BoundedClientRateLimiter _rateLimiter;
+    private readonly ILogger<HealthCheckServer> _logger;
+    private WebApplication? _application;
+    private int _boundPort;
+    private int _disposed;
+
+    public HealthCheckServer(
+        HealthCheckOptions options,
+        DiscordSocketClient discordClient,
+        DiscordConnectionHealth discordConnectionHealth,
+        ILogger<HealthCheckServer> logger)
+        : this(
+            options,
+            CreateSnapshotFactory(discordClient, discordConnectionHealth),
+            logger,
+            DefaultRequestHeadersTimeout,
+            DefaultMaximumConcurrentClients,
+            DefaultMaximumTrackedRateLimitClients,
+            DefaultShutdownTimeout)
+    {
+    }
+
+    internal HealthCheckServer(
+        HealthCheckOptions options,
+        Func<DiscordHealthSnapshot> createHealthSnapshot,
+        ILogger<HealthCheckServer> logger,
+        TimeSpan? requestHeadersTimeout = null,
+        int maximumConcurrentClients = DefaultMaximumConcurrentClients,
+        int maximumTrackedRateLimitClients = DefaultMaximumTrackedRateLimitClients,
+        TimeSpan? shutdownTimeout = null)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(createHealthSnapshot);
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumConcurrentClients);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumTrackedRateLimitClients);
+
+        var effectiveRequestHeadersTimeout = requestHeadersTimeout ?? DefaultRequestHeadersTimeout;
+        var effectiveShutdownTimeout = shutdownTimeout ?? DefaultShutdownTimeout;
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(effectiveRequestHeadersTimeout, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(effectiveShutdownTimeout, TimeSpan.Zero);
+
+        _options = options;
+        _createHealthSnapshot = createHealthSnapshot;
+        _logger = logger;
+        _requestHeadersTimeout = effectiveRequestHeadersTimeout;
+        _shutdownTimeout = effectiveShutdownTimeout;
+        _maximumConcurrentClients = maximumConcurrentClients;
+        _rateLimiter = new BoundedClientRateLimiter(
+            options.MinimumPollInterval,
+            maximumTrackedRateLimitClients);
+    }
+
+    internal int BoundPort
+    {
+        get
         {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-        };
-
-        private readonly object _syncRoot = new();
-        private readonly HealthCheckOptions _options;
-        private readonly Func<DiscordHealthSnapshot> _createHealthSnapshot;
-        private readonly TimeSpan _requestHeadersTimeout;
-        private readonly TimeSpan _shutdownTimeout;
-        private readonly int _maximumConcurrentClients;
-        private readonly BoundedClientRateLimiter _rateLimiter;
-        private readonly ILogger<HealthCheckServer> _logger;
-        private WebApplication? _application;
-        private int _boundPort;
-        private int _disposed;
-
-        public HealthCheckServer(
-            HealthCheckOptions options,
-            DiscordSocketClient discordClient,
-            DiscordConnectionHealth discordConnectionHealth,
-            ILogger<HealthCheckServer> logger)
-            : this(
-                options,
-                CreateSnapshotFactory(discordClient, discordConnectionHealth),
-                logger,
-                DefaultRequestHeadersTimeout,
-                DefaultMaximumConcurrentClients,
-                DefaultMaximumTrackedRateLimitClients,
-                DefaultShutdownTimeout)
-        {
-        }
-
-        internal HealthCheckServer(
-            HealthCheckOptions options,
-            Func<DiscordHealthSnapshot> createHealthSnapshot,
-            ILogger<HealthCheckServer> logger,
-            TimeSpan? requestHeadersTimeout = null,
-            int maximumConcurrentClients = DefaultMaximumConcurrentClients,
-            int maximumTrackedRateLimitClients = DefaultMaximumTrackedRateLimitClients,
-            TimeSpan? shutdownTimeout = null)
-        {
-            ArgumentNullException.ThrowIfNull(options);
-            ArgumentNullException.ThrowIfNull(createHealthSnapshot);
-            ArgumentNullException.ThrowIfNull(logger);
-            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumConcurrentClients);
-            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumTrackedRateLimitClients);
-
-            var effectiveRequestHeadersTimeout = requestHeadersTimeout ?? DefaultRequestHeadersTimeout;
-            var effectiveShutdownTimeout = shutdownTimeout ?? DefaultShutdownTimeout;
-            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(effectiveRequestHeadersTimeout, TimeSpan.Zero);
-            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(effectiveShutdownTimeout, TimeSpan.Zero);
-
-            _options = options;
-            _createHealthSnapshot = createHealthSnapshot;
-            _logger = logger;
-            _requestHeadersTimeout = effectiveRequestHeadersTimeout;
-            _shutdownTimeout = effectiveShutdownTimeout;
-            _maximumConcurrentClients = maximumConcurrentClients;
-            _rateLimiter = new BoundedClientRateLimiter(
-                options.MinimumPollInterval,
-                maximumTrackedRateLimitClients);
-        }
-
-        internal int BoundPort
-        {
-            get
-            {
-                lock (_syncRoot)
-                {
-                    return _boundPort;
-                }
-            }
-        }
-
-        public async Task StartAsync(CancellationToken cancellationToken)
-        {
-            if (!_options.Enabled)
-            {
-                return;
-            }
-
-            ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
-
-            WebApplication application;
             lock (_syncRoot)
             {
-                if (_application is not null)
-                {
-                    throw new InvalidOperationException("The health check server has already been started.");
-                }
-
-                application = CreateApplication();
-                _application = application;
+                return _boundPort;
             }
+        }
+    }
 
-            try
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!_options.Enabled)
+        {
+            return;
+        }
+
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+
+        WebApplication application;
+        lock (_syncRoot)
+        {
+            if (_application is not null)
             {
-                await application.StartAsync(cancellationToken);
-            }
-            catch
-            {
-                lock (_syncRoot)
-                {
-                    if (ReferenceEquals(_application, application))
-                    {
-                        _application = null;
-                        _boundPort = 0;
-                    }
-                }
-
-                await application.DisposeAsync();
-                throw;
+                throw new InvalidOperationException("The health check server has already been started.");
             }
 
+            application = CreateApplication();
+            _application = application;
+        }
+
+        try
+        {
+            await application.StartAsync(cancellationToken);
+        }
+        catch
+        {
             lock (_syncRoot)
             {
                 if (ReferenceEquals(_application, application))
                 {
-                    _boundPort = FindBoundPort(application);
+                    _application = null;
+                    _boundPort = 0;
                 }
             }
 
-            BeanBotLog.HealthEndpointListening(
+            await application.DisposeAsync();
+            throw;
+        }
+
+        lock (_syncRoot)
+        {
+            if (ReferenceEquals(_application, application))
+            {
+                _boundPort = FindBoundPort(application);
+            }
+        }
+
+        BeanBotLog.HealthEndpointListening(
+            _logger,
+            _options.BindAddress,
+            BoundPort,
+            _options.Path,
+            (int)_options.MinimumPollInterval.TotalSeconds);
+
+        if (string.IsNullOrWhiteSpace(_options.BearerToken)
+            && !_options.BindAddress.Equals(IPAddress.Loopback)
+            && !_options.BindAddress.Equals(IPAddress.IPv6Loopback))
+        {
+            BeanBotLog.HealthEndpointUnauthenticated(
                 _logger,
                 _options.BindAddress,
                 BoundPort,
-                _options.Path,
-                (int)_options.MinimumPollInterval.TotalSeconds);
+                _options.Path);
+        }
+    }
 
-            if (string.IsNullOrWhiteSpace(_options.BearerToken)
-                && !_options.BindAddress.Equals(IPAddress.Loopback)
-                && !_options.BindAddress.Equals(IPAddress.IPv6Loopback))
-            {
-                BeanBotLog.HealthEndpointUnauthenticated(
-                    _logger,
-                    _options.BindAddress,
-                    BoundPort,
-                    _options.Path);
-            }
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        WebApplication? application;
+        lock (_syncRoot)
+        {
+            application = _application;
+            _application = null;
+            _boundPort = 0;
         }
 
-        public async Task StopAsync(CancellationToken cancellationToken)
+        if (application is null)
         {
-            WebApplication? application;
-            lock (_syncRoot)
-            {
-                application = _application;
-                _application = null;
-                _boundPort = 0;
-            }
+            return;
+        }
 
-            if (application is null)
-            {
-                return;
-            }
-
+        try
+        {
+            using var shutdown = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            shutdown.CancelAfter(_shutdownTimeout);
             try
             {
-                using var shutdown = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                shutdown.CancelAfter(_shutdownTimeout);
-                try
-                {
-                    await application.StopAsync(shutdown.Token);
-                }
-                catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
-                {
-                    BeanBotLog.HealthEndpointShutdownTimedOut(
-                        _logger,
-                        _shutdownTimeout.TotalSeconds);
-                }
+                await application.StopAsync(shutdown.Token);
             }
-            finally
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
             {
-                await application.DisposeAsync();
+                BeanBotLog.HealthEndpointShutdownTimedOut(
+                    _logger,
+                    _shutdownTimeout.TotalSeconds);
             }
         }
-
-        public async ValueTask DisposeAsync()
+        finally
         {
-            if (Interlocked.Exchange(ref _disposed, 1) != 0)
-            {
-                return;
-            }
+            await application.DisposeAsync();
+        }
+    }
 
-            await StopAsync(CancellationToken.None);
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
         }
 
-        private static Func<DiscordHealthSnapshot> CreateSnapshotFactory(
-            DiscordSocketClient discordClient,
-            DiscordConnectionHealth discordConnectionHealth)
+        await StopAsync(CancellationToken.None);
+    }
+
+    private static Func<DiscordHealthSnapshot> CreateSnapshotFactory(
+        DiscordSocketClient discordClient,
+        DiscordConnectionHealth discordConnectionHealth)
+    {
+        ArgumentNullException.ThrowIfNull(discordClient);
+        ArgumentNullException.ThrowIfNull(discordConnectionHealth);
+        return () => discordConnectionHealth.CreateSnapshot(discordClient);
+    }
+
+    private WebApplication CreateApplication()
+    {
+        var builder = WebApplication.CreateSlimBuilder(new WebApplicationOptions
         {
-            ArgumentNullException.ThrowIfNull(discordClient);
-            ArgumentNullException.ThrowIfNull(discordConnectionHealth);
-            return () => discordConnectionHealth.CreateSnapshot(discordClient);
+            Args = [],
+            ApplicationName = typeof(HealthCheckServer).Assembly.GetName().Name
+        });
+        builder.Logging.ClearProviders();
+        builder.Logging.AddSerilog(Log.Logger, dispose: false);
+        builder.Logging.AddFilter<SerilogLoggerProvider>(
+            (_, logLevel) => logLevel >= LogLevel.Warning);
+        builder.WebHost.ConfigureKestrel(serverOptions =>
+        {
+            serverOptions.Listen(_options.BindAddress, _options.Port);
+            serverOptions.Limits.MaxConcurrentConnections = _maximumConcurrentClients;
+            serverOptions.Limits.MaxRequestLineSize = MaxRequestLineLength;
+            serverOptions.Limits.MaxRequestHeaderCount = MaxHeaderCount;
+            serverOptions.Limits.MaxRequestHeadersTotalSize = MaxHeaderCharacters;
+            serverOptions.Limits.RequestHeadersTimeout = _requestHeadersTimeout;
+        });
+
+        var application = builder.Build();
+        application.Run(HandleRequestAsync);
+        return application;
+    }
+
+    private static int FindBoundPort(WebApplication application)
+    {
+        var addresses = application.Services
+            .GetRequiredService<IServer>()
+            .Features
+            .Get<IServerAddressesFeature>()
+            ?.Addresses;
+        return SelectBoundPort(addresses ?? Array.Empty<string>());
+    }
+
+    internal static int SelectBoundPort(IEnumerable<string> addresses)
+    {
+        ArgumentNullException.ThrowIfNull(addresses);
+
+        // Kestrel normally exposes one address for this server. If hosting
+        // configuration adds more, the lowest actual TCP port is stable and
+        // avoids making lifecycle logging or test discovery order-dependent.
+        return addresses
+            .Select(address => Uri.TryCreate(address, UriKind.Absolute, out var uri) ? uri.Port : 0)
+            .Where(port => port > 0)
+            .DefaultIfEmpty(0)
+            .Min();
+    }
+
+    private async Task HandleRequestAsync(HttpContext context)
+    {
+        context.Response.Headers.Connection = "close";
+        var isHeadRequest = HttpMethods.IsHead(context.Request.Method);
+        if (!HttpMethods.IsGet(context.Request.Method) && !isHeadRequest)
+        {
+            context.Response.Headers.Allow = "GET, HEAD";
+            await WritePlainTextResponseAsync(
+                context,
+                StatusCodes.Status405MethodNotAllowed,
+                "Only GET and HEAD are supported.",
+                suppressBody: false);
+            return;
         }
 
-        private WebApplication CreateApplication()
+        if (!string.Equals(context.Request.Path.Value, _options.Path, StringComparison.OrdinalIgnoreCase))
         {
-            var builder = WebApplication.CreateSlimBuilder(new WebApplicationOptions
-            {
-                Args = Array.Empty<string>(),
-                ApplicationName = typeof(HealthCheckServer).Assembly.GetName().Name
-            });
-            builder.Logging.ClearProviders();
-            builder.Logging.AddSerilog(Log.Logger, dispose: false);
-            builder.Logging.AddFilter<SerilogLoggerProvider>(
-                (_, logLevel) => logLevel >= LogLevel.Warning);
-            builder.WebHost.ConfigureKestrel(serverOptions =>
-            {
-                serverOptions.Listen(_options.BindAddress, _options.Port);
-                serverOptions.Limits.MaxConcurrentConnections = _maximumConcurrentClients;
-                serverOptions.Limits.MaxRequestLineSize = MaxRequestLineLength;
-                serverOptions.Limits.MaxRequestHeaderCount = MaxHeaderCount;
-                serverOptions.Limits.MaxRequestHeadersTotalSize = MaxHeaderCharacters;
-                serverOptions.Limits.RequestHeadersTimeout = _requestHeadersTimeout;
-            });
-
-            var application = builder.Build();
-            application.Run(HandleRequestAsync);
-            return application;
+            await WritePlainTextResponseAsync(
+                context,
+                StatusCodes.Status404NotFound,
+                "Not Found",
+                isHeadRequest);
+            return;
         }
 
-        private static int FindBoundPort(WebApplication application)
+        if (!IsAuthorized(context.Request))
         {
-            var addresses = application.Services
-                .GetRequiredService<IServer>()
-                .Features
-                .Get<IServerAddressesFeature>()
-                ?.Addresses;
-            return SelectBoundPort(addresses ?? Array.Empty<string>());
+            context.Response.Headers.WWWAuthenticate = "Bearer";
+            await WritePlainTextResponseAsync(
+                context,
+                StatusCodes.Status401Unauthorized,
+                "Missing or invalid bearer token.",
+                isHeadRequest);
+            return;
         }
 
-        internal static int SelectBoundPort(IEnumerable<string> addresses)
+        var clientIdentifier = context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        if (_rateLimiter.IsRateLimited(clientIdentifier, out var retryAfterSeconds))
         {
-            ArgumentNullException.ThrowIfNull(addresses);
-
-            // Kestrel normally exposes one address for this server. If hosting
-            // configuration adds more, the lowest actual TCP port is stable and
-            // avoids making lifecycle logging or test discovery order-dependent.
-            return addresses
-                .Select(address => Uri.TryCreate(address, UriKind.Absolute, out var uri) ? uri.Port : 0)
-                .Where(port => port > 0)
-                .DefaultIfEmpty(0)
-                .Min();
-        }
-
-        private async Task HandleRequestAsync(HttpContext context)
-        {
-            context.Response.Headers.Connection = "close";
-            var isHeadRequest = HttpMethods.IsHead(context.Request.Method);
-            if (!HttpMethods.IsGet(context.Request.Method) && !isHeadRequest)
-            {
-                context.Response.Headers.Allow = "GET, HEAD";
-                await WritePlainTextResponseAsync(
-                    context,
-                    StatusCodes.Status405MethodNotAllowed,
-                    "Only GET and HEAD are supported.",
-                    suppressBody: false);
-                return;
-            }
-
-            if (!string.Equals(context.Request.Path.Value, _options.Path, StringComparison.OrdinalIgnoreCase))
-            {
-                await WritePlainTextResponseAsync(
-                    context,
-                    StatusCodes.Status404NotFound,
-                    "Not Found",
-                    isHeadRequest);
-                return;
-            }
-
-            if (!IsAuthorized(context.Request))
-            {
-                context.Response.Headers.WWWAuthenticate = "Bearer";
-                await WritePlainTextResponseAsync(
-                    context,
-                    StatusCodes.Status401Unauthorized,
-                    "Missing or invalid bearer token.",
-                    isHeadRequest);
-                return;
-            }
-
-            var clientIdentifier = context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
-            if (_rateLimiter.IsRateLimited(clientIdentifier, out var retryAfterSeconds))
-            {
-                context.Response.Headers.RetryAfter = retryAfterSeconds.ToString(CultureInfo.InvariantCulture);
-                await WriteJsonResponseAsync(
-                    context,
-                    StatusCodes.Status429TooManyRequests,
-                    new
-                    {
-                        status = "rate_limited",
-                        message = $"Wait {retryAfterSeconds} more seconds before polling {_options.Path} again.",
-                        retryAfterSeconds
-                    },
-                    isHeadRequest);
-                return;
-            }
-
-            var healthSnapshot = _createHealthSnapshot();
+            context.Response.Headers.RetryAfter = retryAfterSeconds.ToString(CultureInfo.InvariantCulture);
             await WriteJsonResponseAsync(
                 context,
-                healthSnapshot.IsHealthy
-                    ? StatusCodes.Status200OK
-                    : StatusCodes.Status503ServiceUnavailable,
+                StatusCodes.Status429TooManyRequests,
                 new
                 {
-                    status = healthSnapshot.IsHealthy ? "ok" : "unhealthy",
-                    discordConnected = healthSnapshot.IsHealthy,
-                    message = healthSnapshot.StatusMessage,
-                    loginState = healthSnapshot.LoginState,
-                    connectionState = healthSnapshot.ConnectionState,
-                    lastReadyAtUtc = healthSnapshot.LastReadyAtUtc,
-                    lastDisconnectedAtUtc = healthSnapshot.LastDisconnectedAtUtc,
-                    unhealthySinceAtUtc = healthSnapshot.UnhealthySinceAtUtc,
-                    mostRecentDisconnectReason = healthSnapshot.MostRecentDisconnectReason
+                    status = "rate_limited",
+                    message = $"Wait {retryAfterSeconds} more seconds before polling {_options.Path} again.",
+                    retryAfterSeconds
                 },
                 isHeadRequest);
+            return;
         }
 
-        private bool IsAuthorized(HttpRequest request)
-        {
-            if (string.IsNullOrWhiteSpace(_options.BearerToken))
+        var healthSnapshot = _createHealthSnapshot();
+        await WriteJsonResponseAsync(
+            context,
+            healthSnapshot.IsHealthy
+                ? StatusCodes.Status200OK
+                : StatusCodes.Status503ServiceUnavailable,
+            new
             {
-                return true;
-            }
+                status = healthSnapshot.IsHealthy ? "ok" : "unhealthy",
+                discordConnected = healthSnapshot.IsHealthy,
+                message = healthSnapshot.StatusMessage,
+                loginState = healthSnapshot.LoginState,
+                connectionState = healthSnapshot.ConnectionState,
+                lastReadyAtUtc = healthSnapshot.LastReadyAtUtc,
+                lastDisconnectedAtUtc = healthSnapshot.LastDisconnectedAtUtc,
+                unhealthySinceAtUtc = healthSnapshot.UnhealthySinceAtUtc,
+                mostRecentDisconnectReason = healthSnapshot.MostRecentDisconnectReason
+            },
+            isHeadRequest);
+    }
 
-            var authorizationHeader = request.Headers.Authorization.ToString();
-            if (!authorizationHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-
-            var providedToken = Encoding.UTF8.GetBytes(authorizationHeader["Bearer ".Length..].Trim());
-            var expectedToken = Encoding.UTF8.GetBytes(_options.BearerToken);
-            return CryptographicOperations.FixedTimeEquals(providedToken, expectedToken);
+    private bool IsAuthorized(HttpRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(_options.BearerToken))
+        {
+            return true;
         }
 
-        private static Task WritePlainTextResponseAsync(
-            HttpContext context,
-            int statusCode,
-            string body,
-            bool suppressBody)
+        var authorizationHeader = request.Headers.Authorization.ToString();
+        if (!authorizationHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
         {
-            return WriteResponseAsync(
-                context,
-                statusCode,
-                "text/plain; charset=utf-8",
-                Encoding.UTF8.GetBytes(body),
-                suppressBody);
+            return false;
         }
 
-        private static Task WriteJsonResponseAsync(
-            HttpContext context,
-            int statusCode,
-            object payload,
-            bool suppressBody)
-        {
-            return WriteResponseAsync(
-                context,
-                statusCode,
-                "application/json; charset=utf-8",
-                JsonSerializer.SerializeToUtf8Bytes(payload, JsonOptions),
-                suppressBody);
-        }
+        var providedToken = Encoding.UTF8.GetBytes(authorizationHeader["Bearer ".Length..].Trim());
+        var expectedToken = Encoding.UTF8.GetBytes(_options.BearerToken);
+        return CryptographicOperations.FixedTimeEquals(providedToken, expectedToken);
+    }
 
-        private static async Task WriteResponseAsync(
-            HttpContext context,
-            int statusCode,
-            string contentType,
-            byte[] body,
-            bool suppressBody)
+    private static Task WritePlainTextResponseAsync(
+        HttpContext context,
+        int statusCode,
+        string body,
+        bool suppressBody)
+    {
+        return WriteResponseAsync(
+            context,
+            statusCode,
+            "text/plain; charset=utf-8",
+            Encoding.UTF8.GetBytes(body),
+            suppressBody);
+    }
+
+    private static Task WriteJsonResponseAsync(
+        HttpContext context,
+        int statusCode,
+        object payload,
+        bool suppressBody)
+    {
+        return WriteResponseAsync(
+            context,
+            statusCode,
+            "application/json; charset=utf-8",
+            JsonSerializer.SerializeToUtf8Bytes(payload, JsonOptions),
+            suppressBody);
+    }
+
+    private static async Task WriteResponseAsync(
+        HttpContext context,
+        int statusCode,
+        string contentType,
+        byte[] body,
+        bool suppressBody)
+    {
+        context.Response.StatusCode = statusCode;
+        context.Response.ContentType = contentType;
+        context.Response.ContentLength = body.Length;
+        if (!suppressBody)
         {
-            context.Response.StatusCode = statusCode;
-            context.Response.ContentType = contentType;
-            context.Response.ContentLength = body.Length;
-            if (!suppressBody)
-            {
-                await context.Response.Body.WriteAsync(body, context.RequestAborted);
-            }
+            await context.Response.Body.WriteAsync(body, context.RequestAborted);
         }
     }
 }

--- a/BeanBot/Services/ReactionRoleSetupTransaction.cs
+++ b/BeanBot/Services/ReactionRoleSetupTransaction.cs
@@ -1,40 +1,36 @@
-using System;
-using System.Threading.Tasks;
+namespace BeanBot.Services;
 
-namespace BeanBot.Services
+internal static class ReactionRoleSetupTransaction
 {
-    internal static class ReactionRoleSetupTransaction
+    public static async Task<TMessage> ExecuteAsync<TMessage>(
+        Func<Task<TMessage>> createMessage,
+        Func<TMessage, Task> configureAndPersist,
+        Func<TMessage, Task> deleteMessage,
+        Action<Exception> onCompensationFailure)
+        where TMessage : class
     {
-        public static async Task<TMessage> ExecuteAsync<TMessage>(
-            Func<Task<TMessage>> createMessage,
-            Func<TMessage, Task> configureAndPersist,
-            Func<TMessage, Task> deleteMessage,
-            Action<Exception> onCompensationFailure)
-            where TMessage : class
+        TMessage? message = null;
+        try
         {
-            TMessage? message = null;
-            try
+            message = await createMessage();
+            await configureAndPersist(message);
+            return message;
+        }
+        catch
+        {
+            if (message != null)
             {
-                message = await createMessage();
-                await configureAndPersist(message);
-                return message;
-            }
-            catch
-            {
-                if (message != null)
+                try
                 {
-                    try
-                    {
-                        await deleteMessage(message);
-                    }
-                    catch (Exception compensationException)
-                    {
-                        onCompensationFailure(compensationException);
-                    }
+                    await deleteMessage(message);
                 }
-
-                throw;
+                catch (Exception compensationException)
+                {
+                    onCompensationFailure(compensationException);
+                }
             }
+
+            throw;
         }
     }
 }

--- a/BeanBot/Services/RoleReactService.cs
+++ b/BeanBot/Services/RoleReactService.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+using System.Globalization;
 using BeanBot.Entities;
 using BeanBot.Repository;
 using BeanBot.Util;
@@ -5,335 +7,327 @@ using Discord;
 using Discord.WebSocket;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace BeanBot.Services
+namespace BeanBot.Services;
+
+public class RoleReactService : IDisposable, IAsyncDisposable
 {
-    public class RoleReactService : IDisposable, IAsyncDisposable
+    private static readonly TimeSpan DefaultShutdownDrainTimeout = TimeSpan.FromSeconds(5);
+    private readonly RoleReactRepository _roleReactRepository;
+    private readonly DiscordSocketClient? _client;
+    private readonly SemaphoreSlim _cacheLock = new(1, 1);
+    private readonly ConcurrentDictionary<string, RoleSettings> _roleSettings = [];
+    private readonly object _operationSync = new();
+    private readonly HashSet<Task> _inFlightOperations = [];
+    private readonly TimeSpan _shutdownDrainTimeout;
+    private readonly TaskCompletionSource _disposeCompletion = new(
+        TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly ILogger<RoleReactService> _logger;
+    private readonly CancellationTokenSource _shutdownCancellation;
+    private readonly CancellationToken _shutdownToken;
+    private volatile bool _cacheLoaded;
+    private bool _stopping;
+    private int _disposeStarted;
+
+    public RoleReactService(
+        RoleReactRepository roleReactRepository,
+        IHostApplicationLifetime applicationLifetime,
+        ILogger<RoleReactService> logger,
+        DiscordSocketClient? client = null)
+        : this(
+            roleReactRepository,
+            client,
+            DefaultShutdownDrainTimeout,
+            logger,
+            (applicationLifetime ?? throw new ArgumentNullException(nameof(applicationLifetime)))
+                .ApplicationStopping)
     {
-        private static readonly TimeSpan DefaultShutdownDrainTimeout = TimeSpan.FromSeconds(5);
-        private readonly RoleReactRepository _roleReactRepository;
-        private readonly DiscordSocketClient? _client;
-        private readonly SemaphoreSlim _cacheLock = new SemaphoreSlim(1, 1);
-        private readonly ConcurrentDictionary<string, RoleSettings> _roleSettings = new ConcurrentDictionary<string, RoleSettings>();
-        private readonly object _operationSync = new();
-        private readonly HashSet<Task> _inFlightOperations = new();
-        private readonly TimeSpan _shutdownDrainTimeout;
-        private readonly TaskCompletionSource _disposeCompletion = new(
-            TaskCreationOptions.RunContinuationsAsynchronously);
-        private readonly ILogger<RoleReactService> _logger;
-        private readonly CancellationTokenSource _shutdownCancellation;
-        private readonly CancellationToken _shutdownToken;
-        private volatile bool _cacheLoaded;
-        private bool _stopping;
-        private int _disposeStarted;
+    }
 
-        public RoleReactService(
-            RoleReactRepository roleReactRepository,
-            IHostApplicationLifetime applicationLifetime,
-            ILogger<RoleReactService> logger,
-            DiscordSocketClient? client = null)
-            : this(
-                roleReactRepository,
-                client,
-                DefaultShutdownDrainTimeout,
-                logger,
-                (applicationLifetime ?? throw new ArgumentNullException(nameof(applicationLifetime)))
-                    .ApplicationStopping)
+    internal RoleReactService(
+        RoleReactRepository roleReactRepository,
+        DiscordSocketClient? client,
+        TimeSpan shutdownDrainTimeout,
+        ILogger<RoleReactService> logger,
+        CancellationToken applicationStopping)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(shutdownDrainTimeout, TimeSpan.Zero);
+        _roleReactRepository = roleReactRepository ?? throw new ArgumentNullException(nameof(roleReactRepository));
+        _client = client;
+        _shutdownDrainTimeout = shutdownDrainTimeout;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _shutdownCancellation = CancellationTokenSource.CreateLinkedTokenSource(applicationStopping);
+        _shutdownToken = _shutdownCancellation.Token;
+    }
+
+    public Task HandleReact(Cacheable<IUserMessage, ulong> message, Cacheable<IMessageChannel, ulong> channel, SocketReaction reaction)
+        => TrackHandlerAsync(cancellationToken =>
+            HandleReactionAsync(message, channel, reaction, addRole: true, cancellationToken));
+
+    public Task HandleRemoveReact(Cacheable<IUserMessage, ulong> message, Cacheable<IMessageChannel, ulong> channel, SocketReaction reaction)
+        => TrackHandlerAsync(cancellationToken =>
+            HandleReactionAsync(message, channel, reaction, addRole: false, cancellationToken));
+
+    internal Task TrackHandlerAsync(Func<CancellationToken, Task> beginOperation)
+        => TrackOperationAsync(beginOperation, skipWhenStopping: true);
+
+    private Task TrackRequiredOperationAsync(Func<CancellationToken, Task> beginOperation)
+        => TrackOperationAsync(beginOperation, skipWhenStopping: false);
+
+    private Task TrackOperationAsync(
+        Func<CancellationToken, Task> beginOperation,
+        bool skipWhenStopping)
+    {
+        ArgumentNullException.ThrowIfNull(beginOperation);
+
+        Task operation;
+        lock (_operationSync)
         {
+            if (_stopping || _shutdownToken.IsCancellationRequested)
+            {
+                return skipWhenStopping
+                    ? Task.CompletedTask
+                    : Task.FromCanceled(_shutdownToken);
+            }
+
+            operation = beginOperation(_shutdownToken);
+            _inFlightOperations.Add(operation);
         }
 
-        internal RoleReactService(
-            RoleReactRepository roleReactRepository,
-            DiscordSocketClient? client,
-            TimeSpan shutdownDrainTimeout,
-            ILogger<RoleReactService> logger,
-            CancellationToken applicationStopping)
+        return ObserveOperationAsync(operation);
+    }
+
+    private async Task ObserveOperationAsync(Task operation)
+    {
+        try
         {
-            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(shutdownDrainTimeout, TimeSpan.Zero);
-            _roleReactRepository = roleReactRepository ?? throw new ArgumentNullException(nameof(roleReactRepository));
-            _client = client;
-            _shutdownDrainTimeout = shutdownDrainTimeout;
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _shutdownCancellation = CancellationTokenSource.CreateLinkedTokenSource(applicationStopping);
-            _shutdownToken = _shutdownCancellation.Token;
+            await operation;
         }
-
-        public Task HandleReact(Cacheable<IUserMessage, ulong> message, Cacheable<IMessageChannel, ulong> channel, SocketReaction reaction)
-            => TrackHandlerAsync(cancellationToken =>
-                HandleReactionAsync(message, channel, reaction, addRole: true, cancellationToken));
-
-        public Task HandleRemoveReact(Cacheable<IUserMessage, ulong> message, Cacheable<IMessageChannel, ulong> channel, SocketReaction reaction)
-            => TrackHandlerAsync(cancellationToken =>
-                HandleReactionAsync(message, channel, reaction, addRole: false, cancellationToken));
-
-        internal Task TrackHandlerAsync(Func<CancellationToken, Task> beginOperation)
-            => TrackOperationAsync(beginOperation, skipWhenStopping: true);
-
-        private Task TrackRequiredOperationAsync(Func<CancellationToken, Task> beginOperation)
-            => TrackOperationAsync(beginOperation, skipWhenStopping: false);
-
-        private Task TrackOperationAsync(
-            Func<CancellationToken, Task> beginOperation,
-            bool skipWhenStopping)
+        finally
         {
-            ArgumentNullException.ThrowIfNull(beginOperation);
-
-            Task operation;
             lock (_operationSync)
             {
-                if (_stopping || _shutdownToken.IsCancellationRequested)
-                {
-                    return skipWhenStopping
-                        ? Task.CompletedTask
-                        : Task.FromCanceled(_shutdownToken);
-                }
-
-                operation = beginOperation(_shutdownToken);
-                _inFlightOperations.Add(operation);
+                _inFlightOperations.Remove(operation);
             }
-
-            return ObserveOperationAsync(operation);
         }
+    }
 
-        private async Task ObserveOperationAsync(Task operation)
+    private async Task HandleReactionAsync(
+        Cacheable<IUserMessage, ulong> message,
+        Cacheable<IMessageChannel, ulong> channel,
+        SocketReaction reaction,
+        bool addRole,
+        CancellationToken cancellationToken)
+    {
+        try
         {
-            try
+            var currentUser = _client?.CurrentUser;
+            if (currentUser == null)
             {
-                await operation;
+                return;
             }
-            finally
+
+            var resolvedChannel = await channel.GetOrDownloadAsync();
+            if (resolvedChannel is not SocketTextChannel textChannel)
             {
-                lock (_operationSync)
-                {
-                    _inFlightOperations.Remove(operation);
-                }
+                return;
+            }
+
+            var cachedMessage = await message.GetOrDownloadAsync();
+            if (cachedMessage.Author.Id != currentUser.Id || reaction.UserId == currentUser.Id)
+            {
+                return;
+            }
+
+            if (reaction.Emote is not Emote customEmote)
+            {
+                return;
+            }
+
+            var roleSetting = await GetCachedRoleSettingAsync(message.Id, cancellationToken);
+            var pair = roleSetting?.RoleEmotePairs?
+                .FirstOrDefault(candidate =>
+                    candidate.EmojiId == customEmote.Id.ToString(CultureInfo.InvariantCulture));
+            if (pair == null || !ulong.TryParse(pair.RoleId, out var roleId))
+            {
+                return;
+            }
+
+            var guild = (IGuild)textChannel.Guild;
+            var user = await guild.GetUserAsync(reaction.UserId, CacheMode.AllowDownload);
+            var role = guild.Roles.FirstOrDefault(candidate => candidate.Id == roleId);
+            if (user == null || role == null)
+            {
+                return;
+            }
+
+            if (addRole && !user.RoleIds.Contains(roleId))
+            {
+                await user.AddRoleAsync(role);
+            }
+            else if (!addRole && user.RoleIds.Contains(roleId))
+            {
+                await user.RemoveRoleAsync(role);
             }
         }
-
-        private async Task HandleReactionAsync(
-            Cacheable<IUserMessage, ulong> message,
-            Cacheable<IMessageChannel, ulong> channel,
-            SocketReaction reaction,
-            bool addRole,
-            CancellationToken cancellationToken)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            try
-            {
-                var currentUser = _client?.CurrentUser;
-                if (currentUser == null)
-                {
-                    return;
-                }
-
-                var resolvedChannel = await channel.GetOrDownloadAsync();
-                if (resolvedChannel is not SocketTextChannel textChannel)
-                {
-                    return;
-                }
-
-                var cachedMessage = await message.GetOrDownloadAsync();
-                if (cachedMessage.Author.Id != currentUser.Id || reaction.UserId == currentUser.Id)
-                {
-                    return;
-                }
-
-                if (reaction.Emote is not Emote customEmote)
-                {
-                    return;
-                }
-
-                var roleSetting = await GetCachedRoleSettingAsync(message.Id, cancellationToken);
-                var pair = roleSetting?.RoleEmotePairs?
-                    .FirstOrDefault(candidate =>
-                        candidate.EmojiId == customEmote.Id.ToString(CultureInfo.InvariantCulture));
-                if (pair == null || !ulong.TryParse(pair.RoleId, out var roleId))
-                {
-                    return;
-                }
-
-                var guild = (IGuild)textChannel.Guild;
-                var user = await guild.GetUserAsync(reaction.UserId, CacheMode.AllowDownload);
-                var role = guild.Roles.FirstOrDefault(candidate => candidate.Id == roleId);
-                if (user == null || role == null)
-                {
-                    return;
-                }
-
-                if (addRole && !user.RoleIds.Contains(roleId))
-                {
-                    await user.AddRoleAsync(role);
-                }
-                else if (!addRole && user.RoleIds.Contains(roleId))
-                {
-                    await user.RemoveRoleAsync(role);
-                }
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                throw;
-            }
-            catch (Exception exception)
-            {
-                BeanBotLog.ReactionRoleActionFailed(
-                    _logger,
-                    addRole ? "add" : "remove",
-                    message.Id,
-                    exception);
-            }
+            throw;
         }
-
-        internal async Task<RoleSettings?> GetCachedRoleSettingAsync(
-            ulong messageId,
-            CancellationToken cancellationToken)
+        catch (Exception exception)
         {
-            await EnsureCacheLoadedAsync(cancellationToken);
-            var messageIdText = messageId.ToString(CultureInfo.InvariantCulture);
-            if (_roleSettings.TryGetValue(messageIdText, out var cached))
-            {
-                return cached;
-            }
+            BeanBotLog.ReactionRoleActionFailed(
+                _logger,
+                addRole ? "add" : "remove",
+                message.Id,
+                exception);
+        }
+    }
 
-            var roleSetting = await _roleReactRepository.GetRoleSetting(messageId, cancellationToken);
-            if (roleSetting != null && !string.IsNullOrWhiteSpace(roleSetting.MessageId))
-            {
-                _roleSettings[roleSetting.MessageId] = roleSetting;
-            }
-
-            return roleSetting;
+    internal async Task<RoleSettings?> GetCachedRoleSettingAsync(
+        ulong messageId,
+        CancellationToken cancellationToken)
+    {
+        await EnsureCacheLoadedAsync(cancellationToken);
+        var messageIdText = messageId.ToString(CultureInfo.InvariantCulture);
+        if (_roleSettings.TryGetValue(messageIdText, out var cached))
+        {
+            return cached;
         }
 
-        private async Task EnsureCacheLoadedAsync(CancellationToken cancellationToken)
+        var roleSetting = await _roleReactRepository.GetRoleSetting(messageId, cancellationToken);
+        if (roleSetting != null && !string.IsNullOrWhiteSpace(roleSetting.MessageId))
+        {
+            _roleSettings[roleSetting.MessageId] = roleSetting;
+        }
+
+        return roleSetting;
+    }
+
+    private async Task EnsureCacheLoadedAsync(CancellationToken cancellationToken)
+    {
+        if (_cacheLoaded)
+        {
+            return;
+        }
+
+        await _cacheLock.WaitAsync(cancellationToken);
+        try
         {
             if (_cacheLoaded)
             {
                 return;
             }
 
-            await _cacheLock.WaitAsync(cancellationToken);
-            try
+            foreach (var setting in await _roleReactRepository.GetRecentRoleSettings(cancellationToken))
             {
-                if (_cacheLoaded)
+                if (!string.IsNullOrWhiteSpace(setting.MessageId))
                 {
+                    _roleSettings[setting.MessageId] = setting;
+                }
+            }
+            _cacheLoaded = true;
+        }
+        finally
+        {
+            _cacheLock.Release();
+        }
+    }
+
+    public Task SaveRoleSettings(
+        List<RoleEmotePair> roleEmotePair,
+        IMessage messageToListen,
+        CancellationToken cancellationToken = default)
+        => TrackRequiredOperationAsync(async shutdownToken =>
+        {
+            using var operationCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                shutdownToken,
+                cancellationToken);
+            operationCancellation.Token.ThrowIfCancellationRequested();
+            await SaveRoleSettingsCoreAsync(
+                roleEmotePair,
+                messageToListen,
+                operationCancellation.Token);
+        });
+
+    private async Task SaveRoleSettingsCoreAsync(
+        List<RoleEmotePair> roleEmotePair,
+        IMessage messageToListen,
+        CancellationToken cancellationToken)
+    {
+        if (messageToListen.Channel is not SocketTextChannel textChannel)
+        {
+            throw new InvalidOperationException("Reaction-role settings can only be saved from a guild text channel.");
+        }
+
+        var settings = new RoleSettings(
+            roleEmotePair,
+            textChannel.Guild.Id.ToString(CultureInfo.InvariantCulture),
+            messageToListen.Channel.Id.ToString(CultureInfo.InvariantCulture),
+            messageToListen.Id.ToString(CultureInfo.InvariantCulture));
+        await PersistRoleSettingsAsync(settings, cancellationToken);
+    }
+
+    internal async Task PersistRoleSettingsAsync(
+        RoleSettings settings,
+        CancellationToken cancellationToken)
+    {
+        await _roleReactRepository.InsertNewRoleSettings(settings, cancellationToken);
+        _roleSettings[settings.MessageId] = settings;
+    }
+
+    public void Dispose()
+    {
+        DisposeAsync().AsTask().GetAwaiter().GetResult();
+        GC.SuppressFinalize(this);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposeStarted, 1) != 0)
+        {
+            await _disposeCompletion.Task;
+            return;
+        }
+
+        try
+        {
+            _shutdownCancellation.Cancel();
+
+            Task[] inFlightOperations;
+            lock (_operationSync)
+            {
+                _stopping = true;
+                inFlightOperations = [.. _inFlightOperations];
+            }
+
+            if (inFlightOperations.Length > 0)
+            {
+                try
+                {
+                    await Task.WhenAll(inFlightOperations).WaitAsync(_shutdownDrainTimeout);
+                }
+                catch (TimeoutException)
+                {
+                    BeanBotLog.ReactionRoleDrainTimedOut(_logger, inFlightOperations.Length);
                     return;
                 }
-
-                foreach (var setting in await _roleReactRepository.GetRecentRoleSettings(cancellationToken))
+                catch (OperationCanceledException) when (_shutdownToken.IsCancellationRequested)
                 {
-                    if (!string.IsNullOrWhiteSpace(setting.MessageId))
-                    {
-                        _roleSettings[setting.MessageId] = setting;
-                    }
                 }
-                _cacheLoaded = true;
-            }
-            finally
-            {
-                _cacheLock.Release();
-            }
-        }
-
-        public Task SaveRoleSettings(
-            List<RoleEmotePair> roleEmotePair,
-            IMessage messageToListen,
-            CancellationToken cancellationToken = default)
-            => TrackRequiredOperationAsync(async shutdownToken =>
-            {
-                using var operationCancellation = CancellationTokenSource.CreateLinkedTokenSource(
-                    shutdownToken,
-                    cancellationToken);
-                operationCancellation.Token.ThrowIfCancellationRequested();
-                await SaveRoleSettingsCoreAsync(
-                    roleEmotePair,
-                    messageToListen,
-                    operationCancellation.Token);
-            });
-
-        private async Task SaveRoleSettingsCoreAsync(
-            List<RoleEmotePair> roleEmotePair,
-            IMessage messageToListen,
-            CancellationToken cancellationToken)
-        {
-            if (messageToListen.Channel is not SocketTextChannel textChannel)
-            {
-                throw new InvalidOperationException("Reaction-role settings can only be saved from a guild text channel.");
+                catch (Exception exception)
+                {
+                    BeanBotLog.ReactionRoleShutdownOperationFailed(_logger, exception);
+                }
             }
 
-            var settings = new RoleSettings(
-                roleEmotePair,
-                textChannel.Guild.Id.ToString(CultureInfo.InvariantCulture),
-                messageToListen.Channel.Id.ToString(CultureInfo.InvariantCulture),
-                messageToListen.Id.ToString(CultureInfo.InvariantCulture));
-            await PersistRoleSettingsAsync(settings, cancellationToken);
-        }
-
-        internal async Task PersistRoleSettingsAsync(
-            RoleSettings settings,
-            CancellationToken cancellationToken)
-        {
-            await _roleReactRepository.InsertNewRoleSettings(settings, cancellationToken);
-            _roleSettings[settings.MessageId] = settings;
-        }
-
-        public void Dispose()
-        {
-            DisposeAsync().AsTask().GetAwaiter().GetResult();
+            _cacheLock.Dispose();
+            _shutdownCancellation.Dispose();
             GC.SuppressFinalize(this);
         }
-
-        public async ValueTask DisposeAsync()
+        finally
         {
-            if (Interlocked.Exchange(ref _disposeStarted, 1) != 0)
-            {
-                await _disposeCompletion.Task;
-                return;
-            }
-
-            try
-            {
-                _shutdownCancellation.Cancel();
-
-                Task[] inFlightOperations;
-                lock (_operationSync)
-                {
-                    _stopping = true;
-                    inFlightOperations = _inFlightOperations.ToArray();
-                }
-
-                if (inFlightOperations.Length > 0)
-                {
-                    try
-                    {
-                        await Task.WhenAll(inFlightOperations).WaitAsync(_shutdownDrainTimeout);
-                    }
-                    catch (TimeoutException)
-                    {
-                        BeanBotLog.ReactionRoleDrainTimedOut(_logger, inFlightOperations.Length);
-                        return;
-                    }
-                    catch (OperationCanceledException) when (_shutdownToken.IsCancellationRequested)
-                    {
-                    }
-                    catch (Exception exception)
-                    {
-                        BeanBotLog.ReactionRoleShutdownOperationFailed(_logger, exception);
-                    }
-                }
-
-                _cacheLock.Dispose();
-                _shutdownCancellation.Dispose();
-                GC.SuppressFinalize(this);
-            }
-            finally
-            {
-                _disposeCompletion.TrySetResult();
-            }
+            _disposeCompletion.TrySetResult();
         }
     }
 }

--- a/BeanBot/Util/BeanBotLog.cs
+++ b/BeanBot/Util/BeanBotLog.cs
@@ -1,8 +1,6 @@
-using Discord;
-
-using Microsoft.Extensions.Logging;
-
 using System.Net;
+using Discord;
+using Microsoft.Extensions.Logging;
 
 namespace BeanBot.Util;
 

--- a/BeanBot/Util/BotOwner.cs
+++ b/BeanBot/Util/BotOwner.cs
@@ -1,7 +1,6 @@
-namespace BeanBot.Util
+namespace BeanBot.Util;
+
+internal static class BotOwner
 {
-    internal static class BotOwner
-    {
-        public const ulong DiscordUserId = 114559039731531781;
-    }
+    public const ulong DiscordUserId = 114559039731531781;
 }

--- a/BeanBot/Util/DirectorySetup.cs
+++ b/BeanBot/Util/DirectorySetup.cs
@@ -1,32 +1,29 @@
-using System.IO;
+namespace BeanBot.Util;
 
-namespace BeanBot.Util
+public static class DirectorySetup
 {
-    public static class DirectorySetup
+    public readonly static string botBaseDirectory = Path.Combine("BeanBotFiles");
+    public readonly static string logsDirectory = Path.Combine(botBaseDirectory, "Logs");
+
+    public static void MakeSureAllDirectoriesExist()
     {
-        public readonly static string botBaseDirectory = Path.Combine("BeanBotFiles");
-        public readonly static string logsDirectory = Path.Combine(botBaseDirectory, "Logs");
+        MakeSureBaseDirectoryExists();
+        MakeSureLogsDirectoryExists(Path.GetFullPath(logsDirectory));
+    }
 
-        public static void MakeSureAllDirectoriesExist()
+    internal static void MakeSureBaseDirectoryExists()
+    {
+        if (!Directory.Exists(botBaseDirectory))
         {
-            MakeSureBaseDirectoryExists();
-            MakeSureLogsDirectoryExists(Path.GetFullPath(logsDirectory));
+            Directory.CreateDirectory(Path.GetFullPath(botBaseDirectory));
         }
+    }
 
-        internal static void MakeSureBaseDirectoryExists()
+    internal static void MakeSureLogsDirectoryExists(string logDirectory)
+    {
+        if (!Directory.Exists(logDirectory))
         {
-            if (!Directory.Exists(botBaseDirectory))
-            {
-                Directory.CreateDirectory(Path.GetFullPath(botBaseDirectory));
-            }
-        }
-
-        internal static void MakeSureLogsDirectoryExists(string logDirectory)
-        {
-            if (!Directory.Exists(logDirectory))
-            {
-                Directory.CreateDirectory(logDirectory);
-            }
+            Directory.CreateDirectory(logDirectory);
         }
     }
 }

--- a/BeanBot/Util/DiscordOwnerErrorSink.cs
+++ b/BeanBot/Util/DiscordOwnerErrorSink.cs
@@ -1,203 +1,199 @@
+using System.Globalization;
+using System.Threading.Channels;
 using Discord;
 using Discord.WebSocket;
 using Serilog.Core;
 using Serilog.Events;
-using System;
-using System.Globalization;
-using System.Threading;
-using System.Threading.Channels;
-using System.Threading.Tasks;
 
-namespace BeanBot.Util
+namespace BeanBot.Util;
+
+internal interface IOwnerErrorNotifier
 {
-    internal interface IOwnerErrorNotifier
+    void Enqueue(string alert);
+}
+
+internal interface IOwnerAlertDelivery
+{
+    Task DeliverAsync(string alert, CancellationToken cancellationToken);
+}
+
+internal sealed class DiscordOwnerErrorSink : ILogEventSink
+{
+    private readonly IOwnerErrorNotifier _notifier;
+
+    public DiscordOwnerErrorSink(IOwnerErrorNotifier notifier)
     {
-        void Enqueue(string alert);
+        _notifier = notifier ?? throw new ArgumentNullException(nameof(notifier));
     }
 
-    internal interface IOwnerAlertDelivery
+    public void Emit(LogEvent logEvent)
     {
-        Task DeliverAsync(string alert, CancellationToken cancellationToken);
-    }
-
-    internal sealed class DiscordOwnerErrorSink : ILogEventSink
-    {
-        private readonly IOwnerErrorNotifier _notifier;
-
-        public DiscordOwnerErrorSink(IOwnerErrorNotifier notifier)
+        if (logEvent.Level >= LogEventLevel.Error)
         {
-            _notifier = notifier ?? throw new ArgumentNullException(nameof(notifier));
-        }
-
-        public void Emit(LogEvent logEvent)
-        {
-            if (logEvent.Level >= LogEventLevel.Error)
-            {
-                _notifier.Enqueue(FormatAlert(logEvent));
-            }
-        }
-
-        internal static string FormatAlert(LogEvent logEvent)
-        {
-            const int maximumLength = 1900;
-            var exception = logEvent.Exception == null ? string.Empty : $"\n{logEvent.Exception}";
-            var alert = $"BeanBot {logEvent.Level} at {logEvent.Timestamp:O}\n{logEvent.RenderMessage(CultureInfo.InvariantCulture)}{exception}";
-            return alert.Length <= maximumLength
-                ? alert
-                : string.Concat(alert.AsSpan(0, maximumLength - 15), "\n...(truncated)");
+            _notifier.Enqueue(FormatAlert(logEvent));
         }
     }
 
-    internal sealed class DiscordOwnerErrorNotifier : IOwnerErrorNotifier, IAsyncDisposable
+    internal static string FormatAlert(LogEvent logEvent)
     {
-        internal const int DefaultMaximumAttempts = 3;
-        private readonly Channel<string> _alerts;
-        private readonly IOwnerAlertDelivery _delivery;
-        private readonly Func<int, TimeSpan> _retryDelay;
-        private readonly TimeSpan _shutdownFlushTimeout;
-        private readonly CancellationTokenSource _shutdown = new CancellationTokenSource();
-        private readonly Task _worker;
-        private int _sendInProgress;
-        private int _disposed;
+        const int maximumLength = 1900;
+        var exception = logEvent.Exception == null ? string.Empty : $"\n{logEvent.Exception}";
+        var alert = $"BeanBot {logEvent.Level} at {logEvent.Timestamp:O}\n{logEvent.RenderMessage(CultureInfo.InvariantCulture)}{exception}";
+        return alert.Length <= maximumLength
+            ? alert
+            : string.Concat(alert.AsSpan(0, maximumLength - 15), "\n...(truncated)");
+    }
+}
 
-        public DiscordOwnerErrorNotifier(DiscordSocketClient discordClient)
-            : this(new DiscordOwnerAlertDelivery(discordClient))
+internal sealed class DiscordOwnerErrorNotifier : IOwnerErrorNotifier, IAsyncDisposable
+{
+    internal const int DefaultMaximumAttempts = 3;
+    private readonly Channel<string> _alerts;
+    private readonly IOwnerAlertDelivery _delivery;
+    private readonly Func<int, TimeSpan> _retryDelay;
+    private readonly TimeSpan _shutdownFlushTimeout;
+    private readonly CancellationTokenSource _shutdown = new();
+    private readonly Task _worker;
+    private int _sendInProgress;
+    private int _disposed;
+
+    public DiscordOwnerErrorNotifier(DiscordSocketClient discordClient)
+        : this(new DiscordOwnerAlertDelivery(discordClient))
+    {
+    }
+
+    internal DiscordOwnerErrorNotifier(
+        IOwnerAlertDelivery delivery,
+        Func<int, TimeSpan>? retryDelay = null,
+        TimeSpan? shutdownFlushTimeout = null)
+    {
+        _delivery = delivery ?? throw new ArgumentNullException(nameof(delivery));
+        _retryDelay = retryDelay ?? (attempt => TimeSpan.FromSeconds(attempt));
+        _shutdownFlushTimeout = shutdownFlushTimeout ?? TimeSpan.FromSeconds(3);
+        _alerts = Channel.CreateBounded<string>(new BoundedChannelOptions(100)
+        {
+            FullMode = BoundedChannelFullMode.DropOldest,
+            SingleReader = true,
+            SingleWriter = false
+        });
+        _worker = Task.Run(() => ProcessAlertsAsync(_shutdown.Token));
+    }
+
+    public void Enqueue(string alert)
+    {
+        if (Volatile.Read(ref _disposed) == 0)
+        {
+            _alerts.Writer.TryWrite(alert);
+        }
+    }
+
+    public async Task FlushAsync(TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        while ((_alerts.Reader.Count > 0 || Volatile.Read(ref _sendInProgress) != 0) &&
+               DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(25));
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        _alerts.Writer.TryComplete();
+        await FlushAsync(_shutdownFlushTimeout);
+        _shutdown.Cancel();
+
+        try
+        {
+            await _worker;
+        }
+        catch (OperationCanceledException)
         {
         }
 
-        internal DiscordOwnerErrorNotifier(
-            IOwnerAlertDelivery delivery,
-            Func<int, TimeSpan>? retryDelay = null,
-            TimeSpan? shutdownFlushTimeout = null)
+        _shutdown.Dispose();
+    }
+
+    private async Task ProcessAlertsAsync(CancellationToken cancellationToken)
+    {
+        await foreach (var alert in _alerts.Reader.ReadAllAsync(cancellationToken))
         {
-            _delivery = delivery ?? throw new ArgumentNullException(nameof(delivery));
-            _retryDelay = retryDelay ?? (attempt => TimeSpan.FromSeconds(attempt));
-            _shutdownFlushTimeout = shutdownFlushTimeout ?? TimeSpan.FromSeconds(3);
-            _alerts = Channel.CreateBounded<string>(new BoundedChannelOptions(100)
-            {
-                FullMode = BoundedChannelFullMode.DropOldest,
-                SingleReader = true,
-                SingleWriter = false
-            });
-            _worker = Task.Run(() => ProcessAlertsAsync(_shutdown.Token));
-        }
-
-        public void Enqueue(string alert)
-        {
-            if (Volatile.Read(ref _disposed) == 0)
-            {
-                _alerts.Writer.TryWrite(alert);
-            }
-        }
-
-        public async Task FlushAsync(TimeSpan timeout)
-        {
-            var deadline = DateTimeOffset.UtcNow.Add(timeout);
-            while ((_alerts.Reader.Count > 0 || Volatile.Read(ref _sendInProgress) != 0) &&
-                   DateTimeOffset.UtcNow < deadline)
-            {
-                await Task.Delay(TimeSpan.FromMilliseconds(25));
-            }
-        }
-
-        public async ValueTask DisposeAsync()
-        {
-            if (Interlocked.Exchange(ref _disposed, 1) != 0)
-            {
-                return;
-            }
-
-            _alerts.Writer.TryComplete();
-            await FlushAsync(_shutdownFlushTimeout);
-            _shutdown.Cancel();
-
+            Interlocked.Exchange(ref _sendInProgress, 1);
             try
             {
-                await _worker;
+                await DeliverWithRetryAsync(alert, cancellationToken);
             }
-            catch (OperationCanceledException)
+            finally
             {
-            }
-
-            _shutdown.Dispose();
-        }
-
-        private async Task ProcessAlertsAsync(CancellationToken cancellationToken)
-        {
-            await foreach (var alert in _alerts.Reader.ReadAllAsync(cancellationToken))
-            {
-                Interlocked.Exchange(ref _sendInProgress, 1);
-                try
-                {
-                    await DeliverWithRetryAsync(alert, cancellationToken);
-                }
-                finally
-                {
-                    Interlocked.Exchange(ref _sendInProgress, 0);
-                }
-            }
-        }
-
-        private async Task DeliverWithRetryAsync(string alert, CancellationToken cancellationToken)
-        {
-            for (var attempt = 1; attempt <= DefaultMaximumAttempts; attempt++)
-            {
-                try
-                {
-                    // Discord.Net does not expose cancellation on every DM operation.
-                    // WaitAsync still guarantees the notifier worker and application
-                    // shutdown are not held hostage by a stalled network task.
-                    await _delivery.DeliverAsync(alert, cancellationToken).WaitAsync(cancellationToken);
-                    return;
-                }
-                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-                {
-                    throw;
-                }
-                catch (Exception exception)
-                {
-                    if (attempt == DefaultMaximumAttempts)
-                    {
-                        // Never use Serilog here: that would recursively enqueue another owner alert.
-                        Console.Error.WriteLine(
-                            $"Could not DM BeanBot error to its owner after {attempt} attempts: {exception.Message}");
-                        return;
-                    }
-
-                    await Task.Delay(_retryDelay(attempt), cancellationToken);
-                }
+                Interlocked.Exchange(ref _sendInProgress, 0);
             }
         }
     }
 
-    internal sealed class DiscordOwnerAlertDelivery : IOwnerAlertDelivery
+    private async Task DeliverWithRetryAsync(string alert, CancellationToken cancellationToken)
     {
-        private readonly DiscordSocketClient _discordClient;
-
-        public DiscordOwnerAlertDelivery(DiscordSocketClient discordClient)
+        for (var attempt = 1; attempt <= DefaultMaximumAttempts; attempt++)
         {
-            _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
+            try
+            {
+                // Discord.Net does not expose cancellation on every DM operation.
+                // WaitAsync still guarantees the notifier worker and application
+                // shutdown are not held hostage by a stalled network task.
+                await _delivery.DeliverAsync(alert, cancellationToken).WaitAsync(cancellationToken);
+                return;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                if (attempt == DefaultMaximumAttempts)
+                {
+                    // Never use Serilog here: that would recursively enqueue another owner alert.
+                    Console.Error.WriteLine(
+                        $"Could not DM BeanBot error to its owner after {attempt} attempts: {exception.Message}");
+                    return;
+                }
+
+                await Task.Delay(_retryDelay(attempt), cancellationToken);
+            }
+        }
+    }
+}
+
+internal sealed class DiscordOwnerAlertDelivery : IOwnerAlertDelivery
+{
+    private readonly DiscordSocketClient _discordClient;
+
+    public DiscordOwnerAlertDelivery(DiscordSocketClient discordClient)
+    {
+        _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
+    }
+
+    public async Task DeliverAsync(string alert, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (_discordClient.LoginState != LoginState.LoggedIn)
+        {
+            throw new InvalidOperationException("Discord is not logged in, so the owner alert cannot be delivered yet.");
         }
 
-        public async Task DeliverAsync(string alert, CancellationToken cancellationToken)
+        var owner = _discordClient.GetUser(BotOwner.DiscordUserId) ??
+            await ((IDiscordClient)_discordClient).GetUserAsync(BotOwner.DiscordUserId, CacheMode.AllowDownload);
+        if (owner == null)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (_discordClient.LoginState != LoginState.LoggedIn)
-            {
-                throw new InvalidOperationException("Discord is not logged in, so the owner alert cannot be delivered yet.");
-            }
-
-            var owner = _discordClient.GetUser(BotOwner.DiscordUserId) ??
-                await ((IDiscordClient)_discordClient).GetUserAsync(BotOwner.DiscordUserId, CacheMode.AllowDownload);
-            if (owner == null)
-            {
-                throw new InvalidOperationException($"Discord user {BotOwner.DiscordUserId} could not be found.");
-            }
-
-            cancellationToken.ThrowIfCancellationRequested();
-            var directMessageChannel = await owner.CreateDMChannelAsync();
-            cancellationToken.ThrowIfCancellationRequested();
-            await directMessageChannel.SendMessageAsync(alert);
+            throw new InvalidOperationException($"Discord user {BotOwner.DiscordUserId} could not be found.");
         }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var directMessageChannel = await owner.CreateDMChannelAsync();
+        cancellationToken.ThrowIfCancellationRequested();
+        await directMessageChannel.SendMessageAsync(alert);
     }
 }

--- a/BeanBot/Util/FortuneAnswerStore.cs
+++ b/BeanBot/Util/FortuneAnswerStore.cs
@@ -1,54 +1,53 @@
-namespace BeanBot.Util
+namespace BeanBot.Util;
+
+public readonly record struct FortuneAnswerReservation(ulong RecipientId, string Answer, long Version);
+
+public sealed class FortuneAnswerStore
 {
-    public readonly record struct FortuneAnswerReservation(ulong RecipientId, string Answer, long Version);
+    private readonly object _sync = new();
+    private string? _answer;
+    private ulong _recipientId;
+    private long _version;
 
-    public sealed class FortuneAnswerStore
+    public void Queue(ulong recipientId, bool positive)
     {
-        private readonly object _sync = new object();
-        private string? _answer;
-        private ulong _recipientId;
-        private long _version;
-
-        public void Queue(ulong recipientId, bool positive)
+        lock (_sync)
         {
-            lock (_sync)
-            {
-                _recipientId = recipientId;
-                _answer = positive ? "positive" : "negative";
-                _version++;
-            }
+            _recipientId = recipientId;
+            _answer = positive ? "positive" : "negative";
+            _version++;
         }
+    }
 
-        public bool TryReserve(ulong recipientId, out FortuneAnswerReservation reservation)
+    public bool TryReserve(ulong recipientId, out FortuneAnswerReservation reservation)
+    {
+        lock (_sync)
         {
-            lock (_sync)
+            if (_answer == null || recipientId != _recipientId)
             {
-                if (_answer == null || recipientId != _recipientId)
-                {
-                    reservation = default;
-                    return false;
-                }
-
-                reservation = new FortuneAnswerReservation(_recipientId, _answer, _version);
-                return true;
+                reservation = default;
+                return false;
             }
+
+            reservation = new FortuneAnswerReservation(_recipientId, _answer, _version);
+            return true;
         }
+    }
 
-        public bool Consume(FortuneAnswerReservation reservation)
+    public bool Consume(FortuneAnswerReservation reservation)
+    {
+        lock (_sync)
         {
-            lock (_sync)
+            if (_answer != reservation.Answer ||
+                _recipientId != reservation.RecipientId ||
+                _version != reservation.Version)
             {
-                if (_answer != reservation.Answer ||
-                    _recipientId != reservation.RecipientId ||
-                    _version != reservation.Version)
-                {
-                    return false;
-                }
-
-                _answer = null;
-                _recipientId = 0;
-                return true;
+                return false;
             }
+
+            _answer = null;
+            _recipientId = 0;
+            return true;
         }
     }
 }

--- a/BeanBot/Util/FortuneResponseOverrides.cs
+++ b/BeanBot/Util/FortuneResponseOverrides.cs
@@ -1,648 +1,644 @@
-
-using System;
-using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
 
-namespace BeanBot.Util
+namespace BeanBot.Util;
+
+public static partial class FortuneResponseOverrides
 {
-    public static partial class FortuneResponseOverrides
+    public const string ShowerResponse = "Yes. Go take a shower.";
+
+    private const int MaximumPhraseLength = 24;
+
+    private static readonly HashSet<string> AdviceCues = new(StringComparer.OrdinalIgnoreCase)
     {
-        public const string ShowerResponse = "Yes. Go take a shower.";
+        "allowed",
+        "avoid",
+        "avoiding",
+        "bad",
+        "better",
+        "can",
+        "can't",
+        "could",
+        "couldn't",
+        "delay",
+        "delaying",
+        "fine",
+        "good",
+        "may",
+        "might",
+        "mistake",
+        "must",
+        "mustn't",
+        "necessary",
+        "need",
+        "needn't",
+        "okay",
+        "ok",
+        "ought",
+        "oughtn't",
+        "postpone",
+        "postponing",
+        "recommend",
+        "recommended",
+        "refrain",
+        "refraining",
+        "required",
+        "sensible",
+        "shall",
+        "should",
+        "shouldn't",
+        "skip",
+        "skipping",
+        "smart",
+        "supposed",
+        "time",
+        "wise",
+        "without",
+        "worse",
+        "wrong"
+    };
 
-        private const int MaximumPhraseLength = 24;
+    private static readonly HashSet<string> EvaluationCues = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "bad",
+        "better",
+        "fine",
+        "good",
+        "mistake",
+        "necessary",
+        "okay",
+        "ok",
+        "recommended",
+        "sensible",
+        "smart",
+        "wise",
+        "worse",
+        "wrong"
+    };
 
-        private static readonly HashSet<string> AdviceCues = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    private static readonly HashSet<string> DirectAdviceModals = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "can",
+        "can't",
+        "could",
+        "couldn't",
+        "may",
+        "might",
+        "must",
+        "mustn't",
+        "needn't",
+        "ought",
+        "oughtn't",
+        "shall",
+        "should",
+        "shouldn't"
+    };
+
+    private static readonly HashSet<string> BathingActionIntroducers = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "get",
+        "getting",
+        "got",
+        "had",
+        "have",
+        "having",
+        "take",
+        "taking",
+        "took"
+    };
+
+    private static readonly HashSet<string> BathingCoordinationWords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "after",
+        "and",
+        "before",
+        "then"
+    };
+
+    private static readonly HashSet<string> BathingActions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "bath",
+        "bathe",
+        "bathed",
+        "bathes",
+        "bathing",
+        "baths",
+        "shower",
+        "showered",
+        "showering",
+        "showers",
+        "unshowered"
+    };
+
+    private static readonly HashSet<string> AllowedBeforeAction = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "a",
+        "actually",
+        "again",
+        "allowed",
+        "an",
+        "and",
+        "another",
+        "anything",
+        "avoid",
+        "avoiding",
+        "bad",
+        "be",
+        "being",
+        "better",
+        "can",
+        "can't",
+        "cold",
+        "could",
+        "couldn't",
+        "definitely",
+        "delay",
+        "delaying",
+        "didn't",
+        "do",
+        "doing",
+        "don't",
+        "ever",
+        "even",
+        "fine",
+        "finally",
+        "for",
+        "from",
+        "get",
+        "getting",
+        "go",
+        "going",
+        "good",
+        "got",
+        "had",
+        "have",
+        "having",
+        "hot",
+        "in",
+        "into",
+        "idea",
+        "it",
+        "just",
+        "long",
+        "may",
+        "me",
+        "might",
+        "mistake",
+        "must",
+        "mustn't",
+        "my",
+        "myself",
+        "necessary",
+        "need",
+        "needed",
+        "needn't",
+        "never",
+        "normal",
+        "not",
+        "now",
+        "of",
+        "off",
+        "okay",
+        "ok",
+        "opposite",
+        "other",
+        "ought",
+        "oughtn't",
+        "ourself",
+        "ourselves",
+        "please",
+        "postpone",
+        "postponing",
+        "probably",
+        "proper",
+        "quick",
+        "really",
+        "recommend",
+        "recommended",
+        "refrain",
+        "refraining",
+        "remain",
+        "remaining",
+        "required",
+        "safe",
+        "sensible",
+        "seriously",
+        "shall",
+        "short",
+        "should",
+        "shouldn't",
+        "skip",
+        "skipping",
+        "smart",
+        "something",
+        "stay",
+        "staying",
+        "still",
+        "supposed",
+        "take",
+        "taking",
+        "than",
+        "the",
+        "time",
+        "to",
+        "today",
+        "tonight",
+        "took",
+        "us",
+        "warm",
+        "wise",
+        "without",
+        "worse",
+        "wrong"
+    };
+
+    private static readonly HashSet<string> AllowedAfterAction = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "after",
+        "again",
+        "already",
+        "am",
+        "and",
+        "are",
+        "aren't",
+        "at",
+        "because",
+        "before",
+        "but",
+        "can",
+        "can't",
+        "correct",
+        "could",
+        "couldn't",
+        "daily",
+        "during",
+        "eh",
+        "every",
+        "first",
+        "for",
+        "if",
+        "in",
+        "instead",
+        "is",
+        "isn't",
+        "later",
+        "less",
+        "more",
+        "naked",
+        "no",
+        "normally",
+        "now",
+        "on",
+        "or",
+        "please",
+        "properly",
+        "quickly",
+        "regularly",
+        "right",
+        "so",
+        "soon",
+        "should",
+        "shouldn't",
+        "than",
+        "then",
+        "today",
+        "tomorrow",
+        "tonight",
+        "too",
+        "twice",
+        "when",
+        "while",
+        "with",
+        "without",
+        "would",
+        "wouldn't",
+        "yes"
+    };
+
+    [GeneratedRegex(
+        @"[\p{L}\p{N}]+(?:['\u2019][\p{L}\p{N}]+)*",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex WordRegex();
+
+    public static string? GetResponse(string? question)
+    {
+        if (question == null || !QuestionValidator.IsQuestion(question))
         {
-            "allowed",
-            "avoid",
-            "avoiding",
-            "bad",
-            "better",
-            "can",
-            "can't",
-            "could",
-            "couldn't",
-            "delay",
-            "delaying",
-            "fine",
-            "good",
-            "may",
-            "might",
-            "mistake",
-            "must",
-            "mustn't",
-            "necessary",
-            "need",
-            "needn't",
-            "okay",
-            "ok",
-            "ought",
-            "oughtn't",
-            "postpone",
-            "postponing",
-            "recommend",
-            "recommended",
-            "refrain",
-            "refraining",
-            "required",
-            "sensible",
-            "shall",
-            "should",
-            "shouldn't",
-            "skip",
-            "skipping",
-            "smart",
-            "supposed",
-            "time",
-            "wise",
-            "without",
-            "worse",
-            "wrong"
-        };
-
-        private static readonly HashSet<string> EvaluationCues = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            "bad",
-            "better",
-            "fine",
-            "good",
-            "mistake",
-            "necessary",
-            "okay",
-            "ok",
-            "recommended",
-            "sensible",
-            "smart",
-            "wise",
-            "worse",
-            "wrong"
-        };
-
-        private static readonly HashSet<string> DirectAdviceModals = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            "can",
-            "can't",
-            "could",
-            "couldn't",
-            "may",
-            "might",
-            "must",
-            "mustn't",
-            "needn't",
-            "ought",
-            "oughtn't",
-            "shall",
-            "should",
-            "shouldn't"
-        };
-
-        private static readonly HashSet<string> BathingActionIntroducers = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            "get",
-            "getting",
-            "got",
-            "had",
-            "have",
-            "having",
-            "take",
-            "taking",
-            "took"
-        };
-
-        private static readonly HashSet<string> BathingCoordinationWords = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            "after",
-            "and",
-            "before",
-            "then"
-        };
-
-        private static readonly HashSet<string> BathingActions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            "bath",
-            "bathe",
-            "bathed",
-            "bathes",
-            "bathing",
-            "baths",
-            "shower",
-            "showered",
-            "showering",
-            "showers",
-            "unshowered"
-        };
-
-        private static readonly HashSet<string> AllowedBeforeAction = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            "a",
-            "actually",
-            "again",
-            "allowed",
-            "an",
-            "and",
-            "another",
-            "anything",
-            "avoid",
-            "avoiding",
-            "bad",
-            "be",
-            "being",
-            "better",
-            "can",
-            "can't",
-            "cold",
-            "could",
-            "couldn't",
-            "definitely",
-            "delay",
-            "delaying",
-            "didn't",
-            "do",
-            "doing",
-            "don't",
-            "ever",
-            "even",
-            "fine",
-            "finally",
-            "for",
-            "from",
-            "get",
-            "getting",
-            "go",
-            "going",
-            "good",
-            "got",
-            "had",
-            "have",
-            "having",
-            "hot",
-            "in",
-            "into",
-            "idea",
-            "it",
-            "just",
-            "long",
-            "may",
-            "me",
-            "might",
-            "mistake",
-            "must",
-            "mustn't",
-            "my",
-            "myself",
-            "necessary",
-            "need",
-            "needed",
-            "needn't",
-            "never",
-            "normal",
-            "not",
-            "now",
-            "of",
-            "off",
-            "okay",
-            "ok",
-            "opposite",
-            "other",
-            "ought",
-            "oughtn't",
-            "ourself",
-            "ourselves",
-            "please",
-            "postpone",
-            "postponing",
-            "probably",
-            "proper",
-            "quick",
-            "really",
-            "recommend",
-            "recommended",
-            "refrain",
-            "refraining",
-            "remain",
-            "remaining",
-            "required",
-            "safe",
-            "sensible",
-            "seriously",
-            "shall",
-            "short",
-            "should",
-            "shouldn't",
-            "skip",
-            "skipping",
-            "smart",
-            "something",
-            "stay",
-            "staying",
-            "still",
-            "supposed",
-            "take",
-            "taking",
-            "than",
-            "the",
-            "time",
-            "to",
-            "today",
-            "tonight",
-            "took",
-            "us",
-            "warm",
-            "wise",
-            "without",
-            "worse",
-            "wrong"
-        };
-
-        private static readonly HashSet<string> AllowedAfterAction = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            "after",
-            "again",
-            "already",
-            "am",
-            "and",
-            "are",
-            "aren't",
-            "at",
-            "because",
-            "before",
-            "but",
-            "can",
-            "can't",
-            "correct",
-            "could",
-            "couldn't",
-            "daily",
-            "during",
-            "eh",
-            "every",
-            "first",
-            "for",
-            "if",
-            "in",
-            "instead",
-            "is",
-            "isn't",
-            "later",
-            "less",
-            "more",
-            "naked",
-            "no",
-            "normally",
-            "now",
-            "on",
-            "or",
-            "please",
-            "properly",
-            "quickly",
-            "regularly",
-            "right",
-            "so",
-            "soon",
-            "should",
-            "shouldn't",
-            "than",
-            "then",
-            "today",
-            "tomorrow",
-            "tonight",
-            "too",
-            "twice",
-            "when",
-            "while",
-            "with",
-            "without",
-            "would",
-            "wouldn't",
-            "yes"
-        };
-
-        [GeneratedRegex(
-            @"[\p{L}\p{N}]+(?:['\u2019][\p{L}\p{N}]+)*",
-            RegexOptions.CultureInvariant)]
-        private static partial Regex WordRegex();
-
-        public static string? GetResponse(string? question)
-        {
-            if (question == null || !QuestionValidator.IsQuestion(question))
-            {
-                return null;
-            }
-
-            var normalizedQuestion = question.Normalize(NormalizationForm.FormKC)
-                .Replace('\u2019', '\'')
-                .ToLowerInvariant();
-            var words = GetWords(normalizedQuestion);
-
-            return IsPersonalShowerAdvice(words) || IsImpersonalShowerAdvice(words)
-                ? ShowerResponse
-                : null;
+            return null;
         }
 
-        private static bool IsPersonalShowerAdvice(List<string> words)
+        var normalizedQuestion = question.Normalize(NormalizationForm.FormKC)
+            .Replace('\u2019', '\'')
+            .ToLowerInvariant();
+        var words = GetWords(normalizedQuestion);
+
+        return IsPersonalShowerAdvice(words) || IsImpersonalShowerAdvice(words)
+            ? ShowerResponse
+            : null;
+    }
+
+    private static bool IsPersonalShowerAdvice(List<string> words)
+    {
+        for (var subjectIndex = 0; subjectIndex < words.Count; subjectIndex++)
         {
-            for (var subjectIndex = 0; subjectIndex < words.Count; subjectIndex++)
+            if (words[subjectIndex] != "i" && words[subjectIndex] != "we")
             {
-                if (words[subjectIndex] != "i" && words[subjectIndex] != "we")
+                continue;
+            }
+
+            var endIndex = Math.Min(words.Count - 1, subjectIndex + MaximumPhraseLength);
+            for (var actionIndex = subjectIndex + 1; actionIndex <= endIndex; actionIndex++)
+            {
+                if (!BathingActions.Contains(words[actionIndex]) ||
+                    !IsSelfBathingUse(words, actionIndex) ||
+                    !HasPersonalAdviceFrame(words, subjectIndex, actionIndex))
                 {
                     continue;
                 }
 
-                var endIndex = Math.Min(words.Count - 1, subjectIndex + MaximumPhraseLength);
-                for (var actionIndex = subjectIndex + 1; actionIndex <= endIndex; actionIndex++)
-                {
-                    if (!BathingActions.Contains(words[actionIndex]) ||
-                        !IsSelfBathingUse(words, actionIndex) ||
-                        !HasPersonalAdviceFrame(words, subjectIndex, actionIndex))
-                    {
-                        continue;
-                    }
-
-                    if (HasAllowedPathToAction(words, subjectIndex + 1, actionIndex) ||
-                        IsReflexiveBathingConstruction(words, actionIndex) ||
-                        IsCoordinatedBathingConstruction(words, subjectIndex + 1, actionIndex))
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
-        }
-
-        private static bool IsImpersonalShowerAdvice(List<string> words)
-        {
-            for (var cueIndex = 0; cueIndex < words.Count; cueIndex++)
-            {
-                if (!EvaluationCues.Contains(words[cueIndex]) && words[cueIndex] != "time")
-                {
-                    continue;
-                }
-
-                if (TryFindBoundBathingAction(words, cueIndex + 1, true, out var cueActionIndex) &&
-                    IsBathingActionConstruction(words, cueIndex + 1, cueActionIndex))
+                if (HasAllowedPathToAction(words, subjectIndex + 1, actionIndex) ||
+                    IsReflexiveBathingConstruction(words, actionIndex) ||
+                    IsCoordinatedBathingConstruction(words, subjectIndex + 1, actionIndex))
                 {
                     return true;
                 }
             }
-
-            if (words.Count < 2 ||
-                (words[0] != "is" && words[0] != "are" && words[0] != "was" &&
-                 words[0] != "were" && words[0] != "would" && words[0] != "could"))
-            {
-                return false;
-            }
-
-            return TryFindBoundBathingAction(words, 1, false, out var actionIndex) &&
-                IsBathingActionConstruction(words, 1, actionIndex) &&
-                IsEvaluatedBathingUse(words, actionIndex);
         }
 
-        private static bool HasPersonalAdviceFrame(
-            List<string> words,
-            int subjectIndex,
-            int actionIndex)
+        return false;
+    }
+
+    private static bool IsImpersonalShowerAdvice(List<string> words)
+    {
+        for (var cueIndex = 0; cueIndex < words.Count; cueIndex++)
         {
-            if (subjectIndex > 0 && DirectAdviceModals.Contains(words[subjectIndex - 1]))
+            if (!EvaluationCues.Contains(words[cueIndex]) && words[cueIndex] != "time")
+            {
+                continue;
+            }
+
+            if (TryFindBoundBathingAction(words, cueIndex + 1, true, out var cueActionIndex) &&
+                IsBathingActionConstruction(words, cueIndex + 1, cueActionIndex))
             {
                 return true;
             }
+        }
 
-            for (var index = subjectIndex + 1; index < actionIndex; index++)
-            {
-                if (AdviceCues.Contains(words[index]))
-                {
-                    return true;
-                }
-
-                if (index < actionIndex - 1 &&
-                    ((words[index] == "have" && words[index + 1] == "to") ||
-                     (words[index] == "got" && words[index + 1] == "to")))
-                {
-                    return true;
-                }
-            }
-
-            var precedingStartIndex = Math.Max(0, subjectIndex - 6);
-            for (var index = precedingStartIndex; index < subjectIndex; index++)
-            {
-                if (words[index] == "recommend" || words[index] == "recommended")
-                {
-                    return true;
-                }
-            }
-
-            if (subjectIndex > 0 && words[subjectIndex - 1] == "if")
-            {
-                for (var index = precedingStartIndex; index < subjectIndex - 1; index++)
-                {
-                    if (EvaluationCues.Contains(words[index]))
-                    {
-                        return true;
-                    }
-                }
-            }
-
+        if (words.Count < 2 ||
+            (words[0] != "is" && words[0] != "are" && words[0] != "was" &&
+             words[0] != "were" && words[0] != "would" && words[0] != "could"))
+        {
             return false;
         }
 
-        private static bool HasAllowedPathToAction(
-            List<string> words,
-            int startIndex,
-            int actionIndex)
-        {
-            for (var index = startIndex; index < actionIndex; index++)
-            {
-                if (!AllowedBeforeAction.Contains(words[index]))
-                {
-                    return false;
-                }
-            }
+        return TryFindBoundBathingAction(words, 1, false, out var actionIndex) &&
+            IsBathingActionConstruction(words, 1, actionIndex) &&
+            IsEvaluatedBathingUse(words, actionIndex);
+    }
 
+    private static bool HasPersonalAdviceFrame(
+        List<string> words,
+        int subjectIndex,
+        int actionIndex)
+    {
+        if (subjectIndex > 0 && DirectAdviceModals.Contains(words[subjectIndex - 1]))
+        {
             return true;
         }
 
-        private static bool IsReflexiveBathingConstruction(List<string> words, int actionIndex)
+        for (var index = subjectIndex + 1; index < actionIndex; index++)
         {
-            if (actionIndex < words.Count - 1 && IsReflexive(words[actionIndex + 1]))
+            if (AdviceCues.Contains(words[index]))
             {
                 return true;
             }
 
-            var searchStartIndex = Math.Max(0, actionIndex - 4);
-            for (var index = searchStartIndex; index < actionIndex; index++)
-            {
-                if ((words[index] == "give" || words[index] == "giving") &&
-                    index < words.Count - 1 &&
-                    IsReflexive(words[index + 1]))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private static bool IsCoordinatedBathingConstruction(
-            List<string> words,
-            int startIndex,
-            int actionIndex)
-        {
-            if (!IsExplicitBathingConstruction(words, startIndex, actionIndex))
-            {
-                return false;
-            }
-
-            for (var index = startIndex; index < actionIndex; index++)
-            {
-                if (BathingCoordinationWords.Contains(words[index]))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private static bool IsExplicitBathingConstruction(
-            List<string> words,
-            int startIndex,
-            int actionIndex)
-        {
-            var searchStartIndex = Math.Max(startIndex, actionIndex - 5);
-            for (var index = searchStartIndex; index < actionIndex; index++)
-            {
-                if (BathingActionIntroducers.Contains(words[index]))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private static bool IsBathingActionConstruction(
-            List<string> words,
-            int startIndex,
-            int actionIndex)
-        {
-            var action = words[actionIndex];
-            if (action == "showering" || action == "showered" || action == "unshowered" ||
-                action == "bathing" || action == "bathed")
+            if (index < actionIndex - 1 &&
+                ((words[index] == "have" && words[index + 1] == "to") ||
+                 (words[index] == "got" && words[index + 1] == "to")))
             {
                 return true;
             }
+        }
 
-            if (IsExplicitBathingConstruction(words, startIndex, actionIndex))
+        var precedingStartIndex = Math.Max(0, subjectIndex - 6);
+        for (var index = precedingStartIndex; index < subjectIndex; index++)
+        {
+            if (words[index] == "recommend" || words[index] == "recommended")
             {
                 return true;
             }
-
-            var searchStartIndex = Math.Max(startIndex, actionIndex - 5);
-            for (var index = searchStartIndex; index < actionIndex; index++)
-            {
-                if (words[index] == "to" || words[index] == "avoid" || words[index] == "avoiding" ||
-                    words[index] == "skip" || words[index] == "skipping" || words[index] == "without" ||
-                    words[index] == "stay" || words[index] == "staying" || words[index] == "remain" ||
-                    words[index] == "remaining")
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
 
-        private static bool TryFindBoundBathingAction(
-            List<string> words,
-            int startIndex,
-            bool validateFollowingWord,
-            out int actionIndex)
+        if (subjectIndex > 0 && words[subjectIndex - 1] == "if")
         {
-            var endIndex = Math.Min(words.Count - 1, startIndex + MaximumPhraseLength);
-            for (var index = startIndex; index <= endIndex; index++)
-            {
-                if (BathingActions.Contains(words[index]))
-                {
-                    if (!validateFollowingWord || IsSelfBathingUse(words, index))
-                    {
-                        actionIndex = index;
-                        return true;
-                    }
-
-                    actionIndex = -1;
-                    return false;
-                }
-
-                if (!AllowedBeforeAction.Contains(words[index]))
-                {
-                    actionIndex = -1;
-                    return false;
-                }
-            }
-
-            actionIndex = -1;
-            return false;
-        }
-
-        private static bool IsSelfBathingUse(List<string> words, int actionIndex)
-        {
-            if (actionIndex == words.Count - 1 || IsReflexive(words[actionIndex + 1]))
-            {
-                return true;
-            }
-
-            return AllowedAfterAction.Contains(words[actionIndex + 1]);
-        }
-
-        private static bool HasEvaluationCueAfter(List<string> words, int actionIndex)
-        {
-            var endIndex = Math.Min(words.Count - 1, actionIndex + 8);
-            for (var index = actionIndex + 1; index <= endIndex; index++)
+            for (var index = precedingStartIndex; index < subjectIndex - 1; index++)
             {
                 if (EvaluationCues.Contains(words[index]))
                 {
                     return true;
                 }
             }
-
-            return false;
         }
 
-        private static bool IsEvaluatedBathingUse(List<string> words, int actionIndex)
+        return false;
+    }
+
+    private static bool HasAllowedPathToAction(
+        List<string> words,
+        int startIndex,
+        int actionIndex)
+    {
+        for (var index = startIndex; index < actionIndex; index++)
         {
-            if (actionIndex >= words.Count - 1 || !HasEvaluationCueAfter(words, actionIndex))
+            if (!AllowedBeforeAction.Contains(words[index]))
             {
                 return false;
             }
-
-            var followingWord = words[actionIndex + 1];
-            return EvaluationCues.Contains(followingWord) ||
-                AllowedAfterAction.Contains(followingWord) ||
-                followingWord == "a" ||
-                followingWord == "an" ||
-                followingWord == "be" ||
-                followingWord == "being" ||
-                followingWord == "the";
         }
 
-        private static bool IsReflexive(string word)
+        return true;
+    }
+
+    private static bool IsReflexiveBathingConstruction(List<string> words, int actionIndex)
+    {
+        if (actionIndex < words.Count - 1 && IsReflexive(words[actionIndex + 1]))
         {
-            return word == "myself" || word == "ourself" || word == "ourselves";
+            return true;
         }
 
-        private static List<string> GetWords(string text)
+        var searchStartIndex = Math.Max(0, actionIndex - 4);
+        for (var index = searchStartIndex; index < actionIndex; index++)
         {
-            var matches = WordRegex().Matches(text);
-            var words = new List<string>(matches.Count);
-
-            foreach (Match match in matches)
+            if ((words[index] == "give" || words[index] == "giving") &&
+                index < words.Count - 1 &&
+                IsReflexive(words[index + 1]))
             {
-                words.Add(match.Value);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsCoordinatedBathingConstruction(
+        List<string> words,
+        int startIndex,
+        int actionIndex)
+    {
+        if (!IsExplicitBathingConstruction(words, startIndex, actionIndex))
+        {
+            return false;
+        }
+
+        for (var index = startIndex; index < actionIndex; index++)
+        {
+            if (BathingCoordinationWords.Contains(words[index]))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsExplicitBathingConstruction(
+        List<string> words,
+        int startIndex,
+        int actionIndex)
+    {
+        var searchStartIndex = Math.Max(startIndex, actionIndex - 5);
+        for (var index = searchStartIndex; index < actionIndex; index++)
+        {
+            if (BathingActionIntroducers.Contains(words[index]))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsBathingActionConstruction(
+        List<string> words,
+        int startIndex,
+        int actionIndex)
+    {
+        var action = words[actionIndex];
+        if (action == "showering" || action == "showered" || action == "unshowered" ||
+            action == "bathing" || action == "bathed")
+        {
+            return true;
+        }
+
+        if (IsExplicitBathingConstruction(words, startIndex, actionIndex))
+        {
+            return true;
+        }
+
+        var searchStartIndex = Math.Max(startIndex, actionIndex - 5);
+        for (var index = searchStartIndex; index < actionIndex; index++)
+        {
+            if (words[index] == "to" || words[index] == "avoid" || words[index] == "avoiding" ||
+                words[index] == "skip" || words[index] == "skipping" || words[index] == "without" ||
+                words[index] == "stay" || words[index] == "staying" || words[index] == "remain" ||
+                words[index] == "remaining")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryFindBoundBathingAction(
+        List<string> words,
+        int startIndex,
+        bool validateFollowingWord,
+        out int actionIndex)
+    {
+        var endIndex = Math.Min(words.Count - 1, startIndex + MaximumPhraseLength);
+        for (var index = startIndex; index <= endIndex; index++)
+        {
+            if (BathingActions.Contains(words[index]))
+            {
+                if (!validateFollowingWord || IsSelfBathingUse(words, index))
+                {
+                    actionIndex = index;
+                    return true;
+                }
+
+                actionIndex = -1;
+                return false;
             }
 
-            return words;
+            if (!AllowedBeforeAction.Contains(words[index]))
+            {
+                actionIndex = -1;
+                return false;
+            }
         }
+
+        actionIndex = -1;
+        return false;
+    }
+
+    private static bool IsSelfBathingUse(List<string> words, int actionIndex)
+    {
+        if (actionIndex == words.Count - 1 || IsReflexive(words[actionIndex + 1]))
+        {
+            return true;
+        }
+
+        return AllowedAfterAction.Contains(words[actionIndex + 1]);
+    }
+
+    private static bool HasEvaluationCueAfter(List<string> words, int actionIndex)
+    {
+        var endIndex = Math.Min(words.Count - 1, actionIndex + 8);
+        for (var index = actionIndex + 1; index <= endIndex; index++)
+        {
+            if (EvaluationCues.Contains(words[index]))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsEvaluatedBathingUse(List<string> words, int actionIndex)
+    {
+        if (actionIndex >= words.Count - 1 || !HasEvaluationCueAfter(words, actionIndex))
+        {
+            return false;
+        }
+
+        var followingWord = words[actionIndex + 1];
+        return EvaluationCues.Contains(followingWord) ||
+            AllowedAfterAction.Contains(followingWord) ||
+            followingWord == "a" ||
+            followingWord == "an" ||
+            followingWord == "be" ||
+            followingWord == "being" ||
+            followingWord == "the";
+    }
+
+    private static bool IsReflexive(string word)
+    {
+        return word == "myself" || word == "ourself" || word == "ourselves";
+    }
+
+    private static List<string> GetWords(string text)
+    {
+        var matches = WordRegex().Matches(text);
+        var words = new List<string>(matches.Count);
+
+        foreach (Match match in matches)
+        {
+            words.Add(match.Value);
+        }
+
+        return words;
     }
 }

--- a/BeanBot/Util/LogHandler.cs
+++ b/BeanBot/Util/LogHandler.cs
@@ -1,139 +1,133 @@
-﻿using Discord;
+﻿using System.Globalization;
+using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
-
 using Microsoft.Extensions.Logging;
-
 using Serilog;
 using Serilog.Events;
 
-using System.Globalization;
-using System.IO;
-using System.Threading.Tasks;
+namespace BeanBot.Util;
 
-namespace BeanBot.Util
+public sealed class LogHandler
 {
-    public sealed class LogHandler
+    private readonly ILogger<LogHandler> _logger;
+
+    public LogHandler(ILogger<LogHandler> logger)
     {
-        private readonly ILogger<LogHandler> _logger;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
 
-        public LogHandler(ILogger<LogHandler> logger)
+    internal static Serilog.ILogger CreateBootstrapLogger()
+        => new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
+            .CreateBootstrapLogger();
+
+    internal static void ConfigureLogger(
+        LoggerConfiguration loggerConfiguration,
+        IOwnerErrorNotifier ownerErrorNotifier)
+    {
+        ArgumentNullException.ThrowIfNull(loggerConfiguration);
+        ArgumentNullException.ThrowIfNull(ownerErrorNotifier);
+
+        loggerConfiguration
+            .MinimumLevel.Verbose()
+            .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
+            .MinimumLevel.Override("Microsoft.Hosting.Lifetime", LogEventLevel.Information)
+            .MinimumLevel.Override("System", LogEventLevel.Warning)
+            .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
+            .WriteTo.Async(a => a.File(
+                Path.Combine(DirectorySetup.botBaseDirectory, "Logs", "BeanBotLogs.txt"),
+                formatProvider: CultureInfo.InvariantCulture,
+                rollingInterval: RollingInterval.Day))
+            .WriteTo.Sink(new DiscordOwnerErrorSink(ownerErrorNotifier));
+    }
+
+    public Task LogMessages(LogMessage messages)
+    {
+        var formattedMessage = string.IsNullOrWhiteSpace(messages.Source)
+            ? messages.Message ?? messages.ToString()
+            : $"Discord:\t{messages.Source}\t{messages.Message}";
+
+        var severity = messages.Severity;
+        var logLevel = severity switch
         {
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        }
-
-        internal static Serilog.ILogger CreateBootstrapLogger()
-            => new LoggerConfiguration()
-                .MinimumLevel.Verbose()
-                .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
-                .CreateBootstrapLogger();
-
-        internal static void ConfigureLogger(
-            LoggerConfiguration loggerConfiguration,
-            IOwnerErrorNotifier ownerErrorNotifier)
+            LogSeverity.Critical => LogLevel.Critical,
+            LogSeverity.Error => LogLevel.Error,
+            LogSeverity.Warning => LogLevel.Warning,
+            LogSeverity.Info => LogLevel.Information,
+            LogSeverity.Verbose => LogLevel.Trace,
+            LogSeverity.Debug => LogLevel.Debug,
+            _ => LogLevel.None
+        };
+        if (logLevel == LogLevel.None)
         {
-            ArgumentNullException.ThrowIfNull(loggerConfiguration);
-            ArgumentNullException.ThrowIfNull(ownerErrorNotifier);
-
-            loggerConfiguration
-                .MinimumLevel.Verbose()
-                .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
-                .MinimumLevel.Override("Microsoft.Hosting.Lifetime", LogEventLevel.Information)
-                .MinimumLevel.Override("System", LogEventLevel.Warning)
-                .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
-                .WriteTo.Async(a => a.File(
-                    Path.Combine(DirectorySetup.botBaseDirectory, "Logs", "BeanBotLogs.txt"),
-                    formatProvider: CultureInfo.InvariantCulture,
-                    rollingInterval: RollingInterval.Day))
-                .WriteTo.Sink(new DiscordOwnerErrorSink(ownerErrorNotifier));
-        }
-
-        public Task LogMessages(LogMessage messages)
-        {
-            var formattedMessage = string.IsNullOrWhiteSpace(messages.Source)
-                ? messages.Message ?? messages.ToString()
-                : $"Discord:\t{messages.Source}\t{messages.Message}";
-
-            var severity = messages.Severity;
-            var logLevel = severity switch
+            if (_logger.IsEnabled(LogLevel.Information))
             {
-                LogSeverity.Critical => LogLevel.Critical,
-                LogSeverity.Error => LogLevel.Error,
-                LogSeverity.Warning => LogLevel.Warning,
-                LogSeverity.Info => LogLevel.Information,
-                LogSeverity.Verbose => LogLevel.Trace,
-                LogSeverity.Debug => LogLevel.Debug,
-                _ => LogLevel.None
-            };
-            if (logLevel == LogLevel.None)
-            {
-                if (_logger.IsEnabled(LogLevel.Information))
-                {
-                    BeanBotLog.DiscordMessageFallback(
-                        _logger,
-                        severity,
-                        formattedMessage,
-                        messages.Exception);
-                }
-            }
-            else
-            {
-                BeanBotLog.DiscordMessage(
+                BeanBotLog.DiscordMessageFallback(
                     _logger,
-                    logLevel,
+                    severity,
                     formattedMessage,
                     messages.Exception);
             }
-
-            return Task.CompletedTask;
         }
-
-        public Task LogNewMember(SocketGuildUser newUser)
+        else
         {
-            BeanBotLog.DiscordUserJoined(
+            BeanBotLog.DiscordMessage(
                 _logger,
-                newUser.Username,
-                newUser.Id,
-                newUser.Guild);
-            return Task.CompletedTask;
+                logLevel,
+                formattedMessage,
+                messages.Exception);
         }
 
-        public Task LogCommands(Optional<CommandInfo> command, ICommandContext context, IResult result)
-        {
-            ArgumentNullException.ThrowIfNull(context);
-            ArgumentNullException.ThrowIfNull(result);
+        return Task.CompletedTask;
+    }
 
-            var commandName = command.IsSpecified ? command.Value.Name : "Unspecified Command";
-            if (result.IsSuccess)
+    public Task LogNewMember(SocketGuildUser newUser)
+    {
+        BeanBotLog.DiscordUserJoined(
+            _logger,
+            newUser.Username,
+            newUser.Id,
+            newUser.Guild);
+        return Task.CompletedTask;
+    }
+
+    public Task LogCommands(Optional<CommandInfo> command, ICommandContext context, IResult result)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(result);
+
+        var commandName = command.IsSpecified ? command.Value.Name : "Unspecified Command";
+        if (result.IsSuccess)
+        {
+            BeanBotLog.DiscordCommandExecuted(_logger, commandName);
+        }
+        else
+        {
+            var isExpectedUserError = result.Error == CommandError.UnknownCommand ||
+                result.Error == CommandError.ParseFailed ||
+                result.Error == CommandError.BadArgCount ||
+                result.Error == CommandError.ObjectNotFound ||
+                result.Error == CommandError.MultipleMatches ||
+                result.Error == CommandError.UnmetPrecondition;
+            if (isExpectedUserError)
             {
-                BeanBotLog.DiscordCommandExecuted(_logger, commandName);
+                BeanBotLog.DiscordCommandRejected(
+                    _logger,
+                    commandName,
+                    result.Error,
+                    result.ErrorReason);
             }
             else
             {
-                var isExpectedUserError = result.Error == CommandError.UnknownCommand ||
-                    result.Error == CommandError.ParseFailed ||
-                    result.Error == CommandError.BadArgCount ||
-                    result.Error == CommandError.ObjectNotFound ||
-                    result.Error == CommandError.MultipleMatches ||
-                    result.Error == CommandError.UnmetPrecondition;
-                if (isExpectedUserError)
-                {
-                    BeanBotLog.DiscordCommandRejected(
-                        _logger,
-                        commandName,
-                        result.Error,
-                        result.ErrorReason);
-                }
-                else
-                {
-                    BeanBotLog.DiscordCommandFailed(
-                        _logger,
-                        commandName,
-                        result.Error,
-                        result.ErrorReason);
-                }
+                BeanBotLog.DiscordCommandFailed(
+                    _logger,
+                    commandName,
+                    result.Error,
+                    result.ErrorReason);
             }
-            return Task.CompletedTask;
         }
+        return Task.CompletedTask;
     }
 }

--- a/BeanBot/Util/QuestionValidator.cs
+++ b/BeanBot/Util/QuestionValidator.cs
@@ -1,321 +1,318 @@
 #nullable enable
 
-using System;
-using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
-namespace BeanBot.Util
+namespace BeanBot.Util;
+
+public static partial class QuestionValidator
 {
-    public static partial class QuestionValidator
+    private static readonly HashSet<string> InterrogativeWords = new(StringComparer.OrdinalIgnoreCase)
     {
-        private static readonly HashSet<string> InterrogativeWords = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        "how",
+        "what",
+        "when",
+        "where",
+        "which",
+        "who",
+        "whom",
+        "whose",
+        "why"
+    };
+
+    private static readonly HashSet<string> AuxiliaryWords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "ain't",
+        "am",
+        "are",
+        "aren't",
+        "can",
+        "can't",
+        "cannot",
+        "could",
+        "couldn't",
+        "did",
+        "didn't",
+        "do",
+        "does",
+        "doesn't",
+        "don't",
+        "had",
+        "hadn't",
+        "has",
+        "hasn't",
+        "have",
+        "haven't",
+        "is",
+        "isn't",
+        "may",
+        "might",
+        "mightn't",
+        "must",
+        "mustn't",
+        "needn't",
+        "ought",
+        "oughtn't",
+        "shall",
+        "shan't",
+        "should",
+        "shouldn't",
+        "was",
+        "wasn't",
+        "were",
+        "weren't",
+        "will",
+        "won't",
+        "would",
+        "wouldn't"
+    };
+
+    private static readonly HashSet<string> SubjectWords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "anybody",
+        "anyone",
+        "everybody",
+        "everyone",
+        "he",
+        "i",
+        "it",
+        "nobody",
+        "nothing",
+        "she",
+        "somebody",
+        "someone",
+        "something",
+        "that",
+        "there",
+        "these",
+        "they",
+        "this",
+        "those",
+        "we",
+        "who",
+        "you"
+    };
+
+    private static readonly HashSet<string> FiniteAuxiliaryWords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "am",
+        "are",
+        "can",
+        "could",
+        "did",
+        "does",
+        "had",
+        "has",
+        "is",
+        "may",
+        "might",
+        "must",
+        "shall",
+        "should",
+        "was",
+        "were",
+        "will",
+        "would"
+    };
+
+    private static readonly HashSet<string> NonFiniteComplementOpeners = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "am",
+        "are",
+        "aren't",
+        "can",
+        "can't",
+        "could",
+        "couldn't",
+        "did",
+        "didn't",
+        "do",
+        "does",
+        "doesn't",
+        "don't",
+        "is",
+        "isn't",
+        "may",
+        "might",
+        "mightn't",
+        "must",
+        "mustn't",
+        "shall",
+        "shan't",
+        "should",
+        "shouldn't",
+        "was",
+        "wasn't",
+        "were",
+        "weren't",
+        "will",
+        "won't",
+        "would",
+        "wouldn't"
+    };
+
+    private static readonly HashSet<string> ConfirmationTags = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "correct",
+        "eh",
+        "no",
+        "right",
+        "yes"
+    };
+
+    private static readonly HashSet<string> InterrogativeContractionSuffixes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "d",
+        "ll",
+        "re",
+        "s",
+        "ve"
+    };
+
+    [GeneratedRegex(
+        @"<(?:(?:@!?|@&|#)\d+|a?:[^:>\s]+:\d+)>",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex DiscordObjectRegex();
+
+    [GeneratedRegex(
+        @"\b(?:https?://|www\.)[^\s,;]+",
+        RegexOptions.CultureInvariant | RegexOptions.IgnoreCase)]
+    private static partial Regex UrlRegex();
+
+    [GeneratedRegex(
+        @"[\p{L}\p{N}]+(?:['\u2019][\p{L}\p{N}]+)*",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex WordRegex();
+
+    private static readonly char[] ClosingCharacters =
+    [
+        '\"', '\'', '\u2019', '\u201D', ')', ']', '}', '>', '*', '_', '~', '`', '|'
+    ];
+
+    private static readonly char[] ClauseSeparators = [',', ';', ':'];
+
+    public static bool IsQuestion(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
         {
-            "how",
-            "what",
-            "when",
-            "where",
-            "which",
-            "who",
-            "whom",
-            "whose",
-            "why"
-        };
+            return false;
+        }
 
-        private static readonly HashSet<string> AuxiliaryWords = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        var normalizedText = text.Trim().TrimEnd(ClosingCharacters);
+        if (!TryGetQuestionBody(normalizedText, out var questionBody))
         {
-            "ain't",
-            "am",
-            "are",
-            "aren't",
-            "can",
-            "can't",
-            "cannot",
-            "could",
-            "couldn't",
-            "did",
-            "didn't",
-            "do",
-            "does",
-            "doesn't",
-            "don't",
-            "had",
-            "hadn't",
-            "has",
-            "hasn't",
-            "have",
-            "haven't",
-            "is",
-            "isn't",
-            "may",
-            "might",
-            "mightn't",
-            "must",
-            "mustn't",
-            "needn't",
-            "ought",
-            "oughtn't",
-            "shall",
-            "shan't",
-            "should",
-            "shouldn't",
-            "was",
-            "wasn't",
-            "were",
-            "weren't",
-            "will",
-            "won't",
-            "would",
-            "wouldn't"
-        };
+            return false;
+        }
 
-        private static readonly HashSet<string> SubjectWords = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        questionBody = DiscordObjectRegex().Replace(questionBody, " item ");
+        questionBody = UrlRegex().Replace(questionBody, " item ");
+
+        if (IsInterrogativeClause(questionBody))
         {
-            "anybody",
-            "anyone",
-            "everybody",
-            "everyone",
-            "he",
-            "i",
-            "it",
-            "nobody",
-            "nothing",
-            "she",
-            "somebody",
-            "someone",
-            "something",
-            "that",
-            "there",
-            "these",
-            "they",
-            "this",
-            "those",
-            "we",
-            "who",
-            "you"
-        };
+            return true;
+        }
 
-        private static readonly HashSet<string> FiniteAuxiliaryWords = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        var lastSeparatorIndex = questionBody.LastIndexOfAny(ClauseSeparators);
+        if (lastSeparatorIndex < 0)
         {
-            "am",
-            "are",
-            "can",
-            "could",
-            "did",
-            "does",
-            "had",
-            "has",
-            "is",
-            "may",
-            "might",
-            "must",
-            "shall",
-            "should",
-            "was",
-            "were",
-            "will",
-            "would"
-        };
+            return false;
+        }
 
-        private static readonly HashSet<string> NonFiniteComplementOpeners = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        var leadingClause = questionBody.Substring(0, lastSeparatorIndex);
+        var finalClause = questionBody.Substring(lastSeparatorIndex + 1);
+
+        return IsInterrogativeClause(finalClause) || IsConfirmationTag(leadingClause, finalClause);
+    }
+
+    private static bool TryGetQuestionBody(string text, out string questionBody)
+    {
+        var punctuationIndex = text.Length - 1;
+        var hasQuestionMark = false;
+
+        while (punctuationIndex >= 0 && (text[punctuationIndex] == '?' || text[punctuationIndex] == '!'))
         {
-            "am",
-            "are",
-            "aren't",
-            "can",
-            "can't",
-            "could",
-            "couldn't",
-            "did",
-            "didn't",
-            "do",
-            "does",
-            "doesn't",
-            "don't",
-            "is",
-            "isn't",
-            "may",
-            "might",
-            "mightn't",
-            "must",
-            "mustn't",
-            "shall",
-            "shan't",
-            "should",
-            "shouldn't",
-            "was",
-            "wasn't",
-            "were",
-            "weren't",
-            "will",
-            "won't",
-            "would",
-            "wouldn't"
-        };
+            hasQuestionMark |= text[punctuationIndex] == '?';
+            punctuationIndex--;
+        }
 
-        private static readonly HashSet<string> ConfirmationTags = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        questionBody = text.Substring(0, punctuationIndex + 1).Trim();
+        return hasQuestionMark && questionBody.Length > 0;
+    }
+
+    private static bool IsInterrogativeClause(string clause)
+    {
+        var words = WordRegex().Matches(clause);
+        if (words.Count == 0)
         {
-            "correct",
-            "eh",
-            "no",
-            "right",
-            "yes"
-        };
+            return false;
+        }
 
-        private static readonly HashSet<string> InterrogativeContractionSuffixes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        var normalizedFirstWord = NormalizeWord(words[0].Value);
+        var firstWord = NormalizeQuestionOpener(normalizedFirstWord);
+        if (InterrogativeWords.Contains(firstWord))
         {
-            "d",
-            "ll",
-            "re",
-            "s",
-            "ve"
-        };
+            if (words.Count == 1)
+            {
+                // A question word by itself (for example, "why?") does not
+                // provide enough of a proposition for the fortune command.
+                return false;
+            }
 
-        [GeneratedRegex(
-            @"<(?:(?:@!?|@&|#)\d+|a?:[^:>\s]+:\d+)>",
-            RegexOptions.CultureInvariant)]
-        private static partial Regex DiscordObjectRegex();
-
-        [GeneratedRegex(
-            @"\b(?:https?://|www\.)[^\s,;]+",
-            RegexOptions.CultureInvariant | RegexOptions.IgnoreCase)]
-        private static partial Regex UrlRegex();
-
-        [GeneratedRegex(
-            @"[\p{L}\p{N}]+(?:['\u2019][\p{L}\p{N}]+)*",
-            RegexOptions.CultureInvariant)]
-        private static partial Regex WordRegex();
-
-        private static readonly char[] ClosingCharacters =
-        {
-            '\"', '\'', '\u2019', '\u201D', ')', ']', '}', '>', '*', '_', '~', '`', '|'
-        };
-
-        private static readonly char[] ClauseSeparators = { ',', ';', ':' };
-
-        public static bool IsQuestion(string? text)
-        {
-            if (string.IsNullOrWhiteSpace(text))
+            var secondWord = NormalizeWord(words[1].Value);
+            var isContractedInterrogative = !firstWord.Equals(normalizedFirstWord, StringComparison.OrdinalIgnoreCase);
+            if (!isContractedInterrogative && SubjectWords.Contains(secondWord))
             {
                 return false;
             }
 
-            var normalizedText = text.Trim().TrimEnd(ClosingCharacters);
-            if (!TryGetQuestionBody(normalizedText, out var questionBody))
-            {
-                return false;
-            }
-
-            questionBody = DiscordObjectRegex().Replace(questionBody, " item ");
-            questionBody = UrlRegex().Replace(questionBody, " item ");
-
-            if (IsInterrogativeClause(questionBody))
-            {
-                return true;
-            }
-
-            var lastSeparatorIndex = questionBody.LastIndexOfAny(ClauseSeparators);
-            if (lastSeparatorIndex < 0)
-            {
-                return false;
-            }
-
-            var leadingClause = questionBody.Substring(0, lastSeparatorIndex);
-            var finalClause = questionBody.Substring(lastSeparatorIndex + 1);
-
-            return IsInterrogativeClause(finalClause) || IsConfirmationTag(leadingClause, finalClause);
+            return !firstWord.Equals("what", StringComparison.OrdinalIgnoreCase) ||
+                (!secondWord.Equals("a", StringComparison.OrdinalIgnoreCase) &&
+                 !secondWord.Equals("an", StringComparison.OrdinalIgnoreCase));
         }
 
-        private static bool TryGetQuestionBody(string text, out string questionBody)
+        if (!AuxiliaryWords.Contains(firstWord) || words.Count < 2)
         {
-            var punctuationIndex = text.Length - 1;
-            var hasQuestionMark = false;
-
-            while (punctuationIndex >= 0 && (text[punctuationIndex] == '?' || text[punctuationIndex] == '!'))
-            {
-                hasQuestionMark |= text[punctuationIndex] == '?';
-                punctuationIndex--;
-            }
-
-            questionBody = text.Substring(0, punctuationIndex + 1).Trim();
-            return hasQuestionMark && questionBody.Length > 0;
+            return false;
         }
 
-        private static bool IsInterrogativeClause(string clause)
+        var secondAuxiliaryWord = NormalizeWord(words[1].Value);
+        if (words.Count == 2)
         {
-            var words = WordRegex().Matches(clause);
-            if (words.Count == 0)
-            {
-                return false;
-            }
-
-            var normalizedFirstWord = NormalizeWord(words[0].Value);
-            var firstWord = NormalizeQuestionOpener(normalizedFirstWord);
-            if (InterrogativeWords.Contains(firstWord))
-            {
-                if (words.Count == 1)
-                {
-                    // A question word by itself (for example, "why?") does not
-                    // provide enough of a proposition for the fortune command.
-                    return false;
-                }
-
-                var secondWord = NormalizeWord(words[1].Value);
-                var isContractedInterrogative = !firstWord.Equals(normalizedFirstWord, StringComparison.OrdinalIgnoreCase);
-                if (!isContractedInterrogative && SubjectWords.Contains(secondWord))
-                {
-                    return false;
-                }
-
-                return !firstWord.Equals("what", StringComparison.OrdinalIgnoreCase) ||
-                    (!secondWord.Equals("a", StringComparison.OrdinalIgnoreCase) &&
-                     !secondWord.Equals("an", StringComparison.OrdinalIgnoreCase));
-            }
-
-            if (!AuxiliaryWords.Contains(firstWord) || words.Count < 2)
-            {
-                return false;
-            }
-
-            var secondAuxiliaryWord = NormalizeWord(words[1].Value);
-            if (words.Count == 2)
-            {
-                return SubjectWords.Contains(secondAuxiliaryWord);
-            }
-
-            var thirdWord = NormalizeWord(words[2].Value);
-            return !FiniteAuxiliaryWords.Contains(secondAuxiliaryWord) &&
-                (!NonFiniteComplementOpeners.Contains(firstWord) || !FiniteAuxiliaryWords.Contains(thirdWord));
+            return SubjectWords.Contains(secondAuxiliaryWord);
         }
 
-        private static bool IsConfirmationTag(string leadingClause, string finalClause)
+        var thirdWord = NormalizeWord(words[2].Value);
+        return !FiniteAuxiliaryWords.Contains(secondAuxiliaryWord) &&
+            (!NonFiniteComplementOpeners.Contains(firstWord) || !FiniteAuxiliaryWords.Contains(thirdWord));
+    }
+
+    private static bool IsConfirmationTag(string leadingClause, string finalClause)
+    {
+        var leadingWords = WordRegex().Matches(leadingClause);
+        var finalWords = WordRegex().Matches(finalClause);
+
+        return leadingWords.Count >= 2 &&
+            finalWords.Count == 1 &&
+            ConfirmationTags.Contains(NormalizeWord(finalWords[0].Value));
+    }
+
+    private static string NormalizeWord(string word)
+    {
+        return word.Replace('\u2019', '\'');
+    }
+
+    private static string NormalizeQuestionOpener(string word)
+    {
+        var normalizedWord = NormalizeWord(word);
+        var contractionIndex = normalizedWord.IndexOf('\'');
+        if (contractionIndex <= 0)
         {
-            var leadingWords = WordRegex().Matches(leadingClause);
-            var finalWords = WordRegex().Matches(finalClause);
-
-            return leadingWords.Count >= 2 &&
-                finalWords.Count == 1 &&
-                ConfirmationTags.Contains(NormalizeWord(finalWords[0].Value));
+            return normalizedWord;
         }
 
-        private static string NormalizeWord(string word)
-        {
-            return word.Replace('\u2019', '\'');
-        }
-
-        private static string NormalizeQuestionOpener(string word)
-        {
-            var normalizedWord = NormalizeWord(word);
-            var contractionIndex = normalizedWord.IndexOf('\'');
-            if (contractionIndex <= 0)
-            {
-                return normalizedWord;
-            }
-
-            var baseWord = normalizedWord.Substring(0, contractionIndex);
-            var suffix = normalizedWord.Substring(contractionIndex + 1);
-            return InterrogativeWords.Contains(baseWord) && InterrogativeContractionSuffixes.Contains(suffix)
-                ? baseWord
-                : normalizedWord;
-        }
+        var baseWord = normalizedWord.Substring(0, contractionIndex);
+        var suffix = normalizedWord.Substring(contractionIndex + 1);
+        return InterrogativeWords.Contains(baseWord) && InterrogativeContractionSuffixes.Contains(suffix)
+            ? baseWord
+            : normalizedWord;
     }
 }

--- a/scripts/test-verification.sh
+++ b/scripts/test-verification.sh
@@ -82,6 +82,7 @@ fast_log="$temporary_directory/fast.log"
 )
 assert_contains "$repository_root|dotnet|restore BeanBot.sln" "$fast_log"
 assert_contains "$repository_root|dotnet|format BeanBot.sln --verify-no-changes --no-restore --severity warn" "$fast_log"
+assert_contains "$repository_root|dotnet|format BeanBot.sln --verify-no-changes --no-restore --diagnostics IDE0005" "$fast_log"
 assert_contains "$repository_root|dotnet|test BeanBot.sln --configuration Release --no-build" "$fast_log"
 assert_not_contains "|dotnet|list " "$fast_log"
 assert_not_contains "|docker|" "$fast_log"
@@ -98,6 +99,7 @@ assert_contains "$repository_root|docker|build --tag beanbot-verification:local 
 assert_count 1 "|python3|scripts/validate-workflow.py" "$full_log"
 assert_count 1 "|dotnet|restore BeanBot.sln" "$full_log"
 assert_count 1 "|dotnet|format BeanBot.sln --verify-no-changes --no-restore --severity warn" "$full_log"
+assert_count 1 "|dotnet|format BeanBot.sln --verify-no-changes --no-restore --diagnostics IDE0005" "$full_log"
 assert_count 1 "|dotnet|build BeanBot.sln --configuration Release --no-restore" "$full_log"
 assert_count 1 "|dotnet|test BeanBot.sln --configuration Release --no-build" "$full_log"
 assert_count 1 "|dotnet|list BeanBot.sln package --vulnerable --include-transitive --format json --output-version 1" "$full_log"
@@ -121,6 +123,17 @@ fi
 assert_contains "|dotnet|format BeanBot.sln --verify-no-changes --no-restore --severity warn" "$format_failure_log"
 assert_not_contains "|dotnet|build " "$format_failure_log"
 assert_not_contains "|dotnet|test " "$format_failure_log"
+
+using_failure_log="$temporary_directory/using-failure.log"
+if PATH="$stub_directory:$PATH" BEANBOT_VERIFY_TEST_LOG="$using_failure_log" \
+  BEANBOT_VERIFY_TEST_FAIL="--diagnostics IDE0005" BEANBOT_VERIFY_SKIP_SELF_TEST=1 \
+  "$verify_script" fast; then
+  echo "Injected redundant-using formatter failure unexpectedly succeeded" >&2
+  exit 1
+fi
+assert_contains "|dotnet|format BeanBot.sln --verify-no-changes --no-restore --diagnostics IDE0005" "$using_failure_log"
+assert_not_contains "|dotnet|build " "$using_failure_log"
+assert_not_contains "|dotnet|test " "$using_failure_log"
 
 failure_log="$temporary_directory/failure.log"
 if PATH="$stub_directory:$PATH" BEANBOT_VERIFY_TEST_LOG="$failure_log" \

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -48,6 +48,10 @@ build_and_test() {
   run_stage "Restore .NET dependencies" dotnet restore BeanBot.sln
   run_stage "Verify .NET formatting and analyzers" \
     dotnet format BeanBot.sln --verify-no-changes --no-restore --severity warn
+  # Roslyn requires XML documentation generation when IDE0005 is a build warning.
+  # Keep this explicit gate so redundant usings fail verification without changing publish output.
+  run_stage "Verify redundant using cleanup" \
+    dotnet format BeanBot.sln --verify-no-changes --no-restore --diagnostics IDE0005
   run_stage "Build Release" dotnet build BeanBot.sln --configuration Release --no-restore
   run_stage "Run Release tests" dotnet test BeanBot.sln --configuration Release --no-build
 }


### PR DESCRIPTION
## Summary

- enforce file-scoped namespaces, target-typed construction, exact-type collection expressions, and safe null checks through `.editorconfig`
- apply the conventions across BeanBot production and test code without changing runtime behavior or public APIs
- add an explicit IDE0005 verification gate and failure-path coverage without enabling XML documentation output

## Verification

- `./scripts/verify.sh fast`
- `./scripts/verify.sh full`
- 347 tests passed
- independent Verifier: PASS
- independent Reviewer: CLEAN

Closes #96
