### PR TITLE
Give legacy prefix commands safe error feedback

### DIFF
--- a/BeanBot.Tests/Discord/Commands/LegacyCommandFeedbackResponderTests.cs
+++ b/BeanBot.Tests/Discord/Commands/LegacyCommandFeedbackResponderTests.cs
@@ -161,9 +161,14 @@ public class LegacyCommandFeedbackResponderTests
 
     private sealed class UsageModule : ModuleBase<SocketCommandContext>
     {
+        private int _invocationCount;
+
         [Command("sample")]
         public Task SampleAsync(string text, int count)
-            => Task.FromResult(HashCode.Combine(GetHashCode(), text, count));
+        {
+            _invocationCount += text.Length + count;
+            return Task.CompletedTask;
+        }
     }
 
     private sealed class RecordingDelivery : ILegacyCommandFeedbackDelivery

--- a/BeanBot.Tests/Discord/Commands/LegacyCommandFeedbackResponderTests.cs
+++ b/BeanBot.Tests/Discord/Commands/LegacyCommandFeedbackResponderTests.cs
@@ -163,7 +163,7 @@ public class LegacyCommandFeedbackResponderTests
     {
         [Command("sample")]
         public Task SampleAsync(string text, int count)
-            => Task.CompletedTask;
+            => Task.FromResult(HashCode.Combine(GetHashCode(), text, count));
     }
 
     private sealed class RecordingDelivery : ILegacyCommandFeedbackDelivery

--- a/BeanBot.Tests/Discord/Commands/LegacyCommandFeedbackResponderTests.cs
+++ b/BeanBot.Tests/Discord/Commands/LegacyCommandFeedbackResponderTests.cs
@@ -1,0 +1,238 @@
+using BeanBot.Discord.Commands;
+using Discord;
+using Discord.Commands;
+using Discord.WebSocket;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.Commands;
+
+public class LegacyCommandFeedbackResponderTests
+{
+    [Fact]
+    public async Task UnknownCommand_ReturnsActionableHelpHintWithoutEchoingRawReason()
+    {
+        var delivery = new RecordingDelivery();
+        var responder = CreateResponder(delivery);
+        var result = new FakeResult(CommandError.UnknownCommand, "@everyone token=secret");
+
+        await responder.RespondAsync(default, new StubCommandContext(), result);
+
+        var message = Assert.Single(delivery.Messages);
+        Assert.Equal("I don't know that command. Try `%help`.", message);
+        Assert.DoesNotContain("@everyone", message, StringComparison.Ordinal);
+        Assert.DoesNotContain("secret", message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(CommandError.BadArgCount)]
+    [InlineData(CommandError.ParseFailed)]
+    [InlineData(CommandError.ObjectNotFound)]
+    [InlineData(CommandError.MultipleMatches)]
+    public async Task ArgumentErrors_WithCommandMetadata_ReturnBoundedUsageGuidance(CommandError error)
+    {
+        var command = await GetUsageCommandAsync();
+        var delivery = new RecordingDelivery();
+        var responder = CreateResponder(delivery);
+
+        await responder.RespondAsync(
+            new Optional<CommandInfo>(command),
+            new StubCommandContext(),
+            new FakeResult(error, "internal parser detail"));
+
+        var message = Assert.Single(delivery.Messages);
+        Assert.Contains("Usage: `%sample <text> <count>`", message, StringComparison.Ordinal);
+        Assert.Contains("%help", message, StringComparison.Ordinal);
+        Assert.DoesNotContain("internal parser detail", message, StringComparison.Ordinal);
+        Assert.True(message.Length <= LegacyCommandFeedbackResponder.MaxFeedbackLength);
+    }
+
+    [Fact]
+    public async Task ArgumentError_WithoutCommandMetadata_FallsBackToHelpHint()
+    {
+        var delivery = new RecordingDelivery();
+        var responder = CreateResponder(delivery);
+
+        await responder.RespondAsync(
+            default,
+            new StubCommandContext(),
+            new FakeResult(CommandError.ParseFailed, "raw parse detail"));
+
+        Assert.Equal(
+            "I couldn't understand those arguments. Try `%help`.",
+            Assert.Single(delivery.Messages));
+    }
+
+    [Fact]
+    public async Task UnmetPrecondition_ReturnsSafeContextFeedbackWithoutRawReason()
+    {
+        var delivery = new RecordingDelivery();
+        var responder = CreateResponder(delivery);
+
+        await responder.RespondAsync(
+            default,
+            new StubCommandContext(),
+            new FakeResult(CommandError.UnmetPrecondition, "database says user 123 lacks secret role 456"));
+
+        var message = Assert.Single(delivery.Messages);
+        Assert.Contains("Check your permissions", message, StringComparison.Ordinal);
+        Assert.DoesNotContain("database", message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("456", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task UnexpectedFailure_ReturnsOnlyGenericSafeMessage()
+    {
+        var delivery = new RecordingDelivery();
+        var responder = CreateResponder(delivery);
+
+        await responder.RespondAsync(
+            default,
+            new StubCommandContext(),
+            new FakeResult(CommandError.Exception, "Mongo connection string mongodb://secret"));
+
+        var message = Assert.Single(delivery.Messages);
+        Assert.Equal("Bean Bot couldn't complete that command. Try again in a moment.", message);
+        Assert.DoesNotContain("Mongo", message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("secret", message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task SuccessfulCommand_DoesNotSendExtraFeedback()
+    {
+        var delivery = new RecordingDelivery();
+        var responder = CreateResponder(delivery);
+
+        await responder.RespondAsync(
+            default,
+            new StubCommandContext(),
+            new FakeResult(null, string.Empty, isSuccess: true));
+
+        Assert.Empty(delivery.Messages);
+        Assert.Equal(0, delivery.Attempts);
+    }
+
+    [Fact]
+    public async Task FeedbackDeliveryFailure_IsWarningOnlyAndDoesNotRecurse()
+    {
+        var exception = new InvalidOperationException("send failed");
+        var delivery = new RecordingDelivery(exception);
+        var logger = new RecordingLogger<LegacyCommandFeedbackResponder>();
+        var responder = new LegacyCommandFeedbackResponder(delivery, logger);
+
+        await responder.RespondAsync(
+            default,
+            new StubCommandContext(),
+            new FakeResult(CommandError.UnknownCommand, "unknown"));
+
+        Assert.Equal(1, delivery.Attempts);
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Same(exception, entry.Exception);
+    }
+
+    [Fact]
+    public void Feedback_IsBoundedBelowDiscordMessageLimit()
+    {
+        var feedback = LegacyCommandFeedbackResponder.BoundFeedback(new string('x', 2_000));
+
+        Assert.Equal(LegacyCommandFeedbackResponder.MaxFeedbackLength, feedback.Length);
+        Assert.EndsWith("…", feedback, StringComparison.Ordinal);
+        Assert.True(feedback.Length < DiscordConfig.MaxMessageSize);
+    }
+
+    [Fact]
+    public void DiscordDelivery_DisablesMentionsAndUsesBoundedWait()
+    {
+        Assert.Same(AllowedMentions.None, DiscordLegacyCommandFeedbackDelivery.SafeAllowedMentions);
+        Assert.True(DiscordLegacyCommandFeedbackDelivery.SendTimeout > TimeSpan.Zero);
+        Assert.True(DiscordLegacyCommandFeedbackDelivery.SendTimeout <= TimeSpan.FromSeconds(30));
+    }
+
+    private static LegacyCommandFeedbackResponder CreateResponder(RecordingDelivery delivery)
+        => new(delivery, new RecordingLogger<LegacyCommandFeedbackResponder>());
+
+    private static async Task<CommandInfo> GetUsageCommandAsync()
+    {
+        var commandService = new CommandService();
+        await commandService.AddModuleAsync<UsageModule>(null!);
+        return Assert.Single(commandService.Commands, command => command.Name == "sample");
+    }
+
+    private sealed class UsageModule : ModuleBase<SocketCommandContext>
+    {
+        [Command("sample")]
+        public Task SampleAsync(string text, int count)
+            => Task.CompletedTask;
+    }
+
+    private sealed class RecordingDelivery : ILegacyCommandFeedbackDelivery
+    {
+        private readonly Exception? _exception;
+
+        public RecordingDelivery(Exception? exception = null)
+        {
+            _exception = exception;
+        }
+
+        public int Attempts { get; private set; }
+        public List<string> Messages { get; } = [];
+
+        public Task SendAsync(ICommandContext context, string message)
+        {
+            Attempts++;
+            if (_exception != null)
+            {
+                throw _exception;
+            }
+
+            Messages.Add(message);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed record LogEntry(LogLevel Level, Exception? Exception);
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => Entries.Add(new LogEntry(logLevel, exception));
+    }
+
+    private sealed class FakeResult : IResult
+    {
+        public FakeResult(
+            CommandError? error,
+            string errorReason,
+            bool isSuccess = false)
+        {
+            Error = error;
+            ErrorReason = errorReason;
+            IsSuccess = isSuccess;
+        }
+
+        public CommandError? Error { get; }
+        public string ErrorReason { get; }
+        public bool IsSuccess { get; }
+    }
+
+    private sealed class StubCommandContext : ICommandContext
+    {
+        public IDiscordClient Client => throw new NotSupportedException();
+        public IGuild Guild => throw new NotSupportedException();
+        public IMessageChannel Channel => throw new NotSupportedException();
+        public IUser User => throw new NotSupportedException();
+        public IUserMessage Message => throw new NotSupportedException();
+    }
+}

--- a/BeanBot/Discord/Commands/LegacyCommandFeedbackResponder.cs
+++ b/BeanBot/Discord/Commands/LegacyCommandFeedbackResponder.cs
@@ -1,0 +1,152 @@
+using BeanBot.Logging;
+using Discord;
+using Discord.Commands;
+using Microsoft.Extensions.Logging;
+
+namespace BeanBot.Discord.Commands;
+
+internal interface ILegacyCommandFeedbackDelivery
+{
+    Task SendAsync(ICommandContext context, string message);
+}
+
+internal sealed class DiscordLegacyCommandFeedbackDelivery : ILegacyCommandFeedbackDelivery
+{
+    internal static readonly TimeSpan SendTimeout = TimeSpan.FromSeconds(10);
+    internal static AllowedMentions SafeAllowedMentions => AllowedMentions.None;
+
+    public async Task SendAsync(ICommandContext context, string message)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+
+        Task sendTask = context.Channel.SendMessageAsync(
+            message,
+            allowedMentions: SafeAllowedMentions);
+        try
+        {
+            await sendTask.WaitAsync(SendTimeout);
+        }
+        catch (TimeoutException)
+        {
+            ObserveLateFault(sendTask);
+            throw;
+        }
+    }
+
+    private static void ObserveLateFault(Task sendTask)
+    {
+        if (sendTask.IsCompleted)
+        {
+            _ = sendTask.Exception;
+            return;
+        }
+
+        _ = sendTask.ContinueWith(
+            completedTask => _ = completedTask.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+}
+
+internal sealed class LegacyCommandFeedbackResponder
+{
+    internal const int MaxFeedbackLength = 500;
+    private const string HelpHint = "Try `%help`.";
+    private const string GenericFailureMessage = "Bean Bot couldn't complete that command. Try again in a moment.";
+
+    private readonly ILegacyCommandFeedbackDelivery _delivery;
+    private readonly ILogger<LegacyCommandFeedbackResponder> _logger;
+
+    public LegacyCommandFeedbackResponder(
+        ILegacyCommandFeedbackDelivery delivery,
+        ILogger<LegacyCommandFeedbackResponder> logger)
+    {
+        _delivery = delivery ?? throw new ArgumentNullException(nameof(delivery));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task RespondAsync(
+        Optional<CommandInfo> command,
+        ICommandContext context,
+        IResult result)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(result);
+
+        if (result.IsSuccess)
+        {
+            return;
+        }
+
+        var feedback = CreateFeedback(command, result);
+        try
+        {
+            await _delivery.SendAsync(context, feedback);
+        }
+        catch (Exception exception)
+        {
+            BeanBotLog.LegacyCommandFeedbackDeliveryFailed(
+                _logger,
+                result.Error,
+                exception);
+        }
+    }
+
+    internal static string CreateFeedback(Optional<CommandInfo> command, IResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        var feedback = result.Error switch
+        {
+            CommandError.UnknownCommand => $"I don't know that command. {HelpHint}",
+            CommandError.BadArgCount or
+            CommandError.ParseFailed or
+            CommandError.ObjectNotFound or
+            CommandError.MultipleMatches => CreateArgumentFeedback(command),
+            CommandError.UnmetPrecondition =>
+                $"You can't use that command in this context. Check your permissions and try `%help` for usage details.",
+            _ => GenericFailureMessage
+        };
+
+        return BoundFeedback(feedback);
+    }
+
+    internal static string BoundFeedback(string message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        if (message.Length <= MaxFeedbackLength)
+        {
+            return message;
+        }
+
+        return string.Concat(message.AsSpan(0, MaxFeedbackLength - 1), "…");
+    }
+
+    private static string CreateArgumentFeedback(Optional<CommandInfo> command)
+    {
+        var usage = command.IsSpecified
+            ? CreateUsage(command.Value)
+            : null;
+        return usage == null
+            ? $"I couldn't understand those arguments. {HelpHint}"
+            : $"I couldn't understand those arguments. Usage: `{usage}`. Try `%help` for more details.";
+    }
+
+    private static string? CreateUsage(CommandInfo command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        if (string.IsNullOrWhiteSpace(command.Name))
+        {
+            return null;
+        }
+
+        var parameters = command.Parameters
+            .Select(parameter => $"<{parameter.Name}>");
+        var parameterList = string.Join(" ", parameters);
+        return string.IsNullOrEmpty(parameterList)
+            ? $"%{command.Name}"
+            : $"%{command.Name} {parameterList}";
+    }
+}

--- a/BeanBot/Discord/Events/CommandHandler.cs
+++ b/BeanBot/Discord/Events/CommandHandler.cs
@@ -34,6 +34,7 @@ public sealed class CommandHandler : IDisposable
     private readonly FortuneAnswerStore _fortuneAnswers;
     private readonly DiscordMessageWaiter _messageWaiter;
     private readonly LogHandler _logHandler;
+    private readonly LegacyCommandFeedbackResponder _feedbackResponder;
     private readonly ILogger<CommandHandler> _logger;
     private bool _initialized;
 
@@ -42,12 +43,14 @@ public sealed class CommandHandler : IDisposable
         CommandService commandService,
         IServiceProvider services,
         LogHandler logHandler,
+        LegacyCommandFeedbackResponder feedbackResponder,
         ILogger<CommandHandler> logger)
     {
         _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
         _commandService = commandService ?? throw new ArgumentNullException(nameof(commandService));
         _services = services ?? throw new ArgumentNullException(nameof(services));
         _logHandler = logHandler ?? throw new ArgumentNullException(nameof(logHandler));
+        _feedbackResponder = feedbackResponder ?? throw new ArgumentNullException(nameof(feedbackResponder));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _fortuneAnswers = _services.GetRequiredService<FortuneAnswerStore>();
         _messageWaiter = _services.GetRequiredService<DiscordMessageWaiter>();
@@ -64,6 +67,7 @@ public sealed class CommandHandler : IDisposable
         BeanBotLog.CommandsInstalling(_logger);
         _discordClient.MessageReceived += HandleCommandAsync;
         _commandService.CommandExecuted += _logHandler.LogCommands;
+        _commandService.CommandExecuted += _feedbackResponder.RespondAsync;
         await _commandService.AddModulesAsync(assembly: Assembly.GetEntryAssembly() ?? typeof(CommandHandler).Assembly,
                                               services: _services);
         _initialized = true;
@@ -74,6 +78,7 @@ public sealed class CommandHandler : IDisposable
         if (_initialized)
         {
             _discordClient.MessageReceived -= HandleCommandAsync;
+            _commandService.CommandExecuted -= _feedbackResponder.RespondAsync;
             _commandService.CommandExecuted -= _logHandler.LogCommands;
             _initialized = false;
         }

--- a/BeanBot/Discord/Events/CommandHandler.cs
+++ b/BeanBot/Discord/Events/CommandHandler.cs
@@ -43,14 +43,13 @@ public sealed class CommandHandler : IDisposable
         CommandService commandService,
         IServiceProvider services,
         LogHandler logHandler,
-        LegacyCommandFeedbackResponder feedbackResponder,
         ILogger<CommandHandler> logger)
     {
         _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
         _commandService = commandService ?? throw new ArgumentNullException(nameof(commandService));
         _services = services ?? throw new ArgumentNullException(nameof(services));
         _logHandler = logHandler ?? throw new ArgumentNullException(nameof(logHandler));
-        _feedbackResponder = feedbackResponder ?? throw new ArgumentNullException(nameof(feedbackResponder));
+        _feedbackResponder = _services.GetRequiredService<LegacyCommandFeedbackResponder>();
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _fortuneAnswers = _services.GetRequiredService<FortuneAnswerStore>();
         _messageWaiter = _services.GetRequiredService<DiscordMessageWaiter>();

--- a/BeanBot/Discord/Events/CommandHandler.cs
+++ b/BeanBot/Discord/Events/CommandHandler.cs
@@ -64,11 +64,11 @@ public sealed class CommandHandler : IDisposable
         }
 
         BeanBotLog.CommandsInstalling(_logger);
+        await _commandService.AddModulesAsync(assembly: Assembly.GetEntryAssembly() ?? typeof(CommandHandler).Assembly,
+                                              services: _services);
         _discordClient.MessageReceived += HandleCommandAsync;
         _commandService.CommandExecuted += _logHandler.LogCommands;
         _commandService.CommandExecuted += _feedbackResponder.RespondAsync;
-        await _commandService.AddModulesAsync(assembly: Assembly.GetEntryAssembly() ?? typeof(CommandHandler).Assembly,
-                                              services: _services);
         _initialized = true;
     }
 

--- a/BeanBot/Hosting/BeanBotServiceCollectionExtensions.cs
+++ b/BeanBot/Hosting/BeanBotServiceCollectionExtensions.cs
@@ -99,6 +99,10 @@ internal static class BeanBotServiceCollectionExtensions
             provider.GetRequiredService<DiscordOwnerErrorNotifier>());
         services.AddSingleton<DiscordOutageRecoveryNotifier>();
         services.AddSingleton<LogHandler>();
+        services.AddSingleton<DiscordLegacyCommandFeedbackDelivery>();
+        services.AddSingleton<ILegacyCommandFeedbackDelivery>(provider =>
+            provider.GetRequiredService<DiscordLegacyCommandFeedbackDelivery>());
+        services.AddSingleton<LegacyCommandFeedbackResponder>();
 
         services.AddSingleton<DiscordGatewayRecoveryService>(provider =>
         {

--- a/BeanBot/Logging/CommandFeedbackLog.cs
+++ b/BeanBot/Logging/CommandFeedbackLog.cs
@@ -1,0 +1,15 @@
+using Discord.Commands;
+using Microsoft.Extensions.Logging;
+
+namespace BeanBot.Logging;
+
+internal static partial class BeanBotLog
+{
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Could not send legacy command failure feedback. CommandError={CommandError}")]
+    internal static partial void LegacyCommandFeedbackDeliveryFailed(
+        ILogger logger,
+        CommandError? commandError,
+        Exception exception);
+}


### PR DESCRIPTION
Closes #141.

## Summary
- add a dedicated legacy command feedback responder alongside the existing structured command logger
- return concise safe feedback for unknown commands, argument/parser/object lookup failures, unmet preconditions, and unexpected execution failures
- include canonical `%command <arg>` usage guidance when Discord.Net provides matched command metadata
- suppress all mentions in feedback responses and bound messages to 500 characters
- bound Discord feedback delivery waits to 10 seconds and observe late task faults
- log feedback-delivery failures at Warning so they remain observable without recursively triggering owner Error/Fatal alerts
- preserve `%`, `succ `, and mention-prefix routing, successful-command behavior, and slash-command behavior
- install command modules before wiring Discord/CommandService event handlers so a failed module load cannot leave duplicate subscriptions behind on retry

## Tests
- unknown-command feedback and raw-reason non-disclosure
- argument failures with and without command metadata
- safe precondition and unexpected-failure messaging
- success path emits no extra feedback
- feedback-delivery failure is warning-only and non-recursive
- message length bound, mention suppression configuration, and bounded send timeout
- existing routing tests continue to prove `%`, `succ `, and mention prefixes all use the shared legacy command execution path

## Review fix
- fresh verification/review caught that `InitializeCommandsAsync` subscribed handlers before `AddModulesAsync` completed; if module loading failed, `_initialized` stayed false while handlers remained attached, allowing duplicate subscriptions on retry and incomplete cleanup
- corrected the ordering so module installation completes first, then `MessageReceived`/`CommandExecuted` handlers are attached and `_initialized` is set
- the Copilot review thread covering the same lifecycle issue is resolved

## Verification
- final head `6ef1e6e665cde077ec6502f838106451d0d0ec0e`
- Repository Verification run #228: `./scripts/verify.sh full` passed
- 419 tests passed, 0 failed, 0 skipped
- coverage gate passed (lines 65.53% >= 64.67% minimum; branches 53.83% >= 52.69% minimum)
- vulnerable NuGet package scan passed
- hardened Docker image build, runtime smoke test, and SIGTERM shutdown smoke test passed
- CodeQL run #60 passed
- Dependency Review run #50 passed
- fresh post-fix Verifier: PASS
- fresh post-fix Reviewer: CLEAN
- all review threads resolved

Local repository execution is unavailable in the automation environment because outbound GitHub DNS access is blocked; GitHub Actions for the final PR head supplied the required full verification evidence under the repository workflow.

## Manual validation
After deployment, smoke-test one invalid command through each legacy prefix (`%`, `succ `, and mention-prefix) and one argument/precondition failure to confirm the expected safe response renders correctly in Discord and does not generate mentions.
