### PR TITLE
Make reflected command output mention-safe

### DIFF
--- a/BeanBot.Tests/Discord/Commands/MemeModuleTests.cs
+++ b/BeanBot.Tests/Discord/Commands/MemeModuleTests.cs
@@ -47,7 +47,7 @@ public class MemeModuleTests
         var reply = MemeModule.CreateMentionSafeReply(content);
 
         Assert.Equal(content, reply.Content);
-        Assert.Same(AllowedMentions.None, reply.AllowedMentions);
+        AssertMentionsDisabled(reply.AllowedMentions);
     }
 
     [Fact]
@@ -59,7 +59,7 @@ public class MemeModuleTests
         var reply = MemeModule.CreateMentionSafeReply(content);
 
         Assert.Equal("*succ succ succ* lol you're gay <@&123456789>", reply.Content);
-        Assert.Same(AllowedMentions.None, reply.AllowedMentions);
+        AssertMentionsDisabled(reply.AllowedMentions);
     }
 
     [Fact]
@@ -71,6 +71,16 @@ public class MemeModuleTests
         var reply = MemeModule.CreateMentionSafeReply(content);
 
         Assert.Equal("> will @everyone and <@987654321> have a good day? \nYeehaw", reply.Content);
-        Assert.Same(AllowedMentions.None, reply.AllowedMentions);
+        AssertMentionsDisabled(reply.AllowedMentions);
+    }
+
+    private static void AssertMentionsDisabled(AllowedMentions allowedMentions)
+    {
+        var parsedTypes = allowedMentions.AllowedTypes ?? AllowedMentionTypes.None;
+        var notificationTypes = AllowedMentionTypes.Users | AllowedMentionTypes.Roles | AllowedMentionTypes.Everyone;
+
+        Assert.Equal(AllowedMentionTypes.None, parsedTypes & notificationTypes);
+        Assert.True(allowedMentions.UserIds is null || allowedMentions.UserIds.Count == 0);
+        Assert.True(allowedMentions.RoleIds is null || allowedMentions.RoleIds.Count == 0);
     }
 }

--- a/BeanBot.Tests/Discord/Commands/MemeModuleTests.cs
+++ b/BeanBot.Tests/Discord/Commands/MemeModuleTests.cs
@@ -1,4 +1,5 @@
 using BeanBot.Discord.Commands;
+using Discord;
 using Xunit;
 
 namespace BeanBot.Tests.Discord.Commands;
@@ -33,5 +34,43 @@ public class MemeModuleTests
 
         Assert.Equal("@friend", result);
         Assert.Equal(new[] { "succ", "@friend" }, input);
+    }
+
+    [Theory]
+    [InlineData("@everyone")]
+    [InlineData("@here")]
+    [InlineData("<@&123456789>")]
+    [InlineData("<@987654321>")]
+    [InlineData("plain text")]
+    public void CreateMentionSafeReply_PreservesContentAndUsesDiscordNoMentionPolicy(string content)
+    {
+        var reply = MemeModule.CreateMentionSafeReply(content);
+
+        Assert.Equal(content, reply.Content);
+        Assert.Same(AllowedMentions.None, reply.AllowedMentions);
+    }
+
+    [Fact]
+    public void CreateMentionSafeReply_SuccRoleTarget_PreservesVisibleTargetWithoutNotificationPolicy()
+    {
+        var target = MemeModule.NormalizeSuccTarget(new[] { "<@&123456789>" }, "<@987654321>");
+        var content = $"*succ succ succ* lol you're gay {target}";
+
+        var reply = MemeModule.CreateMentionSafeReply(content);
+
+        Assert.Equal("*succ succ succ* lol you're gay <@&123456789>", reply.Content);
+        Assert.Same(AllowedMentions.None, reply.AllowedMentions);
+    }
+
+    [Fact]
+    public void CreateMentionSafeReply_FortuneQuestion_PreservesQuotedMentionsWithoutNotificationPolicy()
+    {
+        const string question = "will @everyone and <@987654321> have a good day?";
+        var content = $"> {question} \nYeehaw";
+
+        var reply = MemeModule.CreateMentionSafeReply(content);
+
+        Assert.Equal("> will @everyone and <@987654321> have a good day? \nYeehaw", reply.Content);
+        Assert.Same(AllowedMentions.None, reply.AllowedMentions);
     }
 }

--- a/BeanBot/Discord/Commands/MemeModule.cs
+++ b/BeanBot/Discord/Commands/MemeModule.cs
@@ -65,7 +65,7 @@ public class MemeModule : ModuleBase<SocketCommandContext>
     public async Task UserSucc([Summary("The (optional) user to succ")] params string[] input)
     {
         var userToSucc = NormalizeSuccTarget(input, Context.Message.Author.Mention);
-        await ReplyAsync($"*succ succ succ* lol you're gay {userToSucc}");
+        await ReplyWithReflectedContentAsync($"*succ succ succ* lol you're gay {userToSucc}");
     }
 
     [Command("2am")]
@@ -131,7 +131,7 @@ public class MemeModule : ModuleBase<SocketCommandContext>
         {
             BeanBotLog.EchoSourceDeleteFailed(_logger, Context.Message.Id, exception);
         }
-        await ReplyAsync(text);
+        await ReplyWithReflectedContentAsync(text);
     }
 
     [Command("8ball")]
@@ -239,7 +239,7 @@ public class MemeModule : ModuleBase<SocketCommandContext>
         if (responseOverride != null)
         {
             var hasQueuedAnswer = _fortuneAnswers.TryReserve(Context.Message.Author.Id, out var reservation);
-            await ReplyAsync($"> {question} \n{responseOverride}");
+            await ReplyWithReflectedContentAsync($"> {question} \n{responseOverride}");
             if (hasQueuedAnswer)
             {
                 _fortuneAnswers.Consume(reservation);
@@ -258,19 +258,19 @@ public class MemeModule : ModuleBase<SocketCommandContext>
                     if (reservation.Answer == "positive")
                     {
                         var answer = EightBallResponses[Random.Shared.Next(0, 3)];
-                        await ReplyAsync($"> {question} \n{answer}");
+                        await ReplyWithReflectedContentAsync($"> {question} \n{answer}");
                     }
                     else
                     {
                         var answer = EightBallResponses[Random.Shared.Next(3, 5)];
-                        await ReplyAsync($"> {question} \n{answer}");
+                        await ReplyWithReflectedContentAsync($"> {question} \n{answer}");
                     }
                     _fortuneAnswers.Consume(reservation);
                 }
                 else
                 {
                     var answer = EightBallResponses[Random.Shared.Next(EightBallResponses.Length)];
-                    await ReplyAsync($"> {question} \n{answer}");
+                    await ReplyWithReflectedContentAsync($"> {question} \n{answer}");
                 }
             }
         }
@@ -278,14 +278,18 @@ public class MemeModule : ModuleBase<SocketCommandContext>
         {
             var gordonGif = Random.Shared.Next(1, 9);
             var rejection = $"> {question} \nThat is not a question";
+            var safeRejection = CreateMentionSafeReply(rejection);
             try
             {
-                await Context.Channel.SendFileAsync($"Resources/gordon{gordonGif}.gif", rejection);
+                await Context.Channel.SendFileAsync(
+                    $"Resources/gordon{gordonGif}.gif",
+                    safeRejection.Content,
+                    allowedMentions: safeRejection.AllowedMentions);
             }
             catch (Exception exception)
             {
                 BeanBotLog.GordonAttachmentFailed(_logger, exception);
-                await ReplyAsync(rejection);
+                await ReplyWithReflectedContentAsync(rejection);
             }
         }
     }
@@ -296,7 +300,7 @@ public class MemeModule : ModuleBase<SocketCommandContext>
             question.Contains("rigged", StringComparison.OrdinalIgnoreCase) && !question.Contains("not", StringComparison.OrdinalIgnoreCase) ||
             question.Contains("ban", StringComparison.OrdinalIgnoreCase) && question.Contains("padoru", StringComparison.OrdinalIgnoreCase) && !question.Contains("not", StringComparison.OrdinalIgnoreCase))
         {
-            await ReplyAsync($"> {question} \nThe spirit of Texas tells me No");
+            await ReplyWithReflectedContentAsync($"> {question} \nThe spirit of Texas tells me No");
         }
         else
         {
@@ -304,17 +308,17 @@ public class MemeModule : ModuleBase<SocketCommandContext>
             if (chance >= 1 && chance <= 10)
             {
                 var positiveAns = EightBallResponses[Random.Shared.Next(0, 3)];
-                await ReplyAsync($"> {question} \n{positiveAns}");
+                await ReplyWithReflectedContentAsync($"> {question} \n{positiveAns}");
             }
             else if (chance > 10 && chance <= 40)
             {
                 var negativeAns = EightBallResponses[Random.Shared.Next(3, 5)];
-                await ReplyAsync($"> {question} \n{negativeAns}");
+                await ReplyWithReflectedContentAsync($"> {question} \n{negativeAns}");
             }
             else
             {
                 var succAns = EightBallResponses[Random.Shared.Next(5, 8)];
-                await ReplyAsync($"> {question} \n{succAns}");
+                await ReplyWithReflectedContentAsync($"> {question} \n{succAns}");
             }
         }
     }
@@ -357,6 +361,18 @@ public class MemeModule : ModuleBase<SocketCommandContext>
         }
 
         return target;
+    }
+
+    internal static (string Content, AllowedMentions AllowedMentions) CreateMentionSafeReply(string content)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        return (content, AllowedMentions.None);
+    }
+
+    private Task<IUserMessage> ReplyWithReflectedContentAsync(string content)
+    {
+        var reply = CreateMentionSafeReply(content);
+        return ReplyAsync(reply.Content, allowedMentions: reply.AllowedMentions);
     }
 
     private async Task ReplyWithOchoOcho()


### PR DESCRIPTION
Closes #143.

## Summary
- suppress Discord mention notifications when `%echo`, `%succ`, and `8ball`/`fortune` reflect user-controlled text
- preserve the visible response text while applying Discord.Net's native `AllowedMentions.None` policy at the send boundary
- cover the Gordon GIF attachment caption and fallback path as well as every fortune response branch
- keep static bot-authored responses and unrelated command/error/lifecycle behavior unchanged

## Tests
- cover `@everyone`, `@here`, role mention syntax, user mention syntax, and ordinary text
- verify free-form `%succ` role targets preserve visible text while all notification-producing mention types and explicit mention allowlists remain disabled
- verify quoted fortune questions preserve their text under the same no-mention policy
- retain the existing `%succ` normalization regression coverage

## Verification
- final head `ea043b587a866e5e3f5178e0ec9bf225fd1de715`
- Repository Verification run #230: `./scripts/verify.sh full` passed
- 414 tests passed, 0 failed, 0 skipped
- coverage gate passed (lines 65.37% >= 64.67% minimum; branches 53.40% >= 52.69% minimum)
- formatting/analyzers and Release build passed with 0 warnings / 0 errors
- vulnerable NuGet package scan passed
- hardened Docker image build, runtime smoke test, and SIGTERM shutdown smoke test passed
- CodeQL run #62 passed
- Dependency Review run #52 passed

## Independent review pass
- fresh Verifier rechecked the final diff against issue #143's acceptance criteria, branch policy, and exact-head CI evidence: **PASS**
- fresh independent Reviewer inspected the final diff and surrounding command behavior for security, lifecycle, reliability, test, Docker/runtime, dependency, and release-workflow regressions: **CLEAN**
- no additional repair commit was required during this review pass
- no review threads are open
- ordinary branch policy is satisfied: `fix/issue-143-mention-safe-output` targets the current `develop` head

Local repository execution was unavailable in the automation environment because outbound GitHub DNS resolution was blocked. Exact-head GitHub Actions supplied the required full verification evidence under repository policy.

## Manual validation
After deployment, smoke-test `%echo @everyone`, free-form `%succ` input containing an everyone/role/user mention, and an `8ball`/`fortune` question containing mention syntax in a safe test channel. Confirm the mention text still renders normally but BeanBot does not generate everyone, role, or user notifications. Also exercise the invalid-question Gordon GIF path so its reflected caption is covered at runtime.