### PR TITLE
Bound external media command I/O

### DIFF
--- a/BeanBot.Tests/Discord/Commands/BoundedDiscordFileSenderTests.cs
+++ b/BeanBot.Tests/Discord/Commands/BoundedDiscordFileSenderTests.cs
@@ -21,12 +21,12 @@ public class BoundedDiscordFileSenderTests
                 await stream.CopyToAsync(copy);
                 sentContent = copy.ToArray();
             },
-            new byte[] { 1, 2, 3 },
+            [1, 2, 3],
             TimeSpan.FromSeconds(1),
             CancellationToken.None);
 
         Assert.Equal(1, calls);
-        Assert.Equal(new byte[] { 1, 2, 3 }, sentContent);
+        Assert.Equal([1, 2, 3], sentContent);
     }
 
     [Fact]
@@ -43,7 +43,7 @@ public class BoundedDiscordFileSenderTests
                 requestToken = requestOptions.CancelToken;
                 return completion.Task;
             },
-            new byte[] { 1 },
+            [1],
             TimeSpan.FromMilliseconds(50),
             CancellationToken.None));
 
@@ -67,7 +67,7 @@ public class BoundedDiscordFileSenderTests
                 calls++;
                 return completion.Task;
             },
-            new byte[] { 1 },
+            [1],
             TimeSpan.FromSeconds(5),
             cancellation.Token);
 

--- a/BeanBot.Tests/Discord/Commands/BoundedDiscordFileSenderTests.cs
+++ b/BeanBot.Tests/Discord/Commands/BoundedDiscordFileSenderTests.cs
@@ -1,0 +1,82 @@
+using BeanBot.Discord.Commands;
+using Discord;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.Commands;
+
+public class BoundedDiscordFileSenderTests
+{
+    [Fact]
+    public async Task SendAsync_Success_SendsContentOnce()
+    {
+        var calls = 0;
+        byte[]? sentContent = null;
+
+        await BoundedDiscordFileSender.SendAsync(
+            async (stream, requestOptions) =>
+            {
+                calls++;
+                Assert.False(requestOptions.CancelToken.IsCancellationRequested);
+                using var copy = new MemoryStream();
+                await stream.CopyToAsync(copy);
+                sentContent = copy.ToArray();
+            },
+            new byte[] { 1, 2, 3 },
+            TimeSpan.FromSeconds(1),
+            CancellationToken.None);
+
+        Assert.Equal(1, calls);
+        Assert.Equal(new byte[] { 1, 2, 3 }, sentContent);
+    }
+
+    [Fact]
+    public async Task SendAsync_StalledUpload_TimesOutWithoutRetryAndCancelsRequest()
+    {
+        var calls = 0;
+        CancellationToken requestToken = default;
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await Assert.ThrowsAsync<TimeoutException>(() => BoundedDiscordFileSender.SendAsync(
+            (_, requestOptions) =>
+            {
+                calls++;
+                requestToken = requestOptions.CancelToken;
+                return completion.Task;
+            },
+            new byte[] { 1 },
+            TimeSpan.FromMilliseconds(50),
+            CancellationToken.None));
+
+        Assert.Equal(1, calls);
+        Assert.True(requestToken.IsCancellationRequested);
+
+        completion.SetException(new InvalidOperationException("late upload failure"));
+        await Task.Yield();
+    }
+
+    [Fact]
+    public async Task SendAsync_CallerCancellation_IsNotReportedAsTimeout()
+    {
+        var calls = 0;
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cancellation = new CancellationTokenSource();
+
+        var send = BoundedDiscordFileSender.SendAsync(
+            (_, _) =>
+            {
+                calls++;
+                return completion.Task;
+            },
+            new byte[] { 1 },
+            TimeSpan.FromSeconds(5),
+            cancellation.Token);
+
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => send);
+        Assert.Equal(1, calls);
+
+        completion.SetException(new InvalidOperationException("late upload failure"));
+        await Task.Yield();
+    }
+}

--- a/BeanBot.Tests/Discord/Commands/ExternalImageClientTests.cs
+++ b/BeanBot.Tests/Discord/Commands/ExternalImageClientTests.cs
@@ -10,7 +10,7 @@ public class ExternalImageClientTests
     [Fact]
     public async Task DownloadImageAsync_NormalImage_ReturnsContent()
     {
-        var expected = new byte[] { 1, 2, 3, 4 };
+        byte[] expected = [1, 2, 3, 4];
         using var httpClient = CreateHttpClient(_ => CreateResponse(expected, "image/png"));
         using var client = new ExternalImageClient(httpClient, CreateOptions(maxImageBytes: 16));
 
@@ -24,7 +24,7 @@ public class ExternalImageClientTests
     [Fact]
     public async Task DownloadImageAsync_DeclaredLengthExceedsLimit_RejectsPayload()
     {
-        using var httpClient = CreateHttpClient(_ => CreateResponse(new byte[5], "image/png"));
+        using var httpClient = CreateHttpClient(_ => CreateResponse([0, 0, 0, 0, 0], "image/png"));
         using var client = new ExternalImageClient(httpClient, CreateOptions(maxImageBytes: 4));
 
         await Assert.ThrowsAsync<ExternalMediaPayloadTooLargeException>(() =>
@@ -36,7 +36,7 @@ public class ExternalImageClientTests
     [Fact]
     public async Task DownloadImageAsync_UnknownLengthExceedsLimit_RejectsPayload()
     {
-        var stream = new NonSeekableReadStream(new byte[] { 1, 2, 3, 4, 5 });
+        var stream = new NonSeekableReadStream([1, 2, 3, 4, 5]);
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StreamContent(stream)
@@ -55,7 +55,7 @@ public class ExternalImageClientTests
     [Fact]
     public async Task DownloadImageAsync_NonImageResponse_RejectsPayload()
     {
-        using var httpClient = CreateHttpClient(_ => CreateResponse(new byte[] { 1 }, "text/plain"));
+        using var httpClient = CreateHttpClient(_ => CreateResponse([1], "text/plain"));
         using var client = new ExternalImageClient(httpClient, CreateOptions());
 
         await Assert.ThrowsAsync<InvalidDataException>(() =>

--- a/BeanBot.Tests/Discord/Commands/ExternalImageClientTests.cs
+++ b/BeanBot.Tests/Discord/Commands/ExternalImageClientTests.cs
@@ -1,0 +1,204 @@
+using System.Net;
+using System.Net.Http.Headers;
+using BeanBot.Discord.Commands;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.Commands;
+
+public class ExternalImageClientTests
+{
+    [Fact]
+    public async Task DownloadImageAsync_NormalImage_ReturnsContent()
+    {
+        var expected = new byte[] { 1, 2, 3, 4 };
+        using var httpClient = CreateHttpClient(_ => CreateResponse(expected, "image/png"));
+        using var client = new ExternalImageClient(httpClient, CreateOptions(maxImageBytes: 16));
+
+        var result = await client.DownloadImageAsync(
+            new Uri("https://example.test/image.png"),
+            CancellationToken.None);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public async Task DownloadImageAsync_DeclaredLengthExceedsLimit_RejectsPayload()
+    {
+        using var httpClient = CreateHttpClient(_ => CreateResponse(new byte[5], "image/png"));
+        using var client = new ExternalImageClient(httpClient, CreateOptions(maxImageBytes: 4));
+
+        await Assert.ThrowsAsync<ExternalMediaPayloadTooLargeException>(() =>
+            client.DownloadImageAsync(
+                new Uri("https://example.test/image.png"),
+                CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task DownloadImageAsync_UnknownLengthExceedsLimit_RejectsPayload()
+    {
+        var stream = new NonSeekableReadStream(new byte[] { 1, 2, 3, 4, 5 });
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamContent(stream)
+        };
+        response.Content.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+
+        using var httpClient = CreateHttpClient(_ => response);
+        using var client = new ExternalImageClient(httpClient, CreateOptions(maxImageBytes: 4));
+
+        await Assert.ThrowsAsync<ExternalMediaPayloadTooLargeException>(() =>
+            client.DownloadImageAsync(
+                new Uri("https://example.test/chunked-image"),
+                CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task DownloadImageAsync_NonImageResponse_RejectsPayload()
+    {
+        using var httpClient = CreateHttpClient(_ => CreateResponse(new byte[] { 1 }, "text/plain"));
+        using var client = new ExternalImageClient(httpClient, CreateOptions());
+
+        await Assert.ThrowsAsync<InvalidDataException>(() =>
+            client.DownloadImageAsync(
+                new Uri("https://example.test/not-image"),
+                CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task DownloadImageAsync_StalledBody_TimesOut()
+    {
+        var stalledStream = new StalledReadStream();
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamContent(stalledStream)
+        };
+        response.Content.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+
+        using var httpClient = CreateHttpClient(_ => response);
+        using var client = new ExternalImageClient(
+            httpClient,
+            CreateOptions(imageDownloadTimeout: TimeSpan.FromMilliseconds(50)));
+
+        await Assert.ThrowsAsync<TimeoutException>(() =>
+            client.DownloadImageAsync(
+                new Uri("https://example.test/stalled-image"),
+                CancellationToken.None));
+
+        stalledStream.Fail(new InvalidOperationException("late read failure"));
+        await Task.Yield();
+    }
+
+    [Fact]
+    public async Task DownloadImageAsync_CallerCancellation_IsNotReportedAsTimeout()
+    {
+        var stalledStream = new StalledReadStream();
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamContent(stalledStream)
+        };
+        response.Content.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+
+        using var httpClient = CreateHttpClient(_ => response);
+        using var client = new ExternalImageClient(
+            httpClient,
+            CreateOptions(imageDownloadTimeout: TimeSpan.FromSeconds(5)));
+        using var cancellation = new CancellationTokenSource();
+
+        var download = client.DownloadImageAsync(
+            new Uri("https://example.test/stalled-image"),
+            cancellation.Token);
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => download);
+        stalledStream.Fail(new InvalidOperationException("late read failure"));
+        await Task.Yield();
+    }
+
+    private static ExternalMediaCommandOptions CreateOptions(
+        TimeSpan? imageDownloadTimeout = null,
+        int maxImageBytes = 1024)
+        => new(
+            imageDownloadTimeout ?? TimeSpan.FromSeconds(1),
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromSeconds(1),
+            maxImageBytes);
+
+    private static HttpClient CreateHttpClient(Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
+        => new(new StubHttpMessageHandler((request, _) => Task.FromResult(responseFactory(request))));
+
+    private static HttpResponseMessage CreateResponse(byte[] content, string mediaType)
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(content)
+        };
+        response.Content.Headers.ContentType = new MediaTypeHeaderValue(mediaType);
+        return response;
+    }
+
+    private sealed class StubHttpMessageHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> sendAsync) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+            => sendAsync(request, cancellationToken);
+    }
+
+    private sealed class NonSeekableReadStream(byte[] content) : Stream
+    {
+        private readonly MemoryStream _inner = new(content, writable: false);
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() => throw new NotSupportedException();
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            => _inner.ReadAsync(buffer, cancellationToken);
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inner.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class StalledReadStream : Stream
+    {
+        private readonly TaskCompletionSource<int> _readCompletion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        internal void Fail(Exception exception) => _readCompletion.TrySetException(exception);
+
+        public override void Flush() => throw new NotSupportedException();
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            => new(_readCompletion.Task);
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}

--- a/BeanBot.Tests/Discord/Commands/MemeModuleTests.cs
+++ b/BeanBot.Tests/Discord/Commands/MemeModuleTests.cs
@@ -74,6 +74,15 @@ public class MemeModuleTests
         AssertMentionsDisabled(reply.AllowedMentions);
     }
 
+    [Fact]
+    public void GetSafeMediaSource_RemovesQueryAndUserInfo()
+    {
+        var source = MemeModule.GetSafeMediaSource(
+            new Uri("https://user:secret@example.test/images/toes.png?signature=top-secret#fragment"));
+
+        Assert.Equal("https://example.test/images/toes.png", source);
+    }
+
     private static void AssertMentionsDisabled(AllowedMentions allowedMentions)
     {
         var parsedTypes = allowedMentions.AllowedTypes ?? AllowedMentionTypes.None;

--- a/BeanBot.Tests/Discord/Commands/MemeProviderTests.cs
+++ b/BeanBot.Tests/Discord/Commands/MemeProviderTests.cs
@@ -1,0 +1,62 @@
+using BeanBot.Discord.Commands;
+using MemeApiDotNetWrapper;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.Commands;
+
+public class MemeProviderTests
+{
+    [Fact]
+    public async Task GetMemeAsync_Success_ForwardsSubreddit()
+    {
+        string? receivedSubreddit = null;
+        var provider = new MemeProvider(
+            subreddit =>
+            {
+                receivedSubreddit = subreddit;
+                return Task.FromResult<Meme?>(null);
+            },
+            TimeSpan.FromSeconds(1));
+
+        var result = await provider.GetMemeAsync("memes", CancellationToken.None);
+
+        Assert.Null(result);
+        Assert.Equal("memes", receivedSubreddit);
+    }
+
+    [Fact]
+    public async Task GetMemeAsync_StalledRequest_TimesOutWithoutRetry()
+    {
+        var calls = 0;
+        var completion = new TaskCompletionSource<Meme?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var provider = new MemeProvider(
+            _ =>
+            {
+                calls++;
+                return completion.Task;
+            },
+            TimeSpan.FromMilliseconds(50));
+
+        await Assert.ThrowsAsync<TimeoutException>(() =>
+            provider.GetMemeAsync(string.Empty, CancellationToken.None));
+
+        Assert.Equal(1, calls);
+        completion.SetException(new InvalidOperationException("late API failure"));
+        await Task.Yield();
+    }
+
+    [Fact]
+    public async Task GetMemeAsync_CallerCancellation_IsNotReportedAsTimeout()
+    {
+        var completion = new TaskCompletionSource<Meme?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var provider = new MemeProvider(_ => completion.Task, TimeSpan.FromSeconds(5));
+        using var cancellation = new CancellationTokenSource();
+
+        var request = provider.GetMemeAsync(string.Empty, cancellation.Token);
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => request);
+        completion.SetException(new InvalidOperationException("late API failure"));
+        await Task.Yield();
+    }
+}

--- a/BeanBot/Discord/Commands/BoundedDiscordFileSender.cs
+++ b/BeanBot/Discord/Commands/BoundedDiscordFileSender.cs
@@ -1,0 +1,29 @@
+using Discord;
+
+namespace BeanBot.Discord.Commands;
+
+internal static class BoundedDiscordFileSender
+{
+    internal static async Task SendAsync(
+        Func<Stream, RequestOptions, Task> sendFile,
+        byte[] content,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(sendFile);
+        ArgumentNullException.ThrowIfNull(content);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(timeout, TimeSpan.Zero);
+
+        using var contentStream = new MemoryStream(content, writable: false);
+        await ExternalMediaOperationGuard.RunAsync(
+            token => sendFile(
+                contentStream,
+                new RequestOptions
+                {
+                    CancelToken = token
+                }),
+            timeout,
+            cancellationToken,
+            "Discord media upload timed out.");
+    }
+}

--- a/BeanBot/Discord/Commands/BoundedDiscordFileSender.cs
+++ b/BeanBot/Discord/Commands/BoundedDiscordFileSender.cs
@@ -23,7 +23,7 @@ internal static class BoundedDiscordFileSender
                     CancelToken = token
                 }),
             timeout,
-            cancellationToken,
-            "Discord media upload timed out.");
+            "Discord media upload timed out.",
+            cancellationToken);
     }
 }

--- a/BeanBot/Discord/Commands/ExternalImageClient.cs
+++ b/BeanBot/Discord/Commands/ExternalImageClient.cs
@@ -42,8 +42,8 @@ internal sealed class ExternalImageClient : IExternalImageClient, IDisposable
         return ExternalMediaOperationGuard.RunAsync(
             token => DownloadImageCoreAsync(imageUrl, token),
             _options.ImageDownloadTimeout,
-            cancellationToken,
-            "External image download timed out.");
+            "External image download timed out.",
+            cancellationToken);
     }
 
     private async Task<byte[]> DownloadImageCoreAsync(Uri imageUrl, CancellationToken cancellationToken)

--- a/BeanBot/Discord/Commands/ExternalImageClient.cs
+++ b/BeanBot/Discord/Commands/ExternalImageClient.cs
@@ -3,7 +3,7 @@ using System.Net.Http.Headers;
 
 namespace BeanBot.Discord.Commands;
 
-internal interface IExternalImageClient
+public interface IExternalImageClient
 {
     Task<byte[]> DownloadImageAsync(Uri imageUrl, CancellationToken cancellationToken);
 }
@@ -130,7 +130,7 @@ internal sealed class ExternalImageClient : IExternalImageClient, IDisposable
     }
 }
 
-internal sealed class ExternalMediaPayloadTooLargeException : InvalidDataException
+internal sealed class ExternalMediaPayloadTooLargeException : IOException
 {
     internal ExternalMediaPayloadTooLargeException(int maximumBytes)
         : base($"External image exceeded the {maximumBytes}-byte download limit.")

--- a/BeanBot/Discord/Commands/ExternalImageClient.cs
+++ b/BeanBot/Discord/Commands/ExternalImageClient.cs
@@ -65,14 +65,15 @@ internal sealed class ExternalImageClient : IExternalImageClient, IDisposable
 
         await using var source = await response.Content.ReadAsStreamAsync(cancellationToken);
         using var destination = new MemoryStream(GetInitialCapacity(declaredLength));
-        var buffer = ArrayPool<byte>.Shared.Rent(Math.Min(ReadBufferSize, _options.MaxImageBytes + 1));
+        var bufferSize = (int)Math.Min(ReadBufferSize, (long)_options.MaxImageBytes + 1);
+        var buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
         try
         {
             var totalBytes = 0;
             while (true)
             {
-                var remainingWithSentinel = _options.MaxImageBytes - totalBytes + 1;
-                var bytesToRead = Math.Min(buffer.Length, remainingWithSentinel);
+                var remainingWithSentinel = (long)_options.MaxImageBytes - totalBytes + 1;
+                var bytesToRead = (int)Math.Min(buffer.Length, remainingWithSentinel);
                 var bytesRead = await source.ReadAsync(
                     buffer.AsMemory(0, bytesToRead),
                     cancellationToken);

--- a/BeanBot/Discord/Commands/ExternalImageClient.cs
+++ b/BeanBot/Discord/Commands/ExternalImageClient.cs
@@ -1,0 +1,138 @@
+using System.Buffers;
+using System.Net.Http.Headers;
+
+namespace BeanBot.Discord.Commands;
+
+internal interface IExternalImageClient
+{
+    Task<byte[]> DownloadImageAsync(Uri imageUrl, CancellationToken cancellationToken);
+}
+
+internal sealed class ExternalImageClient : IExternalImageClient, IDisposable
+{
+    private const int ReadBufferSize = 64 * 1024;
+
+    private readonly HttpClient _httpClient;
+    private readonly ExternalMediaCommandOptions _options;
+    private readonly bool _ownsHttpClient;
+
+    public ExternalImageClient(ExternalMediaCommandOptions options)
+        : this(new HttpClient(), options, ownsHttpClient: true)
+    {
+    }
+
+    internal ExternalImageClient(
+        HttpClient httpClient,
+        ExternalMediaCommandOptions options,
+        bool ownsHttpClient = false)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _ownsHttpClient = ownsHttpClient;
+    }
+
+    public Task<byte[]> DownloadImageAsync(Uri imageUrl, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(imageUrl);
+        if (!imageUrl.IsAbsoluteUri)
+        {
+            throw new ArgumentException("External image URL must be absolute.", nameof(imageUrl));
+        }
+
+        return ExternalMediaOperationGuard.RunAsync(
+            token => DownloadImageCoreAsync(imageUrl, token),
+            _options.ImageDownloadTimeout,
+            cancellationToken,
+            "External image download timed out.");
+    }
+
+    private async Task<byte[]> DownloadImageCoreAsync(Uri imageUrl, CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, imageUrl);
+        using var response = await _httpClient.SendAsync(
+            request,
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken);
+
+        response.EnsureSuccessStatusCode();
+        EnsureImageContentType(response.Content.Headers.ContentType);
+
+        var declaredLength = response.Content.Headers.ContentLength;
+        if (declaredLength > _options.MaxImageBytes)
+        {
+            throw new ExternalMediaPayloadTooLargeException(_options.MaxImageBytes);
+        }
+
+        await using var source = await response.Content.ReadAsStreamAsync(cancellationToken);
+        using var destination = new MemoryStream(GetInitialCapacity(declaredLength));
+        var buffer = ArrayPool<byte>.Shared.Rent(Math.Min(ReadBufferSize, _options.MaxImageBytes + 1));
+        try
+        {
+            var totalBytes = 0;
+            while (true)
+            {
+                var remainingWithSentinel = _options.MaxImageBytes - totalBytes + 1;
+                var bytesToRead = Math.Min(buffer.Length, remainingWithSentinel);
+                var bytesRead = await source.ReadAsync(
+                    buffer.AsMemory(0, bytesToRead),
+                    cancellationToken);
+
+                if (bytesRead == 0)
+                {
+                    break;
+                }
+
+                if (bytesRead > _options.MaxImageBytes - totalBytes)
+                {
+                    throw new ExternalMediaPayloadTooLargeException(_options.MaxImageBytes);
+                }
+
+                await destination.WriteAsync(
+                    buffer.AsMemory(0, bytesRead),
+                    cancellationToken);
+                totalBytes += bytesRead;
+            }
+
+            return destination.ToArray();
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private int GetInitialCapacity(long? declaredLength)
+    {
+        if (declaredLength is > 0 and <= int.MaxValue)
+        {
+            return (int)declaredLength.Value;
+        }
+
+        return Math.Min(64 * 1024, _options.MaxImageBytes);
+    }
+
+    private static void EnsureImageContentType(MediaTypeHeaderValue? contentType)
+    {
+        var mediaType = contentType?.MediaType;
+        if (mediaType is null || !mediaType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidDataException("External media response was not an image.");
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_ownsHttpClient)
+        {
+            _httpClient.Dispose();
+        }
+    }
+}
+
+internal sealed class ExternalMediaPayloadTooLargeException : InvalidDataException
+{
+    internal ExternalMediaPayloadTooLargeException(int maximumBytes)
+        : base($"External image exceeded the {maximumBytes}-byte download limit.")
+    {
+    }
+}

--- a/BeanBot/Discord/Commands/ExternalMediaCommandOptions.cs
+++ b/BeanBot/Discord/Commands/ExternalMediaCommandOptions.cs
@@ -1,0 +1,35 @@
+namespace BeanBot.Discord.Commands;
+
+internal sealed class ExternalMediaCommandOptions
+{
+    internal static ExternalMediaCommandOptions Default { get; } = new(
+        imageDownloadTimeout: TimeSpan.FromSeconds(10),
+        discordUploadTimeout: TimeSpan.FromSeconds(10),
+        memeApiTimeout: TimeSpan.FromSeconds(10),
+        maxImageBytes: 8 * 1024 * 1024);
+
+    internal ExternalMediaCommandOptions(
+        TimeSpan imageDownloadTimeout,
+        TimeSpan discordUploadTimeout,
+        TimeSpan memeApiTimeout,
+        int maxImageBytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(imageDownloadTimeout, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(discordUploadTimeout, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(memeApiTimeout, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(maxImageBytes, 0);
+
+        ImageDownloadTimeout = imageDownloadTimeout;
+        DiscordUploadTimeout = discordUploadTimeout;
+        MemeApiTimeout = memeApiTimeout;
+        MaxImageBytes = maxImageBytes;
+    }
+
+    internal TimeSpan ImageDownloadTimeout { get; }
+
+    internal TimeSpan DiscordUploadTimeout { get; }
+
+    internal TimeSpan MemeApiTimeout { get; }
+
+    internal int MaxImageBytes { get; }
+}

--- a/BeanBot/Discord/Commands/ExternalMediaCommandOptions.cs
+++ b/BeanBot/Discord/Commands/ExternalMediaCommandOptions.cs
@@ -1,6 +1,6 @@
 namespace BeanBot.Discord.Commands;
 
-internal sealed class ExternalMediaCommandOptions
+public sealed class ExternalMediaCommandOptions
 {
     internal static ExternalMediaCommandOptions Default { get; } = new(
         imageDownloadTimeout: TimeSpan.FromSeconds(10),

--- a/BeanBot/Discord/Commands/ExternalMediaOperationGuard.cs
+++ b/BeanBot/Discord/Commands/ExternalMediaOperationGuard.cs
@@ -1,0 +1,70 @@
+namespace BeanBot.Discord.Commands;
+
+internal static class ExternalMediaOperationGuard
+{
+    internal static async Task<T> RunAsync<T>(
+        Func<CancellationToken, Task<T>> operation,
+        TimeSpan timeout,
+        CancellationToken cancellationToken,
+        string timeoutMessage)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        ArgumentException.ThrowIfNullOrWhiteSpace(timeoutMessage);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(timeout, TimeSpan.Zero);
+
+        using var operationCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        operationCancellation.CancelAfter(timeout);
+
+        var operationTask = operation(operationCancellation.Token);
+        try
+        {
+            return await operationTask.WaitAsync(operationCancellation.Token);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            ObserveLateFault(operationTask);
+            throw;
+        }
+        catch (OperationCanceledException exception) when (operationCancellation.IsCancellationRequested)
+        {
+            ObserveLateFault(operationTask);
+            throw new TimeoutException(timeoutMessage, exception);
+        }
+    }
+
+    internal static async Task RunAsync(
+        Func<CancellationToken, Task> operation,
+        TimeSpan timeout,
+        CancellationToken cancellationToken,
+        string timeoutMessage)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+
+        await RunAsync(
+            async token =>
+            {
+                await operation(token);
+                return true;
+            },
+            timeout,
+            cancellationToken,
+            timeoutMessage);
+    }
+
+    internal static void ObserveLateFault(Task operationTask)
+    {
+        ArgumentNullException.ThrowIfNull(operationTask);
+
+        if (operationTask.IsCompleted)
+        {
+            _ = operationTask.Exception;
+            return;
+        }
+
+        _ = operationTask.ContinueWith(
+            completedTask => _ = completedTask.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+}

--- a/BeanBot/Discord/Commands/ExternalMediaOperationGuard.cs
+++ b/BeanBot/Discord/Commands/ExternalMediaOperationGuard.cs
@@ -11,6 +11,7 @@ internal static class ExternalMediaOperationGuard
         ArgumentNullException.ThrowIfNull(operation);
         ArgumentException.ThrowIfNullOrWhiteSpace(timeoutMessage);
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(timeout, TimeSpan.Zero);
+        cancellationToken.ThrowIfCancellationRequested();
 
         using var operationCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         operationCancellation.CancelAfter(timeout);

--- a/BeanBot/Discord/Commands/ExternalMediaOperationGuard.cs
+++ b/BeanBot/Discord/Commands/ExternalMediaOperationGuard.cs
@@ -5,8 +5,8 @@ internal static class ExternalMediaOperationGuard
     internal static async Task<T> RunAsync<T>(
         Func<CancellationToken, Task<T>> operation,
         TimeSpan timeout,
-        CancellationToken cancellationToken,
-        string timeoutMessage)
+        string timeoutMessage,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(operation);
         ArgumentException.ThrowIfNullOrWhiteSpace(timeoutMessage);
@@ -36,8 +36,8 @@ internal static class ExternalMediaOperationGuard
     internal static async Task RunAsync(
         Func<CancellationToken, Task> operation,
         TimeSpan timeout,
-        CancellationToken cancellationToken,
-        string timeoutMessage)
+        string timeoutMessage,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(operation);
 
@@ -48,8 +48,8 @@ internal static class ExternalMediaOperationGuard
                 return true;
             },
             timeout,
-            cancellationToken,
-            timeoutMessage);
+            timeoutMessage,
+            cancellationToken);
     }
 
     internal static void ObserveLateFault(Task operationTask)

--- a/BeanBot/Discord/Commands/MemeModule.cs
+++ b/BeanBot/Discord/Commands/MemeModule.cs
@@ -382,7 +382,7 @@ public class MemeModule : ModuleBase<SocketCommandContext>
             _logger,
             stage,
             GetSafeMediaSource(url),
-            exception);
+            exception.GetType().Name);
         await ReplyAsync("I couldn't download that image right now.");
     }
 

--- a/BeanBot/Discord/Commands/MemeModule.cs
+++ b/BeanBot/Discord/Commands/MemeModule.cs
@@ -1,9 +1,10 @@
-﻿using BeanBot.Configuration;
+using BeanBot.Configuration;
 using BeanBot.Discord.Messaging;
 using BeanBot.Logging;
 using Discord;
 using Discord.Commands;
 using MemeApiDotNetWrapper;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace BeanBot.Discord.Commands;
@@ -11,12 +12,14 @@ namespace BeanBot.Discord.Commands;
 [Name("Meme Commands")]
 public class MemeModule : ModuleBase<SocketCommandContext>
 {
-    private static readonly HttpClient HttpClient = new();
-    private readonly MemeMachine _memeMachine = new();
     private readonly BeanBotOptions _options;
     private readonly FortuneAnswerStore _fortuneAnswers;
     private readonly DiscordPaginatorService _paginator;
     private readonly IPunProvider _punProvider;
+    private readonly IExternalImageClient _externalImageClient;
+    private readonly IMemeProvider _memeProvider;
+    private readonly ExternalMediaCommandOptions _mediaOptions;
+    private readonly IHostApplicationLifetime _applicationLifetime;
     private readonly ILogger<MemeModule> _logger;
 
     public MemeModule(
@@ -24,12 +27,20 @@ public class MemeModule : ModuleBase<SocketCommandContext>
         FortuneAnswerStore fortuneAnswers,
         DiscordPaginatorService paginator,
         IPunProvider punProvider,
+        IExternalImageClient externalImageClient,
+        IMemeProvider memeProvider,
+        ExternalMediaCommandOptions mediaOptions,
+        IHostApplicationLifetime applicationLifetime,
         ILogger<MemeModule> logger)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _fortuneAnswers = fortuneAnswers ?? throw new ArgumentNullException(nameof(fortuneAnswers));
         _paginator = paginator ?? throw new ArgumentNullException(nameof(paginator));
         _punProvider = punProvider ?? throw new ArgumentNullException(nameof(punProvider));
+        _externalImageClient = externalImageClient ?? throw new ArgumentNullException(nameof(externalImageClient));
+        _memeProvider = memeProvider ?? throw new ArgumentNullException(nameof(memeProvider));
+        _mediaOptions = mediaOptions ?? throw new ArgumentNullException(nameof(mediaOptions));
+        _applicationLifetime = applicationLifetime ?? throw new ArgumentNullException(nameof(applicationLifetime));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -86,7 +97,6 @@ public class MemeModule : ModuleBase<SocketCommandContext>
     {
         await ReplyWithOchoOcho();
     }
-
 
     [Command("420")]
     [Summary("Astolfour-twenty blaze it")]
@@ -159,23 +169,22 @@ public class MemeModule : ModuleBase<SocketCommandContext>
     {
         await InvokeMemeApi(subreddit);
     }
+
     private async Task InvokeMemeApi(string subreddit)
     {
         Meme? meme;
+        var cancellationToken = _applicationLifetime.ApplicationStopping;
         try
         {
-            if (string.IsNullOrEmpty(subreddit))
-            {
-                meme = await _memeMachine.GetMemeAsync();
-            }
-            else
-            {
-                meme = await _memeMachine.GetMemeAsync(subreddit);
-            }
+            meme = await _memeProvider.GetMemeAsync(subreddit, cancellationToken);
         }
-        catch (Exception ex)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            BeanBotLog.MemeApiFailed(_logger, ex);
+            throw;
+        }
+        catch (Exception exception)
+        {
+            BeanBotLog.MemeApiFailed(_logger, exception);
             meme = null;
         }
 
@@ -220,7 +229,6 @@ public class MemeModule : ModuleBase<SocketCommandContext>
         var fact = TexasFactResponses[Random.Shared.Next(TexasFactResponses.Length)];
         await ReplyAsync($"Did you know: {fact}");
     }
-
 
     private async Task ChooseRandomPun()
     {
@@ -330,18 +338,60 @@ public class MemeModule : ModuleBase<SocketCommandContext>
 
     private async Task SendImageFromUrl(Uri url)
     {
+        var cancellationToken = _applicationLifetime.ApplicationStopping;
+        byte[] imageContent;
         try
         {
-            using var response = await HttpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
-            response.EnsureSuccessStatusCode();
-            using Stream image = await response.Content.ReadAsStreamAsync();
-            await Context.Channel.SendFileAsync(image, "image.png");
+            imageContent = await _externalImageClient.DownloadImageAsync(url, cancellationToken);
         }
-        catch (Exception ex)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            BeanBotLog.ImageDownloadFailed(_logger, url, ex);
-            await ReplyAsync("I couldn't download that image right now.");
+            throw;
         }
+        catch (Exception exception)
+        {
+            await HandleExternalMediaFailureAsync("download", url, exception);
+            return;
+        }
+
+        try
+        {
+            await BoundedDiscordFileSender.SendAsync(
+                async (stream, requestOptions) =>
+                    await Context.Channel.SendFileAsync(
+                        stream,
+                        "image.png",
+                        options: requestOptions),
+                imageContent,
+                _mediaOptions.DiscordUploadTimeout,
+                cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            await HandleExternalMediaFailureAsync("upload", url, exception);
+        }
+    }
+
+    private async Task HandleExternalMediaFailureAsync(string stage, Uri url, Exception exception)
+    {
+        BeanBotLog.ExternalMediaCommandFailed(
+            _logger,
+            stage,
+            GetSafeMediaSource(url),
+            exception);
+        await ReplyAsync("I couldn't download that image right now.");
+    }
+
+    internal static string GetSafeMediaSource(Uri url)
+    {
+        ArgumentNullException.ThrowIfNull(url);
+        return url.GetComponents(
+            UriComponents.SchemeAndServer | UriComponents.Path,
+            UriFormat.SafeUnescaped);
     }
 
     internal static string NormalizeSuccTarget(IEnumerable<string> input, string authorMention)

--- a/BeanBot/Discord/Commands/MemeProvider.cs
+++ b/BeanBot/Discord/Commands/MemeProvider.cs
@@ -1,0 +1,38 @@
+using MemeApiDotNetWrapper;
+
+namespace BeanBot.Discord.Commands;
+
+internal interface IMemeProvider
+{
+    Task<Meme?> GetMemeAsync(string subreddit, CancellationToken cancellationToken);
+}
+
+internal sealed class MemeProvider : IMemeProvider
+{
+    private readonly Func<string, Task<Meme?>> _getMeme;
+    private readonly TimeSpan _timeout;
+
+    public MemeProvider(ExternalMediaCommandOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var memeMachine = new MemeMachine();
+        _getMeme = subreddit => memeMachine.GetMemeAsync(
+            string.IsNullOrWhiteSpace(subreddit) ? null : subreddit);
+        _timeout = options.MemeApiTimeout;
+    }
+
+    internal MemeProvider(Func<string, Task<Meme?>> getMeme, TimeSpan timeout)
+    {
+        _getMeme = getMeme ?? throw new ArgumentNullException(nameof(getMeme));
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(timeout, TimeSpan.Zero);
+        _timeout = timeout;
+    }
+
+    public Task<Meme?> GetMemeAsync(string subreddit, CancellationToken cancellationToken)
+        => ExternalMediaOperationGuard.RunAsync(
+            _ => _getMeme(subreddit ?? string.Empty),
+            _timeout,
+            cancellationToken,
+            "Meme API request timed out.");
+}

--- a/BeanBot/Discord/Commands/MemeProvider.cs
+++ b/BeanBot/Discord/Commands/MemeProvider.cs
@@ -2,7 +2,7 @@ using MemeApiDotNetWrapper;
 
 namespace BeanBot.Discord.Commands;
 
-internal interface IMemeProvider
+public interface IMemeProvider
 {
     Task<Meme?> GetMemeAsync(string subreddit, CancellationToken cancellationToken);
 }

--- a/BeanBot/Discord/Commands/MemeProvider.cs
+++ b/BeanBot/Discord/Commands/MemeProvider.cs
@@ -33,6 +33,6 @@ internal sealed class MemeProvider : IMemeProvider
         => ExternalMediaOperationGuard.RunAsync(
             _ => _getMeme(subreddit ?? string.Empty),
             _timeout,
-            cancellationToken,
-            "Meme API request timed out.");
+            "Meme API request timed out.",
+            cancellationToken);
 }

--- a/BeanBot/Hosting/BeanBotServiceCollectionExtensions.cs
+++ b/BeanBot/Hosting/BeanBotServiceCollectionExtensions.cs
@@ -121,6 +121,13 @@ internal static class BeanBotServiceCollectionExtensions
         services.AddSingleton<PunProvider>();
         services.AddSingleton<IPunProvider>(provider =>
             provider.GetRequiredService<PunProvider>());
+        services.AddSingleton(ExternalMediaCommandOptions.Default);
+        services.AddSingleton<ExternalImageClient>();
+        services.AddSingleton<IExternalImageClient>(provider =>
+            provider.GetRequiredService<ExternalImageClient>());
+        services.AddSingleton<MemeProvider>();
+        services.AddSingleton<IMemeProvider>(provider =>
+            provider.GetRequiredService<MemeProvider>());
         services.AddSingleton<DiscordMessageWaiter>();
         services.AddSingleton<DiscordPaginatorService>();
         services.AddSingleton<EditMessageEventServices>();

--- a/BeanBot/Logging/ExternalMediaLog.cs
+++ b/BeanBot/Logging/ExternalMediaLog.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.Logging;
+
+namespace BeanBot.Logging;
+
+internal static partial class BeanBotLog
+{
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "External media command failed during {Stage} for {MediaSource}")]
+    internal static partial void ExternalMediaCommandFailed(
+        ILogger logger,
+        string stage,
+        string mediaSource,
+        Exception exception);
+}

--- a/BeanBot/Logging/ExternalMediaLog.cs
+++ b/BeanBot/Logging/ExternalMediaLog.cs
@@ -6,10 +6,10 @@ internal static partial class BeanBotLog
 {
     [LoggerMessage(
         Level = LogLevel.Warning,
-        Message = "External media command failed during {Stage} for {MediaSource}")]
+        Message = "External media command failed during {Stage} for {MediaSource}. ErrorType={ErrorType}")]
     internal static partial void ExternalMediaCommandFailed(
         ILogger logger,
         string stage,
         string mediaSource,
-        Exception exception);
+        string errorType);
 }


### PR DESCRIPTION
Closes #152.

## Summary
- move configured image downloads behind an injectable `IExternalImageClient`
- bound the full image request/body-read lifetime to 10 seconds by default
- reject non-image responses and enforce an 8 MiB hard payload cap using both declared `Content-Length` and bounded streaming reads
- bound Discord image uploads to 10 seconds, pass the same cancellation token into Discord.Net, and never retry an ambiguous timed-out upload
- wrap the legacy meme API client behind an injectable `IMemeProvider` with a bounded wait and late-fault observation
- propagate host shutdown cancellation instead of treating it as an ordinary upstream failure
- redact query strings/user info from external-media log sources
- preserve existing `%toes`, `%yoshimaru`, and `%meme` success/fallback text and command names

## Tests
- normal image download succeeds
- oversized declared response is rejected
- no-length/chunked-style response cannot bypass the byte cap
- non-image response is rejected
- stalled body read times out
- caller cancellation remains cancellation rather than timeout
- stalled Discord upload times out once and receives a canceled `RequestOptions` token
- meme API wait is bounded and does not retry
- late faults are observed after abandoned waits
- media log source redacts query/user-info material

## Verification
- exact-head Repository Verification #257: **PASS**
  - Release build: **0 warnings / 0 errors**
  - tests: **443 passed / 0 failed / 0 skipped**
  - coverage: **66.25% lines / 54.27% branches**, baseline gate passed
  - vulnerable NuGet package scan: passed
  - hardened Docker build/runtime/SIGTERM smoke checks: passed
- exact-head CodeQL #90: **PASS**
- exact-head Dependency Review #76: **PASS**
- fresh Verifier rerun against final head `0d76d34954f68934f8212948d881573f4c000093`: **PASS**
- fresh independent Reviewer rerun against the same final diff: **CLEAN**
- review-found repair commits: none required
- open review threads: none

The verifier confirmed the branch is based on and targets the current `develop` head, mapped the issue acceptance criteria to the implementation/tests, inspected the complete 12-file diff, and used the exact-head GitHub Actions full gate as the deterministic verification evidence. No required gate was weakened or skipped.

## Manual validation
After deployment, smoke-test `%toes`, `%yoshimaru`, and `%meme` against real Discord/upstream services and confirm existing presentation/fallback behavior remains unchanged. In particular, confirm a normal configured image still uploads once and `%meme` still renders the same embed/fallback text.