### PR TITLE
Cache static pun resources

### DIFF
--- a/BeanBot.Tests/EventHandlers/PunHandlerTests.cs
+++ b/BeanBot.Tests/EventHandlers/PunHandlerTests.cs
@@ -1,5 +1,7 @@
+using System.Diagnostics.CodeAnalysis;
 using BeanBot.Configuration;
 using BeanBot.EventHandlers;
+using BeanBot.Services;
 
 using Discord.WebSocket;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -21,11 +23,24 @@ public class PunHandlerTests
             new Uri("https://example.com/hatoete"),
             new Uri("https://example.com/yoshimaru"),
             HealthCheckOptions.Disabled);
-        var handler = new PunHandler(client, options, NullLogger<PunHandler>.Instance);
+        var handler = new PunHandler(
+            client,
+            options,
+            new UnavailablePunProvider(),
+            NullLogger<PunHandler>.Instance);
 
         await handler.DisposeAsync();
         await handler.DisposeAsync();
 
         Assert.Throws<ObjectDisposedException>(() => handler.Start());
+    }
+
+    private sealed class UnavailablePunProvider : IPunProvider
+    {
+        public bool TryGetRandomPun([NotNullWhen(true)] out string? pun)
+        {
+            pun = null;
+            return false;
+        }
     }
 }

--- a/BeanBot.Tests/Hosting/BeanBotServiceRegistrationTests.cs
+++ b/BeanBot.Tests/Hosting/BeanBotServiceRegistrationTests.cs
@@ -31,6 +31,8 @@ public class BeanBotServiceRegistrationTests
         AssertSingleton<IBeanBotApplication>(services);
         AssertSingleton<BeanBotHostedService>(services);
         AssertSingleton<RoleReactService>(services);
+        AssertSingleton<PunProvider>(services);
+        AssertSingleton<IPunProvider>(services);
         AssertSingleton<EditMessageEventServices>(services);
         AssertSingleton<LogHandler>(services);
 

--- a/BeanBot.Tests/Services/PunProviderTests.cs
+++ b/BeanBot.Tests/Services/PunProviderTests.cs
@@ -1,0 +1,120 @@
+using BeanBot.Services;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace BeanBot.Tests.Services;
+
+public sealed class PunProviderTests : IDisposable
+{
+    private readonly string _temporaryDirectory = Path.Combine(
+        Path.GetTempPath(),
+        $"beanbot-pun-provider-{Guid.NewGuid():N}");
+
+    public PunProviderTests()
+    {
+        Directory.CreateDirectory(_temporaryDirectory);
+    }
+
+    [Fact]
+    public void TryGetRandomPun_LoadsUsableRowsAndIgnoresBlankRows()
+    {
+        var path = WriteResource("BadPost\n\"First pun\"\n\"\"\n\"Second pun\"\n");
+        var logger = new RecordingLogger<PunProvider>();
+        var provider = new PunProvider(path, logger);
+
+        var selected = GetPun(provider);
+
+        Assert.Contains(selected, new[] { "First pun", "Second pun" });
+        Assert.Contains(logger.Entries, entry =>
+            entry.Level == LogLevel.Information && entry.Message.Contains("Loaded 2 puns", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void TryGetRandomPun_DoesNotReadResourceAgainAfterLoading()
+    {
+        var path = WriteResource("BadPost\n\"Original pun\"\n");
+        var provider = new PunProvider(path, new RecordingLogger<PunProvider>());
+        File.WriteAllText(path, "BadPost\n\"Replacement pun\"\n");
+
+        Assert.Equal("Original pun", GetPun(provider));
+
+        File.Delete(path);
+        Assert.Equal("Original pun", GetPun(provider));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("BadPost\n")]
+    [InlineData("BadPost\n\"\"\n   \n")]
+    public void TryGetRandomPun_EmptyResourceIsUnavailable(string contents)
+    {
+        var logger = new RecordingLogger<PunProvider>();
+        var provider = new PunProvider(WriteResource(contents), logger);
+
+        Assert.False(provider.TryGetRandomPun(out var pun));
+        Assert.Null(pun);
+        Assert.Contains(logger.Entries, entry =>
+            entry.Level == LogLevel.Warning && entry.Message.Contains("No usable puns", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void TryGetRandomPun_MissingResourceIsUnavailable()
+    {
+        var logger = new RecordingLogger<PunProvider>();
+        var provider = new PunProvider(Path.Combine(_temporaryDirectory, "missing.csv"), logger);
+
+        Assert.False(provider.TryGetRandomPun(out var pun));
+        Assert.Null(pun);
+        Assert.Contains(logger.Entries, entry =>
+            entry.Level == LogLevel.Error && entry.Message.Contains("was not found", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("WrongHeader\n\"Not a pun\"\n")]
+    [InlineData("BadPost\n\"Valid first row\"\nbad\"quote\n")]
+    public void TryGetRandomPun_InvalidResourceDoesNotExposePartialResults(string contents)
+    {
+        var logger = new RecordingLogger<PunProvider>();
+        var provider = new PunProvider(WriteResource(contents), logger);
+
+        Assert.False(provider.TryGetRandomPun(out var pun));
+        Assert.Null(pun);
+        Assert.Contains(logger.Entries, entry =>
+            entry.Level == LogLevel.Error && entry.Message.Contains("could not be loaded", StringComparison.Ordinal));
+    }
+
+    public void Dispose()
+    {
+        Directory.Delete(_temporaryDirectory, recursive: true);
+    }
+
+    private string WriteResource(string contents)
+    {
+        var path = Path.Combine(_temporaryDirectory, $"{Guid.NewGuid():N}.csv");
+        File.WriteAllText(path, contents);
+        return path;
+    }
+
+    private static string GetPun(PunProvider provider)
+    {
+        Assert.True(provider.TryGetRandomPun(out var pun));
+        return pun;
+    }
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => Entries.Add((logLevel, formatter(state, exception)));
+    }
+}

--- a/BeanBot/BeanBot.csproj
+++ b/BeanBot/BeanBot.csproj
@@ -60,6 +60,7 @@
     </Content>
     <Content Include="Resources\puns.csv">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
     <Content Include="Resources\gordon6.gif">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/BeanBot/EventHandlers/PunHandler.cs
+++ b/BeanBot/EventHandlers/PunHandler.cs
@@ -1,9 +1,7 @@
 ﻿using System.Globalization;
-using System.Security.Cryptography;
 using BeanBot.Configuration;
-using BeanBot.Entities;
+using BeanBot.Services;
 using BeanBot.Util;
-using CsvHelper;
 using Discord.WebSocket;
 using Microsoft.Extensions.Logging;
 
@@ -13,6 +11,7 @@ public sealed class PunHandler : IAsyncDisposable
 {
     private readonly DiscordSocketClient _discordClient;
     private readonly ulong _generalChannelId;
+    private readonly IPunProvider _punProvider;
     private readonly ILogger<PunHandler> _logger;
     private readonly CancellationTokenSource _tokenSource = new();
     private Task? _runner;
@@ -23,10 +22,12 @@ public sealed class PunHandler : IAsyncDisposable
     public PunHandler(
         DiscordSocketClient discordSocketClient,
         BeanBotOptions options,
+        IPunProvider punProvider,
         ILogger<PunHandler> logger)
     {
         _discordClient = discordSocketClient ?? throw new ArgumentNullException(nameof(discordSocketClient));
         _generalChannelId = (options ?? throw new ArgumentNullException(nameof(options))).GeneralChannelId;
+        _punProvider = punProvider ?? throw new ArgumentNullException(nameof(punProvider));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         BeanBotLog.PunServiceInitializing(_logger);
     }
@@ -101,35 +102,20 @@ public sealed class PunHandler : IAsyncDisposable
             return;
         }
 
+        if (!_punProvider.TryGetRandomPun(out var pun))
+        {
+            return;
+        }
+
         await channel.SendMessageAsync("The time has come and so have I, Bean Bot here to deliver you your daily pun(?)");
         await channel.SendMessageAsync("<:420stolfoit:675553715759087618>");
-
         try
         {
-            using var reader = new StreamReader("Resources/puns.csv");
-            using var punCsv = new CsvReader(reader, CultureInfo.InvariantCulture);
-            var puns = punCsv.GetRecords<Pun>()
-                .Where(pun => !string.IsNullOrEmpty(pun.BadPost))
-                .ToList();
-
-            if (puns.Count == 0)
-            {
-                BeanBotLog.PunFileEmpty(_logger);
-                return;
-            }
-
-            var randomIndex = RandomNumberGenerator.GetInt32(0, puns.Count);
-            var randomPun = puns[randomIndex];
-
-            await channel.SendMessageAsync(randomPun.BadPost);
+            await channel.SendMessageAsync(pun);
         }
-        catch (FileNotFoundException)
+        catch (Exception exception)
         {
-            BeanBotLog.PunFileMissing(_logger);
-        }
-        catch (Exception ex)
-        {
-            BeanBotLog.PunPostingFailed(_logger, ex);
+            BeanBotLog.PunPostingFailed(_logger, exception);
         }
     }
 

--- a/BeanBot/Hosting/BeanBotServiceCollectionExtensions.cs
+++ b/BeanBot/Hosting/BeanBotServiceCollectionExtensions.cs
@@ -105,6 +105,9 @@ internal static class BeanBotServiceCollectionExtensions
         });
 
         services.AddSingleton<FortuneAnswerStore>();
+        services.AddSingleton<PunProvider>();
+        services.AddSingleton<IPunProvider>(provider =>
+            provider.GetRequiredService<PunProvider>());
         services.AddSingleton<DiscordMessageWaiter>();
         services.AddSingleton<DiscordPaginatorService>();
         services.AddSingleton<EditMessageEventServices>();

--- a/BeanBot/Modules/MemeModule.cs
+++ b/BeanBot/Modules/MemeModule.cs
@@ -1,9 +1,6 @@
-﻿using System.Globalization;
-using BeanBot.Configuration;
-using BeanBot.Entities;
+﻿using BeanBot.Configuration;
 using BeanBot.Services;
 using BeanBot.Util;
-using CsvHelper;
 using Discord;
 using Discord.Commands;
 using MemeApiDotNetWrapper;
@@ -19,17 +16,20 @@ public class MemeModule : ModuleBase<SocketCommandContext>
     private readonly BeanBotOptions _options;
     private readonly FortuneAnswerStore _fortuneAnswers;
     private readonly DiscordPaginatorService _paginator;
+    private readonly IPunProvider _punProvider;
     private readonly ILogger<MemeModule> _logger;
 
     public MemeModule(
         BeanBotOptions options,
         FortuneAnswerStore fortuneAnswers,
         DiscordPaginatorService paginator,
+        IPunProvider punProvider,
         ILogger<MemeModule> logger)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _fortuneAnswers = fortuneAnswers ?? throw new ArgumentNullException(nameof(fortuneAnswers));
         _paginator = paginator ?? throw new ArgumentNullException(nameof(paginator));
+        _punProvider = punProvider ?? throw new ArgumentNullException(nameof(punProvider));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -224,23 +224,13 @@ public class MemeModule : ModuleBase<SocketCommandContext>
 
     private async Task ChooseRandomPun()
     {
-        using (var reader = new StreamReader("Resources/puns.csv"))
-        using (var csv = new CsvReader(reader, CultureInfo.InvariantCulture))
+        if (!_punProvider.TryGetRandomPun(out var pun))
         {
-            var puns = csv.GetRecords<Pun>()
-                .Select(record => record.BadPost)
-                .Where(pun => !string.IsNullOrWhiteSpace(pun))
-                .ToList();
-
-            if (puns.Count == 0)
-            {
-                BeanBotLog.ModulePunFileEmpty(_logger);
-                await ReplyAsync("The PunMaster is temporarily out of material.");
-                return;
-            }
-
-            await ReplyAsync(puns[Random.Shared.Next(puns.Count)]);
+            await ReplyAsync("The PunMaster is temporarily out of material.");
+            return;
         }
+
+        await ReplyAsync(pun);
     }
 
     private async Task ChooseRandomAnswer(string question)

--- a/BeanBot/Services/IPunProvider.cs
+++ b/BeanBot/Services/IPunProvider.cs
@@ -1,0 +1,8 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace BeanBot.Services;
+
+public interface IPunProvider
+{
+    bool TryGetRandomPun([NotNullWhen(true)] out string? pun);
+}

--- a/BeanBot/Services/PunProvider.cs
+++ b/BeanBot/Services/PunProvider.cs
@@ -1,0 +1,84 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Security.Cryptography;
+using BeanBot.Entities;
+using BeanBot.Util;
+using CsvHelper;
+using CsvHelper.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace BeanBot.Services;
+
+public sealed class PunProvider : IPunProvider
+{
+    private readonly string[] _puns;
+
+    public PunProvider(ILogger<PunProvider> logger)
+        : this(Path.Combine(AppContext.BaseDirectory, "Resources", "puns.csv"), logger)
+    {
+    }
+
+    internal PunProvider(string resourcePath, ILogger<PunProvider> logger)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourcePath);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _puns = LoadPuns(resourcePath, logger);
+    }
+
+    public bool TryGetRandomPun([NotNullWhen(true)] out string? pun)
+    {
+        if (_puns.Length == 0)
+        {
+            pun = null;
+            return false;
+        }
+
+        pun = _puns[RandomNumberGenerator.GetInt32(_puns.Length)];
+        return true;
+    }
+
+    private static string[] LoadPuns(string resourcePath, ILogger logger)
+    {
+        try
+        {
+            using var reader = new StreamReader(resourcePath);
+            var configuration = new CsvConfiguration(CultureInfo.InvariantCulture)
+            {
+                DetectColumnCountChanges = true,
+                LineBreakInQuotedFieldIsBadData = true
+            };
+            using var csv = new CsvReader(reader, configuration);
+            if (!csv.Read())
+            {
+                BeanBotLog.PunResourceEmpty(logger, resourcePath);
+                return [];
+            }
+
+            csv.ReadHeader();
+            var puns = csv.GetRecords<Pun>()
+                .Select(record => record.BadPost)
+                .Where(pun => !string.IsNullOrWhiteSpace(pun))
+                .ToArray();
+
+            if (puns.Length == 0)
+            {
+                BeanBotLog.PunResourceEmpty(logger, resourcePath);
+                return [];
+            }
+
+            BeanBotLog.PunResourceLoaded(logger, puns.Length, resourcePath);
+            return puns;
+        }
+        catch (Exception exception) when (exception is FileNotFoundException or DirectoryNotFoundException)
+        {
+            BeanBotLog.PunResourceMissing(logger, resourcePath);
+            return [];
+        }
+        catch (Exception exception)
+        {
+            BeanBotLog.PunResourceInvalid(logger, resourcePath, exception);
+            return [];
+        }
+    }
+}

--- a/BeanBot/Util/BeanBotLog.cs
+++ b/BeanBot/Util/BeanBotLog.cs
@@ -39,11 +39,17 @@ internal static partial class BeanBotLog
     [LoggerMessage(Level = LogLevel.Error, Message = "Could not find general channel with ID {ChannelId} to post daily pun")]
     internal static partial void PunChannelMissing(ILogger logger, ulong channelId);
 
-    [LoggerMessage(Level = LogLevel.Error, Message = "No puns found in puns.csv")]
-    internal static partial void PunFileEmpty(ILogger logger);
+    [LoggerMessage(Level = LogLevel.Information, Message = "Loaded {PunCount} puns from {ResourcePath}")]
+    internal static partial void PunResourceLoaded(ILogger logger, int punCount, string resourcePath);
 
-    [LoggerMessage(Level = LogLevel.Error, Message = "puns.csv file not found; cannot post daily pun")]
-    internal static partial void PunFileMissing(ILogger logger);
+    [LoggerMessage(Level = LogLevel.Warning, Message = "No usable puns were found in {ResourcePath}")]
+    internal static partial void PunResourceEmpty(ILogger logger, string resourcePath);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Pun resource file was not found at {ResourcePath}")]
+    internal static partial void PunResourceMissing(ILogger logger, string resourcePath);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Pun resource file at {ResourcePath} could not be loaded")]
+    internal static partial void PunResourceInvalid(ILogger logger, string resourcePath, Exception exception);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Error occurred while posting daily pun")]
     internal static partial void PunPostingFailed(ILogger logger, Exception exception);
@@ -101,9 +107,6 @@ internal static partial class BeanBotLog
 
     [LoggerMessage(Level = LogLevel.Error, Message = "The meme API request failed")]
     internal static partial void MemeApiFailed(ILogger logger, Exception exception);
-
-    [LoggerMessage(Level = LogLevel.Warning, Message = "No usable puns were found in Resources/puns.csv")]
-    internal static partial void ModulePunFileEmpty(ILogger logger);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Could not attach the invalid-question Gordon GIF")]
     internal static partial void GordonAttachmentFailed(ILogger logger, Exception exception);

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN dotnet restore "BeanBot/BeanBot.csproj"
 COPY . .
 WORKDIR /src/BeanBot
 RUN dotnet publish "BeanBot.csproj" -c Release -o /app/publish --no-restore
+RUN test -s /app/publish/Resources/puns.csv
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
 WORKDIR /app


### PR DESCRIPTION
Closes #97

## Summary
- load and validate the packaged pun CSV once through a shared singleton provider
- use the cached provider for both the pun command and daily scheduled post
- fail safely for missing, empty, or malformed data and prevent partial daily announcements
- verify the CSV is present in publish and Docker output

## Verification
- focused tests: 10 passed
- ./scripts/verify.sh fast: 355 passed
- ./scripts/verify.sh full: 355 passed, no vulnerable packages, Docker build passed
- independent Verifier: PASS
- independent Reviewer: CLEAN