### PR TITLE
Throttle expensive external-media commands per user

### DIFF
--- a/BeanBot.Tests/Discord/Commands/ExternalMediaAdmissionGuardTests.cs
+++ b/BeanBot.Tests/Discord/Commands/ExternalMediaAdmissionGuardTests.cs
@@ -1,0 +1,266 @@
+using BeanBot.Discord.Commands;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.Commands;
+
+public class ExternalMediaAdmissionGuardTests
+{
+    private const string BudgetKey = "external-media";
+    private static readonly TimeSpan Cooldown = TimeSpan.FromSeconds(5);
+
+    [Fact]
+    public async Task RunAsync_FirstInvocation_IsAccepted()
+    {
+        var guard = CreateGuard(new ManualTimeProvider());
+        var calls = 0;
+
+        var result = await guard.RunAsync(
+            1,
+            BudgetKey,
+            () =>
+            {
+                calls++;
+                return Task.CompletedTask;
+            });
+
+        Assert.Equal(ExternalMediaAdmissionResult.Accepted, result);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public async Task RunAsync_ConcurrentDuplicate_DoesNotStartSecondOperation()
+    {
+        var guard = CreateGuard(new ManualTimeProvider());
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+
+        var first = guard.RunAsync(
+            1,
+            BudgetKey,
+            async () =>
+            {
+                calls++;
+                started.SetResult();
+                await release.Task;
+            });
+        await started.Task;
+
+        var second = await guard.RunAsync(
+            1,
+            BudgetKey,
+            () =>
+            {
+                calls++;
+                return Task.CompletedTask;
+            });
+
+        Assert.Equal(ExternalMediaAdmissionResult.InFlight, second);
+        Assert.Equal(1, calls);
+
+        release.SetResult();
+        Assert.Equal(ExternalMediaAdmissionResult.Accepted, await first);
+    }
+
+    [Fact]
+    public async Task RunAsync_RapidFollowUp_IsRejectedUntilCooldownExpires()
+    {
+        var timeProvider = new ManualTimeProvider();
+        var guard = CreateGuard(timeProvider);
+        var calls = 0;
+
+        Assert.Equal(
+            ExternalMediaAdmissionResult.Accepted,
+            await guard.RunAsync(1, BudgetKey, CountCall));
+        Assert.Equal(
+            ExternalMediaAdmissionResult.CoolingDown,
+            await guard.RunAsync(1, BudgetKey, CountCall));
+        Assert.Equal(1, calls);
+
+        timeProvider.Advance(Cooldown);
+
+        Assert.Equal(
+            ExternalMediaAdmissionResult.Accepted,
+            await guard.RunAsync(1, BudgetKey, CountCall));
+        Assert.Equal(2, calls);
+        return;
+
+        Task CountCall()
+        {
+            calls++;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_DifferentUsers_DoNotBlockEachOther()
+    {
+        var guard = CreateGuard(new ManualTimeProvider());
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var firstUser = guard.RunAsync(
+            1,
+            BudgetKey,
+            async () =>
+            {
+                started.SetResult();
+                await release.Task;
+            });
+        await started.Task;
+
+        var secondUser = await guard.RunAsync(2, BudgetKey, () => Task.CompletedTask);
+
+        Assert.Equal(ExternalMediaAdmissionResult.Accepted, secondUser);
+
+        release.SetResult();
+        Assert.Equal(ExternalMediaAdmissionResult.Accepted, await firstUser);
+    }
+
+    [Fact]
+    public async Task RunAsync_DifferentBudgetKeys_AreIndependent()
+    {
+        var guard = CreateGuard(new ManualTimeProvider());
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var sharedBudget = guard.RunAsync(
+            1,
+            BudgetKey,
+            async () =>
+            {
+                started.SetResult();
+                await release.Task;
+            });
+        await started.Task;
+
+        var differentBudget = await guard.RunAsync(1, "other-budget", () => Task.CompletedTask);
+
+        Assert.Equal(ExternalMediaAdmissionResult.Accepted, differentBudget);
+
+        release.SetResult();
+        Assert.Equal(ExternalMediaAdmissionResult.Accepted, await sharedBudget);
+    }
+
+    [Fact]
+    public async Task RunAsync_Failure_ReleasesInFlightLeaseAndKeepsCooldown()
+    {
+        var timeProvider = new ManualTimeProvider();
+        var guard = CreateGuard(timeProvider);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            guard.RunAsync(
+                1,
+                BudgetKey,
+                () => Task.FromException(new InvalidOperationException("failure"))));
+
+        Assert.Equal(
+            ExternalMediaAdmissionResult.CoolingDown,
+            await guard.RunAsync(1, BudgetKey, () => Task.CompletedTask));
+
+        timeProvider.Advance(Cooldown);
+
+        Assert.Equal(
+            ExternalMediaAdmissionResult.Accepted,
+            await guard.RunAsync(1, BudgetKey, () => Task.CompletedTask));
+    }
+
+    [Fact]
+    public async Task RunAsync_Timeout_ReleasesInFlightLeaseAndKeepsCooldown()
+    {
+        var timeProvider = new ManualTimeProvider();
+        var guard = CreateGuard(timeProvider);
+
+        await Assert.ThrowsAsync<TimeoutException>(() =>
+            guard.RunAsync(
+                1,
+                BudgetKey,
+                () => Task.FromException(new TimeoutException("timeout"))));
+
+        Assert.Equal(
+            ExternalMediaAdmissionResult.CoolingDown,
+            await guard.RunAsync(1, BudgetKey, () => Task.CompletedTask));
+
+        timeProvider.Advance(Cooldown);
+
+        Assert.Equal(
+            ExternalMediaAdmissionResult.Accepted,
+            await guard.RunAsync(1, BudgetKey, () => Task.CompletedTask));
+    }
+
+    [Fact]
+    public async Task RunAsync_Cancellation_ReleasesInFlightLeaseAndKeepsCooldown()
+    {
+        var timeProvider = new ManualTimeProvider();
+        var guard = CreateGuard(timeProvider);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            guard.RunAsync(
+                1,
+                BudgetKey,
+                () => Task.FromCanceled(cancellation.Token)));
+
+        Assert.Equal(
+            ExternalMediaAdmissionResult.CoolingDown,
+            await guard.RunAsync(1, BudgetKey, () => Task.CompletedTask));
+
+        timeProvider.Advance(Cooldown);
+
+        Assert.Equal(
+            ExternalMediaAdmissionResult.Accepted,
+            await guard.RunAsync(1, BudgetKey, () => Task.CompletedTask));
+    }
+
+    [Fact]
+    public async Task RunAsync_CapacityIsHardBoundAndExpiredEntriesAreReclaimed()
+    {
+        var timeProvider = new ManualTimeProvider();
+        var guard = CreateGuard(timeProvider, capacity: 2);
+
+        Assert.Equal(
+            ExternalMediaAdmissionResult.Accepted,
+            await guard.RunAsync(1, BudgetKey, () => Task.CompletedTask));
+        Assert.Equal(
+            ExternalMediaAdmissionResult.Accepted,
+            await guard.RunAsync(2, BudgetKey, () => Task.CompletedTask));
+        Assert.Equal(
+            ExternalMediaAdmissionResult.CapacityReached,
+            await guard.RunAsync(3, BudgetKey, () => Task.CompletedTask));
+
+        timeProvider.Advance(Cooldown);
+
+        Assert.Equal(
+            ExternalMediaAdmissionResult.Accepted,
+            await guard.RunAsync(3, BudgetKey, () => Task.CompletedTask));
+    }
+
+    private static ExternalMediaAdmissionGuard CreateGuard(
+        ManualTimeProvider timeProvider,
+        int capacity = 16)
+        => new(
+            new ExternalMediaCommandOptions(
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(1),
+                1024,
+                Cooldown,
+                capacity),
+            timeProvider);
+
+    private sealed class ManualTimeProvider : TimeProvider
+    {
+        private long _timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => Interlocked.Read(ref _timestamp);
+
+        internal void Advance(TimeSpan duration)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(duration, TimeSpan.Zero);
+            Interlocked.Add(ref _timestamp, duration.Ticks);
+        }
+    }
+}

--- a/BeanBot.Tests/Discord/Commands/MemeModuleTests.cs
+++ b/BeanBot.Tests/Discord/Commands/MemeModuleTests.cs
@@ -75,6 +75,22 @@ public class MemeModuleTests
     }
 
     [Fact]
+    public void CreateExternalMediaAdmissionReply_IsConciseAndMentionSafe()
+    {
+        var reply = MemeModule.CreateExternalMediaAdmissionReply();
+
+        Assert.Equal("That command is cooling down; try again in a few seconds.", reply.Content);
+        Assert.True(reply.Content.Length < 100);
+        AssertMentionsDisabled(reply.AllowedMentions);
+    }
+
+    [Fact]
+    public void ExternalMediaCommands_UseOneSharedBudgetKey()
+    {
+        Assert.Equal("external-media", MemeModule.ExternalMediaBudgetKey);
+    }
+
+    [Fact]
     public void GetSafeMediaSource_RemovesQueryAndUserInfo()
     {
         var source = MemeModule.GetSafeMediaSource(

--- a/BeanBot/Discord/Commands/ExternalMediaAdmissionGuard.cs
+++ b/BeanBot/Discord/Commands/ExternalMediaAdmissionGuard.cs
@@ -8,7 +8,7 @@ internal enum ExternalMediaAdmissionResult
     CapacityReached
 }
 
-internal sealed class ExternalMediaAdmissionGuard
+public sealed class ExternalMediaAdmissionGuard
 {
     private readonly object _syncRoot = new();
     private readonly Dictionary<AdmissionKey, AdmissionEntry> _entries = [];

--- a/BeanBot/Discord/Commands/ExternalMediaAdmissionGuard.cs
+++ b/BeanBot/Discord/Commands/ExternalMediaAdmissionGuard.cs
@@ -1,0 +1,155 @@
+namespace BeanBot.Discord.Commands;
+
+internal enum ExternalMediaAdmissionResult
+{
+    Accepted,
+    InFlight,
+    CoolingDown,
+    CapacityReached
+}
+
+internal sealed class ExternalMediaAdmissionGuard
+{
+    private readonly object _syncRoot = new();
+    private readonly Dictionary<AdmissionKey, AdmissionEntry> _entries = [];
+    private readonly TimeProvider _timeProvider;
+    private readonly TimeSpan _cooldown;
+    private readonly int _capacity;
+
+    public ExternalMediaAdmissionGuard(ExternalMediaCommandOptions options)
+        : this(options, TimeProvider.System)
+    {
+    }
+
+    internal ExternalMediaAdmissionGuard(
+        ExternalMediaCommandOptions options,
+        TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _cooldown = options.AdmissionCooldown;
+        _capacity = options.AdmissionCapacity;
+    }
+
+    internal async Task<ExternalMediaAdmissionResult> RunAsync(
+        ulong userId,
+        string budgetKey,
+        Func<Task> operation)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(budgetKey);
+        ArgumentNullException.ThrowIfNull(operation);
+
+        var result = TryAcquire(userId, budgetKey, out var lease);
+        if (result != ExternalMediaAdmissionResult.Accepted)
+        {
+            return result;
+        }
+
+        using (lease)
+        {
+            await operation();
+        }
+
+        return ExternalMediaAdmissionResult.Accepted;
+    }
+
+    private ExternalMediaAdmissionResult TryAcquire(
+        ulong userId,
+        string budgetKey,
+        out AdmissionLease? lease)
+    {
+        var key = new AdmissionKey(userId, budgetKey);
+
+        lock (_syncRoot)
+        {
+            var now = _timeProvider.GetTimestamp();
+            RemoveExpiredEntries(now);
+
+            if (_entries.TryGetValue(key, out var existingEntry))
+            {
+                lease = null;
+                return existingEntry.IsActive
+                    ? ExternalMediaAdmissionResult.InFlight
+                    : ExternalMediaAdmissionResult.CoolingDown;
+            }
+
+            if (_entries.Count >= _capacity)
+            {
+                lease = null;
+                return ExternalMediaAdmissionResult.CapacityReached;
+            }
+
+            var entry = new AdmissionEntry
+            {
+                IsActive = true
+            };
+            _entries.Add(key, entry);
+            lease = new AdmissionLease(this, key, entry);
+            return ExternalMediaAdmissionResult.Accepted;
+        }
+    }
+
+    private void Release(AdmissionKey key, AdmissionEntry entry)
+    {
+        lock (_syncRoot)
+        {
+            if (!_entries.TryGetValue(key, out var currentEntry) ||
+                !ReferenceEquals(currentEntry, entry) ||
+                !currentEntry.IsActive)
+            {
+                return;
+            }
+
+            currentEntry.IsActive = false;
+            currentEntry.CooldownStartedTimestamp = _timeProvider.GetTimestamp();
+        }
+    }
+
+    private void RemoveExpiredEntries(long now)
+    {
+        List<AdmissionKey>? expiredKeys = null;
+        foreach (var (key, entry) in _entries)
+        {
+            if (entry.IsActive ||
+                _timeProvider.GetElapsedTime(entry.CooldownStartedTimestamp, now) < _cooldown)
+            {
+                continue;
+            }
+
+            expiredKeys ??= [];
+            expiredKeys.Add(key);
+        }
+
+        if (expiredKeys is null)
+        {
+            return;
+        }
+
+        foreach (var key in expiredKeys)
+        {
+            _entries.Remove(key);
+        }
+    }
+
+    private readonly record struct AdmissionKey(ulong UserId, string BudgetKey);
+
+    private sealed class AdmissionEntry
+    {
+        internal bool IsActive { get; set; }
+
+        internal long CooldownStartedTimestamp { get; set; }
+    }
+
+    private sealed class AdmissionLease(
+        ExternalMediaAdmissionGuard owner,
+        AdmissionKey key,
+        AdmissionEntry entry) : IDisposable
+    {
+        private ExternalMediaAdmissionGuard? _owner = owner;
+
+        public void Dispose()
+        {
+            Interlocked.Exchange(ref _owner, null)?.Release(key, entry);
+        }
+    }
+}

--- a/BeanBot/Discord/Commands/ExternalMediaCommandOptions.cs
+++ b/BeanBot/Discord/Commands/ExternalMediaCommandOptions.cs
@@ -2,27 +2,53 @@ namespace BeanBot.Discord.Commands;
 
 public sealed class ExternalMediaCommandOptions
 {
+    private static readonly TimeSpan DefaultAdmissionCooldown = TimeSpan.FromSeconds(5);
+    private const int DefaultAdmissionCapacity = 256;
+
     internal static ExternalMediaCommandOptions Default { get; } = new(
         imageDownloadTimeout: TimeSpan.FromSeconds(10),
         discordUploadTimeout: TimeSpan.FromSeconds(10),
         memeApiTimeout: TimeSpan.FromSeconds(10),
-        maxImageBytes: 8 * 1024 * 1024);
+        maxImageBytes: 8 * 1024 * 1024,
+        admissionCooldown: DefaultAdmissionCooldown,
+        admissionCapacity: DefaultAdmissionCapacity);
 
     internal ExternalMediaCommandOptions(
         TimeSpan imageDownloadTimeout,
         TimeSpan discordUploadTimeout,
         TimeSpan memeApiTimeout,
         int maxImageBytes)
+        : this(
+            imageDownloadTimeout,
+            discordUploadTimeout,
+            memeApiTimeout,
+            maxImageBytes,
+            DefaultAdmissionCooldown,
+            DefaultAdmissionCapacity)
+    {
+    }
+
+    internal ExternalMediaCommandOptions(
+        TimeSpan imageDownloadTimeout,
+        TimeSpan discordUploadTimeout,
+        TimeSpan memeApiTimeout,
+        int maxImageBytes,
+        TimeSpan admissionCooldown,
+        int admissionCapacity)
     {
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(imageDownloadTimeout, TimeSpan.Zero);
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(discordUploadTimeout, TimeSpan.Zero);
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(memeApiTimeout, TimeSpan.Zero);
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(maxImageBytes, 0);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(admissionCooldown, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(admissionCapacity, 0);
 
         ImageDownloadTimeout = imageDownloadTimeout;
         DiscordUploadTimeout = discordUploadTimeout;
         MemeApiTimeout = memeApiTimeout;
         MaxImageBytes = maxImageBytes;
+        AdmissionCooldown = admissionCooldown;
+        AdmissionCapacity = admissionCapacity;
     }
 
     internal TimeSpan ImageDownloadTimeout { get; }
@@ -32,4 +58,8 @@ public sealed class ExternalMediaCommandOptions
     internal TimeSpan MemeApiTimeout { get; }
 
     internal int MaxImageBytes { get; }
+
+    internal TimeSpan AdmissionCooldown { get; }
+
+    internal int AdmissionCapacity { get; }
 }

--- a/BeanBot/Discord/Commands/MemeModule.cs
+++ b/BeanBot/Discord/Commands/MemeModule.cs
@@ -12,6 +12,10 @@ namespace BeanBot.Discord.Commands;
 [Name("Meme Commands")]
 public class MemeModule : ModuleBase<SocketCommandContext>
 {
+    internal const string ExternalMediaBudgetKey = "external-media";
+    private const string ExternalMediaAdmissionRejectedMessage =
+        "That command is cooling down; try again in a few seconds.";
+
     private readonly BeanBotOptions _options;
     private readonly FortuneAnswerStore _fortuneAnswers;
     private readonly DiscordPaginatorService _paginator;
@@ -19,6 +23,7 @@ public class MemeModule : ModuleBase<SocketCommandContext>
     private readonly IExternalImageClient _externalImageClient;
     private readonly IMemeProvider _memeProvider;
     private readonly ExternalMediaCommandOptions _mediaOptions;
+    private readonly ExternalMediaAdmissionGuard _mediaAdmissionGuard;
     private readonly IHostApplicationLifetime _applicationLifetime;
     private readonly ILogger<MemeModule> _logger;
 
@@ -30,6 +35,7 @@ public class MemeModule : ModuleBase<SocketCommandContext>
         IExternalImageClient externalImageClient,
         IMemeProvider memeProvider,
         ExternalMediaCommandOptions mediaOptions,
+        ExternalMediaAdmissionGuard mediaAdmissionGuard,
         IHostApplicationLifetime applicationLifetime,
         ILogger<MemeModule> logger)
     {
@@ -40,6 +46,7 @@ public class MemeModule : ModuleBase<SocketCommandContext>
         _externalImageClient = externalImageClient ?? throw new ArgumentNullException(nameof(externalImageClient));
         _memeProvider = memeProvider ?? throw new ArgumentNullException(nameof(memeProvider));
         _mediaOptions = mediaOptions ?? throw new ArgumentNullException(nameof(mediaOptions));
+        _mediaAdmissionGuard = mediaAdmissionGuard ?? throw new ArgumentNullException(nameof(mediaAdmissionGuard));
         _applicationLifetime = applicationLifetime ?? throw new ArgumentNullException(nameof(applicationLifetime));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -114,7 +121,7 @@ public class MemeModule : ModuleBase<SocketCommandContext>
     [RequireBotPermission(ChannelPermission.AttachFiles)]
     public async Task Toes()
     {
-        await SendImageFromUrl(_options.HatoeteImageUrl);
+        await RunExternalMediaCommandAsync(() => SendImageFromUrl(_options.HatoeteImageUrl));
     }
 
     [Command("yoshimaru")]
@@ -124,7 +131,7 @@ public class MemeModule : ModuleBase<SocketCommandContext>
     [RequireBotPermission(ChannelPermission.AttachFiles)]
     public async Task YoshiMaru()
     {
-        await SendImageFromUrl(_options.YoshimaruImageUrl);
+        await RunExternalMediaCommandAsync(() => SendImageFromUrl(_options.YoshimaruImageUrl));
     }
 
     [Command("echo")]
@@ -167,7 +174,7 @@ public class MemeModule : ModuleBase<SocketCommandContext>
     [RequireBotPermission(ChannelPermission.SendMessages)]
     public async Task Meme(string subreddit = "")
     {
-        await InvokeMemeApi(subreddit);
+        await RunExternalMediaCommandAsync(() => InvokeMemeApi(subreddit));
     }
 
     private async Task InvokeMemeApi(string subreddit)
@@ -336,6 +343,23 @@ public class MemeModule : ModuleBase<SocketCommandContext>
         return (Context.Message.Author.Id == 262010462323998720);
     }
 
+    private async Task RunExternalMediaCommandAsync(Func<Task> operation)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+
+        var result = await _mediaAdmissionGuard.RunAsync(
+            Context.Message.Author.Id,
+            ExternalMediaBudgetKey,
+            operation);
+        if (result == ExternalMediaAdmissionResult.Accepted)
+        {
+            return;
+        }
+
+        var rejection = CreateExternalMediaAdmissionReply();
+        await ReplyAsync(rejection.Content, allowedMentions: rejection.AllowedMentions);
+    }
+
     private async Task SendImageFromUrl(Uri url)
     {
         var cancellationToken = _applicationLifetime.ApplicationStopping;
@@ -418,6 +442,9 @@ public class MemeModule : ModuleBase<SocketCommandContext>
         ArgumentNullException.ThrowIfNull(content);
         return (content, AllowedMentions.None);
     }
+
+    internal static (string Content, AllowedMentions AllowedMentions) CreateExternalMediaAdmissionReply()
+        => (ExternalMediaAdmissionRejectedMessage, AllowedMentions.None);
 
     private Task<IUserMessage> ReplyWithReflectedContentAsync(string content)
     {

--- a/BeanBot/Discord/Commands/MemeModule.cs
+++ b/BeanBot/Discord/Commands/MemeModule.cs
@@ -373,7 +373,7 @@ public class MemeModule : ModuleBase<SocketCommandContext>
         }
 
         var rejection = CreateExternalMediaAdmissionReply();
-        await ReplyAsync(rejection.Content, allowedMentions: rejection.AllowedMentions);
+        await _replySender.SendMessageAsync(Context, rejection.Content, allowedMentions: rejection.AllowedMentions);
     }
 
     private async Task SendImageFromUrl(Uri url)

--- a/BeanBot/Hosting/BeanBotServiceCollectionExtensions.cs
+++ b/BeanBot/Hosting/BeanBotServiceCollectionExtensions.cs
@@ -122,6 +122,7 @@ internal static class BeanBotServiceCollectionExtensions
         services.AddSingleton<IPunProvider>(provider =>
             provider.GetRequiredService<PunProvider>());
         services.AddSingleton(ExternalMediaCommandOptions.Default);
+        services.AddSingleton<ExternalMediaAdmissionGuard>();
         services.AddSingleton<ExternalImageClient>();
         services.AddSingleton<IExternalImageClient>(provider =>
             provider.GetRequiredService<ExternalImageClient>());


### PR DESCRIPTION
Closes #156.

## Summary
- add a bounded in-memory admission guard for expensive external-media commands
- put `%toes`, `%yoshimaru`, and `%meme` on one shared per-user external-media budget
- allow only one active protected operation per user and apply a 5-second cooldown after an accepted invocation completes
- reject overlapping/cooling-down invocations immediately rather than queueing them
- keep users independent and cap admission state at 256 entries with deterministic reclaim once cooldown entries expire
- use `TimeProvider` monotonic timestamps so cooldown behavior is not tied to wall-clock changes
- release active ownership on completion, failure, timeout, and cancellation through a scoped lease
- return concise Discord mention-safe rejection feedback
- preserve all timeout, payload-size, content-type, cancellation, late-fault, and no-retry safeguards added by #152

## Tests
- first invocation is accepted
- concurrent duplicate does not start a second operation
- cooldown rejects rapid follow-ups and expires without real-time sleeps
- different users remain independent
- budget keys remain independently enforceable while the protected commands use one shared budget
- failure, timeout, and cancellation release in-flight ownership while preserving cooldown
- the hard state capacity rejects excess entries and expired cooldown entries are reclaimed
- rejection feedback is concise and mention-safe

## Verification
Local execution was unavailable because the automation environment could not resolve `github.com`, so repository-policy fallback used exact-head GitHub Actions for the required deterministic gates.

Final head: `ad7511e21b1406dacf2b856ee937a83c0aad6b6c`

- Repository Verification #266: **PASS**
  - `./scripts/verify.sh full`: passed
  - Release build: **0 warnings / 0 errors**
  - tests: **454 passed / 0 failed / 0 skipped**
  - coverage: **66.56% lines / 54.59% branches**, baseline gate passed
  - vulnerable NuGet package scan: passed
  - branch-integrity guard: passed
  - hardened Docker build/runtime/SIGTERM smoke checks: passed
- CodeQL #99: **PASS**
- Dependency Review #79: **PASS**
- fresh Verifier against the final head and complete diff: **PASS**
- fresh independent Reviewer against the verified final diff: **CLEAN**
- all review threads: **resolved**

The fresh verifier confirmed the PR still targets the current `develop` head, mapped issue #156's acceptance criteria to the implementation/tests, and relied on the exact-head full GitHub Actions gate rather than stale evidence. The fresh reviewer found no consequential correctness, concurrency, lifecycle, security, test, Docker, or release-flow defect requiring a repair commit.

Two Copilot notes were reviewed and resolved as non-blocking: the single mention-safe rejection message intentionally collapses all transient admission failures to the same retry action, matching issue #156's proposed UX; and `ExternalMediaAdmissionGuard` remains public because it is injected through the public `MemeModule` constructor while its operational API/result stay internal in this application project. No source change was justified by either note.

## Manual validation
After deployment, invoke `%toes`, `%yoshimaru`, and `%meme` rapidly from one user and confirm only one protected operation is admitted, rejected attempts receive the cooldown message, and another user can still invoke a protected command independently.
