### PR TITLE
Migrate release attestations to actions/attest

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -119,11 +119,12 @@ jobs:
 
       - name: Generate build provenance
         if: steps.selected-image.outputs.provenance-action == 'generate'
-        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
         with:
           subject-name: ${{ steps.selected-image.outputs.image-name }}
           subject-digest: ${{ steps.selected-image.outputs.image-digest }}
           push-to-registry: true
+          create-storage-record: false
 
       - name: Verify existing build provenance
         if: steps.selected-image.outputs.provenance-action == 'verify'
@@ -145,12 +146,13 @@ jobs:
           upload-release-assets: false
 
       - name: Attest image SBOM
-        uses: actions/attest-sbom@4651f806c01d8637787e274ac3bdf724ef169f34 # v3
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
         with:
           subject-name: ${{ steps.selected-image.outputs.image-name }}
           subject-digest: ${{ steps.selected-image.outputs.image-digest }}
           sbom-path: .artifacts/release/beanbot.spdx.json
           push-to-registry: true
+          create-storage-record: false
 
       - name: Create release metadata and checksums
         run: |

--- a/scripts/validate-workflow.py
+++ b/scripts/validate-workflow.py
@@ -170,6 +170,17 @@ def validate_workflows() -> None:
     producer_steps = {step.get("name"): step for step in producer.get("steps", [])}
     consumer_steps = {step.get("name"): step for step in consumer.get("steps", [])}
 
+    expected_producer_permissions = {
+        "contents": "read",
+        "packages": "write",
+        "id-token": "write",
+        "attestations": "write",
+    }
+    if producer.get("permissions") != expected_producer_permissions:
+        fail("release image job permissions must remain least-privilege for GHCR and attestations")
+    if consumer.get("needs") != "verify-and-publish-image":
+        fail("GitHub Release publication must depend on the verified image job succeeding")
+
     upload_step = producer_steps.get("Upload release evidence", {})
     download_step = consumer_steps.get("Download release evidence", {})
     upload_inputs = upload_step.get("with", {})
@@ -212,12 +223,51 @@ def validate_workflows() -> None:
 
     generate_step = producer_steps.get("Generate build provenance", {})
     verify_step = producer_steps.get("Verify existing build provenance", {})
+    sbom_attest_step = producer_steps.get("Attest image SBOM", {})
     if generate_step.get("if") != "steps.selected-image.outputs.provenance-action == 'generate'":
         fail("build provenance generation must be limited to the digest staged by this attempt")
     if verify_step.get("if") != "steps.selected-image.outputs.provenance-action == 'verify'":
         fail("reused image digests must take the existing-provenance verification path")
-    if not str(generate_step.get("uses", "")).startswith("actions/attest-build-provenance@"):
-        fail("newly staged images must use the pinned build-provenance action")
+
+    for deprecated_action in ("actions/attest-build-provenance@", "actions/attest-sbom@"):
+        if deprecated_action in release:
+            fail(f"release workflow must not reference deprecated attestation wrapper: {deprecated_action}")
+
+    generate_action = str(generate_step.get("uses", ""))
+    sbom_action = str(sbom_attest_step.get("uses", ""))
+    if not generate_action.startswith("actions/attest@"):
+        fail("newly staged images must use the consolidated actions/attest action")
+    if sbom_action != generate_action:
+        fail("build provenance and SBOM attestation must use the same pinned actions/attest action")
+    if release.count("uses: actions/attest@") != 2:
+        fail("release workflow must use actions/attest exactly once for provenance and once for SBOM")
+
+    expected_subject_inputs = {
+        "subject-name": "${{ steps.selected-image.outputs.image-name }}",
+        "subject-digest": "${{ steps.selected-image.outputs.image-digest }}",
+        "push-to-registry": True,
+        "create-storage-record": False,
+    }
+    for step_name, step in (
+        ("Generate build provenance", generate_step),
+        ("Attest image SBOM", sbom_attest_step),
+    ):
+        inputs = step.get("with", {})
+        for input_name, expected_value in expected_subject_inputs.items():
+            if inputs.get(input_name) != expected_value:
+                fail(f"{step_name} has unexpected {input_name} input")
+        if step.get("continue-on-error", False):
+            fail(f"{step_name} must fail closed before evidence or publication")
+
+    generate_inputs = generate_step.get("with", {})
+    for custom_predicate_input in ("sbom-path", "predicate-type", "predicate", "predicate-path"):
+        if custom_predicate_input in generate_inputs:
+            fail("build provenance must use actions/attest provenance mode without a custom predicate")
+
+    sbom_inputs = sbom_attest_step.get("with", {})
+    if sbom_inputs.get("sbom-path") != ".artifacts/release/beanbot.spdx.json":
+        fail("SBOM attestation must bind the generated SPDX document")
+
     verify_script = verify_step.get("run", "")
     for fragment in (
         "./scripts/verify-release-provenance.sh",
@@ -234,13 +284,14 @@ def validate_workflows() -> None:
     generate_position = step_names.index("Generate build provenance")
     verify_position = step_names.index("Verify existing build provenance")
     sbom_position = step_names.index("Generate SPDX SBOM")
+    sbom_attest_position = step_names.index("Attest image SBOM")
     evidence_position = step_names.index("Upload release evidence")
     promotion_position = step_names.index("Promote immutable image tags")
     if not (
-        generate_position < sbom_position < evidence_position < promotion_position
-        and verify_position < sbom_position < evidence_position < promotion_position
+        generate_position < sbom_position < sbom_attest_position < evidence_position < promotion_position
+        and verify_position < sbom_position < sbom_attest_position < evidence_position < promotion_position
     ):
-        fail("provenance establishment must precede SBOM evidence and immutable tag promotion")
+        fail("provenance and SBOM attestation must precede evidence and immutable tag promotion")
 
     for fragment in ("fail-on-severity: high", "timeout-minutes:"):
         if fragment not in dependency_review:

--- a/scripts/validate-workflow.py
+++ b/scripts/validate-workflow.py
@@ -178,7 +178,10 @@ def validate_workflows() -> None:
     }
     if producer.get("permissions") != expected_producer_permissions:
         fail("release image job permissions must remain least-privilege for GHCR and attestations")
-    if consumer.get("needs") != "verify-and-publish-image":
+    consumer_needs = consumer.get("needs", [])
+    if isinstance(consumer_needs, str):
+        consumer_needs = [consumer_needs]
+    if not isinstance(consumer_needs, list) or "verify-and-publish-image" not in consumer_needs:
         fail("GitHub Release publication must depend on the verified image job succeeding")
 
     upload_step = producer_steps.get("Upload release evidence", {})
@@ -229,8 +232,14 @@ def validate_workflows() -> None:
     if verify_step.get("if") != "steps.selected-image.outputs.provenance-action == 'verify'":
         fail("reused image digests must take the existing-provenance verification path")
 
+    release_action_uses = [
+        str(step.get("uses", ""))
+        for job in release_jobs.values()
+        for step in job.get("steps", [])
+        if step.get("uses")
+    ]
     for deprecated_action in ("actions/attest-build-provenance@", "actions/attest-sbom@"):
-        if deprecated_action in release:
+        if any(action.startswith(deprecated_action) for action in release_action_uses):
             fail(f"release workflow must not reference deprecated attestation wrapper: {deprecated_action}")
 
     generate_action = str(generate_step.get("uses", ""))
@@ -239,7 +248,7 @@ def validate_workflows() -> None:
         fail("newly staged images must use the consolidated actions/attest action")
     if sbom_action != generate_action:
         fail("build provenance and SBOM attestation must use the same pinned actions/attest action")
-    if release.count("uses: actions/attest@") != 2:
+    if sum(action.startswith("actions/attest@") for action in release_action_uses) != 2:
         fail("release workflow must use actions/attest exactly once for provenance and once for SBOM")
 
     expected_subject_inputs = {


### PR DESCRIPTION
Closes #154.

## Summary
- replace the deprecated/compatibility `actions/attest-build-provenance` and `actions/attest-sbom` wrappers with the consolidated `actions/attest` action
- pin both attestation modes to `actions/attest` v4.2.1 at immutable commit `508db95dd578ae2727ebd6217d5ba78e4fbda05d`
- preserve the exact selected image name/digest and `push-to-registry: true` behavior for both provenance and SBOM attestations
- explicitly set `create-storage-record: false` so this user-owned repository does not require unsupported/unneeded artifact-metadata storage-record permissions
- keep reused images on the existing strict `verify-release-provenance.sh` path rather than generating replacement provenance
- strengthen workflow validation to reject the old wrappers, require both attestation modes to use the same pinned direct action and exact image identity, preserve least-privilege permissions, and keep both attestations fail-closed before evidence/tag/release publication

## Scope
- `.github/workflows/autorelease.yml`
- `scripts/validate-workflow.py`
- no application runtime, dependency, Docker, SemVer, SBOM-generator, provenance-verifier, or release-transaction redesign

## Review fixes
The independent review found two small but actionable validator robustness problems and corrected them on the existing PR branch:
- normalize `create-github-release.needs` so both GitHub-supported string and list forms are accepted while still requiring `verify-and-publish-image`
- inspect parsed workflow `uses` entries instead of raw text when rejecting deprecated wrappers and counting the two direct `actions/attest` uses, avoiding false failures from formatting/comments

Both corresponding Copilot review threads are now resolved on the repaired head.

## Verification
Current exact head: `314346bd2f98dff3d57d9695a048a67a2f1c81fc`

Previous head `0f6aee90fe9c3def22d7d9a453259a4604c34195` passed Repository Verification #258, CodeQL #91, and Dependency Review #77 before the review fixes above.

The repaired exact-head gates have been repeatedly re-checked and are still waiting for GitHub-hosted runners:
- Repository Verification #259: queued
- CodeQL #92: queued
- fresh Verifier: blocked from PASS until required exact-head CI completes
- fresh Reviewer: not started because repository policy requires fresh Verifier PASS first

A local fallback was attempted, but this automation environment cannot resolve `github.com`, so it cannot clone the repository or run `./scripts/verify.sh full` locally. The PR therefore remains draft and no final TL;DR review comment has been posted; prior green evidence is not being treated as evidence for this repaired head.

## Reviewer notes
- branch is exactly 3 commits ahead of the current `develop` head and 0 behind; only `.github/workflows/autorelease.yml` and `scripts/validate-workflow.py` differ
- `actions/attest` v4.2.1 was independently checked against upstream: the pinned SHA is the v4.2.1 tag; provenance mode is selected when no SBOM/custom predicate is supplied; `sbom-path` selects SBOM mode; `create-storage-record: false` avoids organization-only artifact storage-record creation
- both attestation modes remain bound to the exact selected immutable image digest
- the new direct action does not gain `artifact-metadata: write`; storage-record creation is explicitly disabled
- reused images still take the strict existing-provenance verification path and cannot mint replacement build provenance
- attestation steps remain fail-closed and execute before evidence upload, immutable tag promotion, and GitHub Release publication
- no release was dispatched while validating this PR

## Post-merge follow-up
Wrapper-only Dependabot PRs #147 and #149 should be closed/superseded after this migration is merged, as requested by issue #154. They are intentionally left untouched while this implementation PR is still open.