### PR TITLE
Add first-class slash command support

### DIFF
--- a/BeanBot.Tests/Discord/Interactions/BeanBotInteractionModuleTests.cs
+++ b/BeanBot.Tests/Discord/Interactions/BeanBotInteractionModuleTests.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics.CodeAnalysis;
+using BeanBot.Discord.Commands;
+using BeanBot.Discord.Interactions;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.Interactions;
+
+public class BeanBotInteractionModuleTests
+{
+    [Fact]
+    public void GetPunResponse_WhenPunExists_ReturnsProviderValue()
+    {
+        var response = BeanBotInteractionModule.GetPunResponse(new StubPunProvider("bean there, done that"));
+
+        Assert.Equal("bean there, done that", response);
+    }
+
+    [Fact]
+    public void GetPunResponse_WhenProviderIsEmpty_ReturnsLegacyFallback()
+    {
+        var response = BeanBotInteractionModule.GetPunResponse(new StubPunProvider(null));
+
+        Assert.Equal("The PunMaster is temporarily out of material.", response);
+    }
+
+    private sealed class StubPunProvider(string? pun) : IPunProvider
+    {
+        public bool TryGetRandomPun([NotNullWhen(true)] out string? result)
+        {
+            result = pun;
+            return result is not null;
+        }
+    }
+}

--- a/BeanBot.Tests/Discord/Interactions/InteractionCommandRegistrationTests.cs
+++ b/BeanBot.Tests/Discord/Interactions/InteractionCommandRegistrationTests.cs
@@ -1,0 +1,72 @@
+using BeanBot.Discord.Interactions;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.Interactions;
+
+public class InteractionCommandRegistrationTests
+{
+    [Fact]
+    public async Task EnsureRegisteredAsync_AfterSuccess_RegistersOnlyOnce()
+    {
+        var calls = 0;
+        var registration = new InteractionCommandRegistration(
+            () =>
+            {
+                calls++;
+                return Task.CompletedTask;
+            },
+            TimeSpan.FromSeconds(1));
+
+        var first = await registration.EnsureRegisteredAsync();
+        var second = await registration.EnsureRegisteredAsync();
+
+        Assert.True(first);
+        Assert.False(second);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public async Task EnsureRegisteredAsync_ConcurrentCalls_ShareOneRegistration()
+    {
+        var calls = 0;
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var registration = new InteractionCommandRegistration(
+            () =>
+            {
+                Interlocked.Increment(ref calls);
+                return completion.Task;
+            },
+            TimeSpan.FromSeconds(1));
+
+        var first = registration.EnsureRegisteredAsync();
+        var second = registration.EnsureRegisteredAsync();
+        completion.SetResult();
+
+        var results = await Task.WhenAll(first, second);
+
+        Assert.Equal(1, calls);
+        Assert.Single(results, result => result);
+        Assert.Single(results, result => !result);
+    }
+
+    [Fact]
+    public async Task EnsureRegisteredAsync_AfterFailure_AllowsRetry()
+    {
+        var calls = 0;
+        var registration = new InteractionCommandRegistration(
+            () =>
+            {
+                calls++;
+                return calls == 1
+                    ? Task.FromException(new InvalidOperationException("first attempt failed"))
+                    : Task.CompletedTask;
+            },
+            TimeSpan.FromSeconds(1));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => registration.EnsureRegisteredAsync());
+        var retried = await registration.EnsureRegisteredAsync();
+
+        Assert.True(retried);
+        Assert.Equal(2, calls);
+    }
+}

--- a/BeanBot.Tests/Discord/Interactions/InteractionCommandRegistrationTests.cs
+++ b/BeanBot.Tests/Discord/Interactions/InteractionCommandRegistrationTests.cs
@@ -69,4 +69,29 @@ public class InteractionCommandRegistrationTests
         Assert.True(retried);
         Assert.Equal(2, calls);
     }
+
+    [Fact]
+    public async Task EnsureRegisteredAsync_AfterTimeout_AllowsFreshRetry()
+    {
+        var calls = 0;
+        var stalledAttempt = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var registration = new InteractionCommandRegistration(
+            () =>
+            {
+                calls++;
+                return calls == 1
+                    ? stalledAttempt.Task
+                    : Task.CompletedTask;
+            },
+            TimeSpan.FromMilliseconds(20));
+
+        await Assert.ThrowsAsync<TimeoutException>(() => registration.EnsureRegisteredAsync());
+        var retried = await registration.EnsureRegisteredAsync();
+
+        Assert.True(retried);
+        Assert.Equal(2, calls);
+
+        stalledAttempt.SetException(new InvalidOperationException("late failure"));
+        await Task.Yield();
+    }
 }

--- a/BeanBot/BeanBot.csproj
+++ b/BeanBot/BeanBot.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="CsvHelper" />
     <PackageReference Include="Discord.Net.Commands" />
     <PackageReference Include="Discord.Net.Core" />
+    <PackageReference Include="Discord.Net.Interactions" />
     <PackageReference Include="Discord.Net.Rest" />
     <PackageReference Include="Discord.Net.WebSocket" />
     <PackageReference Include="LQ.MemeApiDotNetWrapper" />

--- a/BeanBot/Discord/Interactions/BeanBotInteractionHostedService.cs
+++ b/BeanBot/Discord/Interactions/BeanBotInteractionHostedService.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.Hosting;
+
+namespace BeanBot.Discord.Interactions;
+
+internal sealed class BeanBotInteractionHostedService : IHostedService
+{
+    private readonly InteractionHandler _interactionHandler;
+
+    public BeanBotInteractionHostedService(InteractionHandler interactionHandler)
+    {
+        _interactionHandler = interactionHandler ?? throw new ArgumentNullException(nameof(interactionHandler));
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+        => _interactionHandler.InitializeAsync(cancellationToken);
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _interactionHandler.Dispose();
+        return Task.CompletedTask;
+    }
+}

--- a/BeanBot/Discord/Interactions/BeanBotInteractionModule.cs
+++ b/BeanBot/Discord/Interactions/BeanBotInteractionModule.cs
@@ -1,0 +1,39 @@
+using BeanBot.Discord.Commands;
+using Discord.Interactions;
+
+namespace BeanBot.Discord.Interactions;
+
+public sealed class BeanBotInteractionModule : InteractionModuleBase<SocketInteractionContext>
+{
+    private const string PunFallback = "The PunMaster is temporarily out of material.";
+    private readonly IPunProvider _punProvider;
+
+    public BeanBotInteractionModule(IPunProvider punProvider)
+    {
+        _punProvider = punProvider ?? throw new ArgumentNullException(nameof(punProvider));
+    }
+
+    [SlashCommand("ping", "Check whether Bean Bot is responsive.")]
+    public Task PingAsync()
+        => RespondAsync("Pong!");
+
+    [SlashCommand("pun", "Get one PunMaster-branded pun.")]
+    public Task PunAsync()
+        => RespondAsync(GetPunResponse(_punProvider));
+
+    [SlashCommand("help", "Show Bean Bot's initial slash commands and legacy command syntax.")]
+    public Task HelpAsync()
+        => RespondAsync(
+            "Slash commands currently available: `/ping`, `/pun`, and `/help`. " +
+            "Legacy message commands still work with `%`, `succ `, or by mentioning Bean Bot. " +
+            "Use `%help` for the full legacy command list.",
+            ephemeral: true);
+
+    internal static string GetPunResponse(IPunProvider punProvider)
+    {
+        ArgumentNullException.ThrowIfNull(punProvider);
+        return punProvider.TryGetRandomPun(out var pun)
+            ? pun
+            : PunFallback;
+    }
+}

--- a/BeanBot/Discord/Interactions/BeanBotInteractionServiceCollectionExtensions.cs
+++ b/BeanBot/Discord/Interactions/BeanBotInteractionServiceCollectionExtensions.cs
@@ -1,0 +1,28 @@
+using Discord;
+using Discord.Interactions;
+using Discord.WebSocket;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace BeanBot.Discord.Interactions;
+
+internal static class BeanBotInteractionServiceCollectionExtensions
+{
+    internal static IServiceCollection AddBeanBotInteractions(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton(provider => new InteractionService(
+            provider.GetRequiredService<DiscordSocketClient>().Rest,
+            new InteractionServiceConfig
+            {
+                LogLevel = LogSeverity.Verbose
+            }));
+        services.AddSingleton<InteractionHandler>();
+        services.AddSingleton<BeanBotInteractionHostedService>();
+        services.AddSingleton<IHostedService>(provider =>
+            provider.GetRequiredService<BeanBotInteractionHostedService>());
+
+        return services;
+    }
+}

--- a/BeanBot/Discord/Interactions/InteractionCommandRegistration.cs
+++ b/BeanBot/Discord/Interactions/InteractionCommandRegistration.cs
@@ -1,0 +1,85 @@
+namespace BeanBot.Discord.Interactions;
+
+internal sealed class InteractionCommandRegistration
+{
+    private readonly object _syncRoot = new();
+    private readonly Func<Task> _registerCommands;
+    private readonly TimeSpan _timeout;
+    private Task? _registrationTask;
+    private bool _registered;
+
+    public InteractionCommandRegistration(Func<Task> registerCommands, TimeSpan timeout)
+    {
+        _registerCommands = registerCommands ?? throw new ArgumentNullException(nameof(registerCommands));
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(timeout, TimeSpan.Zero);
+        _timeout = timeout;
+    }
+
+    public async Task<bool> EnsureRegisteredAsync()
+    {
+        Task registrationTask;
+        lock (_syncRoot)
+        {
+            if (_registered)
+            {
+                return false;
+            }
+
+            _registrationTask ??= _registerCommands();
+            registrationTask = _registrationTask;
+        }
+
+        try
+        {
+            await registrationTask.WaitAsync(_timeout);
+        }
+        catch (TimeoutException)
+        {
+            ObserveLateFault(registrationTask);
+            throw;
+        }
+        catch
+        {
+            lock (_syncRoot)
+            {
+                if (ReferenceEquals(_registrationTask, registrationTask))
+                {
+                    _registrationTask = null;
+                }
+            }
+
+            throw;
+        }
+
+        lock (_syncRoot)
+        {
+            if (_registered)
+            {
+                return false;
+            }
+
+            _registered = true;
+            if (ReferenceEquals(_registrationTask, registrationTask))
+            {
+                _registrationTask = null;
+            }
+
+            return true;
+        }
+    }
+
+    private static void ObserveLateFault(Task registrationTask)
+    {
+        if (registrationTask.IsCompleted)
+        {
+            _ = registrationTask.Exception;
+            return;
+        }
+
+        _ = registrationTask.ContinueWith(
+            completedTask => _ = completedTask.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+}

--- a/BeanBot/Discord/Interactions/InteractionCommandRegistration.cs
+++ b/BeanBot/Discord/Interactions/InteractionCommandRegistration.cs
@@ -35,6 +35,14 @@ internal sealed class InteractionCommandRegistration
         }
         catch (TimeoutException)
         {
+            lock (_syncRoot)
+            {
+                if (ReferenceEquals(_registrationTask, registrationTask))
+                {
+                    _registrationTask = null;
+                }
+            }
+
             ObserveLateFault(registrationTask);
             throw;
         }

--- a/BeanBot/Discord/Interactions/InteractionHandler.cs
+++ b/BeanBot/Discord/Interactions/InteractionHandler.cs
@@ -1,0 +1,130 @@
+using System.Reflection;
+using BeanBot.Logging;
+using Discord;
+using Discord.Interactions;
+using Discord.WebSocket;
+using Microsoft.Extensions.Logging;
+
+namespace BeanBot.Discord.Interactions;
+
+internal sealed class InteractionHandler : IDisposable
+{
+    internal static readonly TimeSpan RegistrationTimeout = TimeSpan.FromSeconds(30);
+    private const string SafeFailureMessage = "Bean Bot couldn't complete that command. Try again in a moment.";
+
+    private readonly DiscordSocketClient _discordClient;
+    private readonly InteractionService _interactionService;
+    private readonly IServiceProvider _services;
+    private readonly InteractionCommandRegistration _registration;
+    private readonly ILogger<InteractionHandler> _logger;
+    private bool _initialized;
+
+    public InteractionHandler(
+        DiscordSocketClient discordClient,
+        InteractionService interactionService,
+        IServiceProvider services,
+        ILogger<InteractionHandler> logger)
+    {
+        _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
+        _interactionService = interactionService ?? throw new ArgumentNullException(nameof(interactionService));
+        _services = services ?? throw new ArgumentNullException(nameof(services));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _registration = new InteractionCommandRegistration(
+            () => _interactionService.RegisterCommandsGloballyAsync(deleteMissing: true),
+            RegistrationTimeout);
+    }
+
+    public async Task InitializeAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (_initialized)
+        {
+            return;
+        }
+
+        await _interactionService.AddModulesAsync(
+            Assembly.GetEntryAssembly() ?? typeof(InteractionHandler).Assembly,
+            _services);
+
+        _discordClient.InteractionCreated += HandleInteractionAsync;
+        _discordClient.Ready += HandleReadyAsync;
+        _initialized = true;
+
+        if (_discordClient.ConnectionState == ConnectionState.Connected)
+        {
+            await RegisterCommandsSafelyAsync();
+        }
+    }
+
+    public void Dispose()
+    {
+        if (!_initialized)
+        {
+            return;
+        }
+
+        _discordClient.InteractionCreated -= HandleInteractionAsync;
+        _discordClient.Ready -= HandleReadyAsync;
+        _initialized = false;
+    }
+
+    internal Task HandleReadyAsync()
+        => RegisterCommandsSafelyAsync();
+
+    internal async Task HandleInteractionAsync(SocketInteraction interaction)
+    {
+        ArgumentNullException.ThrowIfNull(interaction);
+
+        try
+        {
+            var context = new SocketInteractionContext(_discordClient, interaction);
+            var result = await _interactionService.ExecuteCommandAsync(context, _services);
+            if (result.IsSuccess)
+            {
+                return;
+            }
+
+            BeanBotLog.InteractionCommandFailed(_logger, interaction.Type, result.ErrorReason);
+            await TryRespondWithFailureAsync(interaction);
+        }
+        catch (Exception exception)
+        {
+            BeanBotLog.InteractionCommandThrew(_logger, interaction.Type, exception);
+            await TryRespondWithFailureAsync(interaction);
+        }
+    }
+
+    private async Task RegisterCommandsSafelyAsync()
+    {
+        try
+        {
+            if (await _registration.EnsureRegisteredAsync())
+            {
+                BeanBotLog.InteractionCommandsRegistered(_logger);
+            }
+        }
+        catch (Exception exception)
+        {
+            BeanBotLog.InteractionCommandRegistrationFailed(_logger, exception);
+        }
+    }
+
+    private async Task TryRespondWithFailureAsync(SocketInteraction interaction)
+    {
+        try
+        {
+            if (interaction.HasResponded)
+            {
+                await interaction.FollowupAsync(SafeFailureMessage, ephemeral: true);
+            }
+            else
+            {
+                await interaction.RespondAsync(SafeFailureMessage, ephemeral: true);
+            }
+        }
+        catch (Exception exception)
+        {
+            BeanBotLog.InteractionFailureResponseFailed(_logger, interaction.Type, exception);
+        }
+    }
+}

--- a/BeanBot/Logging/InteractionLog.cs
+++ b/BeanBot/Logging/InteractionLog.cs
@@ -1,0 +1,22 @@
+using Discord;
+using Microsoft.Extensions.Logging;
+
+namespace BeanBot.Logging;
+
+internal static partial class BeanBotLog
+{
+    [LoggerMessage(Level = LogLevel.Information, Message = "Discord application commands registered successfully")]
+    internal static partial void InteractionCommandsRegistered(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Discord application-command registration failed")]
+    internal static partial void InteractionCommandRegistrationFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Discord interaction execution failed. InteractionType={InteractionType}, Reason={Reason}")]
+    internal static partial void InteractionCommandFailed(ILogger logger, InteractionType interactionType, string? reason);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Discord interaction execution threw unexpectedly. InteractionType={InteractionType}")]
+    internal static partial void InteractionCommandThrew(ILogger logger, InteractionType interactionType, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Could not send the safe failure response for Discord interaction type {InteractionType}")]
+    internal static partial void InteractionFailureResponseFailed(ILogger logger, InteractionType interactionType, Exception exception);
+}

--- a/BeanBot/Program.cs
+++ b/BeanBot/Program.cs
@@ -1,4 +1,5 @@
 using BeanBot.Configuration;
+using BeanBot.Discord.Interactions;
 using BeanBot.Hosting;
 using BeanBot.Logging;
 using BeanBot.Persistence;
@@ -27,6 +28,7 @@ internal static class Program
             builder.Services.Configure<HostOptions>(options =>
                 options.ShutdownTimeout = HostShutdownTimeout);
             builder.Services.AddBeanBot(builder.Configuration);
+            builder.Services.AddBeanBotInteractions();
             builder.Services.AddSerilog((services, loggerConfiguration) =>
                 LogHandler.ConfigureLogger(
                     loggerConfiguration,

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,7 @@
     <PackageVersion Include="CsvHelper" Version="15.0.5" />
     <PackageVersion Include="Discord.Net.Commands" Version="3.20.1" />
     <PackageVersion Include="Discord.Net.Core" Version="3.20.1" />
+    <PackageVersion Include="Discord.Net.Interactions" Version="3.20.1" />
     <PackageVersion Include="Discord.Net.Rest" Version="3.20.1" />
     <PackageVersion Include="Discord.Net.WebSocket" Version="3.20.1" />
     <PackageVersion Include="LQ.MemeApiDotNetWrapper" Version="1.5.1" />

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -1,0 +1,25 @@
+# Slash commands
+
+BeanBot supports Discord application commands alongside the existing message-command system. The initial slash-command surface is intentionally small so application-command infrastructure can ship without rewriting legacy commands.
+
+## Initial commands
+
+- `/ping` checks that BeanBot can receive and answer an interaction.
+- `/pun` uses the same cached `IPunProvider` as the legacy `%pun` command.
+- `/help` summarizes the slash-command surface and points users to `%help` for the complete legacy command list.
+
+The existing `%`, `succ `, and mention-prefix commands remain supported and are not replaced by slash commands.
+
+## Discord application setup
+
+The bot installation must include the `applications.commands` OAuth2 scope in addition to the permissions already required by BeanBot. Existing installations created with a modern Discord bot authorization URL may already include application-command access; if slash commands do not appear, re-authorize the application with the required scope.
+
+BeanBot registers its interaction modules globally after the Discord client is connected. Registration is process-idempotent: repeated `Ready` events share the same registration operation and do not create competing command-registration calls. A failed registration can retry on a later `Ready` event. Registration waits are bounded so an unresponsive Discord REST call does not block the hosted service forever.
+
+Global application-command changes can take time to propagate in Discord. Do not repeatedly restart BeanBot to force propagation.
+
+## Lifecycle and failure behavior
+
+Interaction handlers are owned by a dedicated hosted service registered after the main BeanBot hosted service. The interaction service therefore stops before the core Discord runtime during normal Generic Host shutdown. Event subscriptions are removed on stop.
+
+Interaction execution failures are logged through BeanBot's structured logging path. Users receive a generic ephemeral failure response rather than internal exception details.

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -14,7 +14,7 @@ The existing `%`, `succ `, and mention-prefix commands remain supported and are 
 
 The bot installation must include the `applications.commands` OAuth2 scope in addition to the permissions already required by BeanBot. Existing installations created with a modern Discord bot authorization URL may already include application-command access; if slash commands do not appear, re-authorize the application with the required scope.
 
-BeanBot registers its interaction modules globally after the Discord client is connected. Registration is process-idempotent: repeated `Ready` events share the same registration operation and do not create competing command-registration calls. A failed registration can retry on a later `Ready` event. Registration waits are bounded so an unresponsive Discord REST call does not block the hosted service forever.
+BeanBot registers its interaction modules globally after the Discord client is connected. Normal concurrent or repeated `Ready` events share the same in-flight registration operation, and successful registration becomes a process-level no-op on later `Ready` events. Completed failures can retry on a later `Ready`. Registration waits are bounded; if a Discord REST registration attempt exceeds that bound, BeanBot observes any late fault and abandons that attempt so a later `Ready` can start a fresh registration rather than waiting forever on the stalled task.
 
 Global application-command changes can take time to propagate in Discord. Do not repeatedly restart BeanBot to force propagation.
 


### PR DESCRIPTION
Closes #121.

## Summary
- add Discord.Net Interactions support without replacing the existing `Discord.Commands` prefix/mention command path
- add `/ping`, `/pun`, and `/help` as the initial slash-command surface
- keep `/pun` backed by the same cached `IPunProvider` used by the legacy command
- register interaction handlers through a dedicated hosted service so lifecycle ordering stays isolated from the core BeanBot runtime
- make global command registration idempotent across successful/repeated `Ready` events and bounded to a 30-second wait
- allow completed registration failures to retry, and abandon timed-out registration waits so a later `Ready` can start a fresh attempt while late faults remain observed
- provide generic ephemeral user feedback for interaction failures while keeping exception details in structured logs
- document the required `applications.commands` scope, global command propagation behavior, and timeout/retry semantics

## Compatibility
- `%`, `succ `, and mention-prefix commands are unchanged
- legacy aliases remain unchanged
- no existing command module is migrated or removed

## Tests
- registration succeeds once and becomes a no-op after success
- concurrent registration requests share one underlying Discord registration task
- completed registration failure can retry
- timed-out registration can start a fresh retry while a late fault from the abandoned task remains observed
- slash `/pun` uses the configured pun provider and preserves the existing empty-provider fallback

## Review fixes
- addressed Copilot review feedback that a timed-out registration kept the stalled task cached and prevented a fresh later retry
- added a regression test for timeout -> fresh retry behavior
- clarified documentation so bounded timeout/abandonment semantics match the implementation

## Verification
- initial exact-head GitHub Actions run #169: full repository verification passed
- corrected-code exact-head GitHub Actions run #171: full repository verification passed
- final exact-head GitHub Actions run #172: full repository verification passed
- build/test/analyzer/vulnerability/Docker verification gate: passed
- fresh post-fix Verifier: PASS
- fresh post-fix Reviewer: CLEAN
- Copilot timeout-registration review thread: resolved

## Manual deployment note
The bot application must have the `applications.commands` OAuth2 scope. Global slash-command changes may take time to propagate through Discord after deployment.
