### PR TITLE
Bound and configure new-member welcome DMs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@ BEANBOT_GENERAL_CHANNEL_ID=
 BEANBOT_HATOETE_URL=
 BEANBOT_YOSHIMARU_URL=
 
+# Optional new-member welcome DM
+# Welcomes remain enabled by default. Leave the message unset to preserve the built-in text.
+BEANBOT_NEW_MEMBER_WELCOME_ENABLED=true
+# BEANBOT_NEW_MEMBER_WELCOME_MESSAGE=Welcome to the server!
+
 # Optional health check endpoint
 # Leave BEANBOT_HEALTHCHECK_PORT empty to disable the endpoint entirely.
 BEANBOT_HEALTHCHECK_PORT=

--- a/BeanBot.Tests/Configuration/NewMemberWelcomeConfigurationTests.cs
+++ b/BeanBot.Tests/Configuration/NewMemberWelcomeConfigurationTests.cs
@@ -1,0 +1,127 @@
+using BeanBot.Configuration;
+using BeanBot.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace BeanBot.Tests.Configuration;
+
+public class NewMemberWelcomeConfigurationTests
+{
+    [Fact]
+    public void Options_DefaultsToExistingEnabledWelcomeMessage()
+    {
+        using var provider = CreateProvider(RequiredSettings());
+
+        var options = provider.GetRequiredService<NewMemberWelcomeOptions>();
+
+        Assert.True(options.Enabled);
+        Assert.Equal(NewMemberWelcomeOptions.DefaultMessage, options.Message);
+    }
+
+    [Fact]
+    public void Options_BindsCanonicalWelcomeSettings()
+    {
+        var values = RequiredSettings();
+        values[BeanBotConfiguration.NewMemberWelcomeEnabledVariable] = "false";
+        values[BeanBotConfiguration.NewMemberWelcomeMessageVariable] = "Custom welcome";
+
+        using var provider = CreateProvider(values);
+        var options = provider.GetRequiredService<NewMemberWelcomeOptions>();
+
+        Assert.False(options.Enabled);
+        Assert.Equal("Custom welcome", options.Message);
+    }
+
+    [Fact]
+    public void Options_AcceptsLegacyWelcomeAliases()
+    {
+        var values = RequiredSettings();
+        values["newMemberWelcomeEnabled"] = "true";
+        values["newMemberWelcomeMessage"] = "Legacy welcome";
+
+        using var provider = CreateProvider(values);
+        var options = provider.GetRequiredService<NewMemberWelcomeOptions>();
+
+        Assert.True(options.Enabled);
+        Assert.Equal("Legacy welcome", options.Message);
+    }
+
+    [Fact]
+    public void Options_DisabledWelcomeAllowsBlankMessage()
+    {
+        var values = RequiredSettings();
+        values[BeanBotConfiguration.NewMemberWelcomeEnabledVariable] = "false";
+        values[BeanBotConfiguration.NewMemberWelcomeMessageVariable] = "";
+
+        using var provider = CreateProvider(values);
+        var options = provider.GetRequiredService<NewMemberWelcomeOptions>();
+
+        Assert.False(options.Enabled);
+        Assert.Equal(string.Empty, options.Message);
+    }
+
+    [Theory]
+    [InlineData("not-a-bool")]
+    [InlineData("1")]
+    public void Options_RejectsMalformedEnabledValueWithoutEchoingIt(string value)
+    {
+        var values = RequiredSettings();
+        values[BeanBotConfiguration.NewMemberWelcomeEnabledVariable] = value;
+
+        using var provider = CreateProvider(values);
+        var exception = Assert.Throws<OptionsValidationException>(
+            () => provider.GetRequiredService<NewMemberWelcomeOptions>());
+
+        Assert.Contains(BeanBotConfiguration.NewMemberWelcomeEnabledVariable, exception.Message);
+        Assert.DoesNotContain(value, exception.Message);
+    }
+
+    [Fact]
+    public void Options_RejectsBlankMessageWhileEnabled()
+    {
+        var values = RequiredSettings();
+        values[BeanBotConfiguration.NewMemberWelcomeMessageVariable] = "   ";
+
+        using var provider = CreateProvider(values);
+        var exception = Assert.Throws<OptionsValidationException>(
+            () => provider.GetRequiredService<NewMemberWelcomeOptions>());
+
+        Assert.Contains(BeanBotConfiguration.NewMemberWelcomeMessageVariable, exception.Message);
+    }
+
+    [Fact]
+    public void Options_RejectsOversizedMessageWithoutEchoingIt()
+    {
+        var oversized = new string('x', NewMemberWelcomeOptions.DiscordMessageMaximumLength + 1);
+        var values = RequiredSettings();
+        values[BeanBotConfiguration.NewMemberWelcomeMessageVariable] = oversized;
+
+        using var provider = CreateProvider(values);
+        var exception = Assert.Throws<OptionsValidationException>(
+            () => provider.GetRequiredService<NewMemberWelcomeOptions>());
+
+        Assert.Contains(BeanBotConfiguration.NewMemberWelcomeMessageVariable, exception.Message);
+        Assert.DoesNotContain(oversized, exception.ToString());
+    }
+
+    private static ServiceProvider CreateProvider(IReadOnlyDictionary<string, string?> values)
+    {
+        var configuration = new ConfigurationManager();
+        configuration.AddInMemoryCollection(values);
+        configuration.AddBeanBotConfiguration(Array.Empty<string>());
+        var services = new ServiceCollection();
+        services.AddBeanBot(configuration);
+        return services.BuildServiceProvider();
+    }
+
+    private static Dictionary<string, string?> RequiredSettings() => new()
+    {
+        [BeanBotConfiguration.BotTokenVariable] = "token",
+        [BeanBotConfiguration.MongoConnectionVariable] = "mongodb://localhost:27017",
+        [BeanBotConfiguration.GeneralChannelVariable] = "123",
+        [BeanBotConfiguration.HatoeteUrlVariable] = "https://example.com/hatoete.png",
+        [BeanBotConfiguration.YoshimaruUrlVariable] = "https://example.com/yoshimaru.png"
+    };
+}

--- a/BeanBot.Tests/Discord/Events/DiscordNewMemberWelcomeDeliveryTests.cs
+++ b/BeanBot.Tests/Discord/Events/DiscordNewMemberWelcomeDeliveryTests.cs
@@ -1,0 +1,173 @@
+using BeanBot.Configuration;
+using BeanBot.Discord.Events;
+using Discord;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.Events;
+
+public class DiscordNewMemberWelcomeDeliveryTests
+{
+    [Fact]
+    public async Task DeliverAsync_CreatesDmAndSendsConfiguredMessageOnce()
+    {
+        RequestOptions? createOptions = null;
+        RequestOptions? sendOptions = null;
+        string? sentMessage = null;
+        var delivery = CreateDelivery(
+            (userId, options) =>
+            {
+                Assert.Equal((ulong)42, userId);
+                createOptions = options;
+                return Task.FromResult<IDMChannel>(null!);
+            },
+            (_, message, options) =>
+            {
+                sentMessage = message;
+                sendOptions = options;
+                return Task.CompletedTask;
+            });
+
+        await delivery.DeliverAsync(42, CancellationToken.None);
+
+        Assert.Equal("configured welcome", sentMessage);
+        Assert.NotNull(createOptions);
+        Assert.Same(createOptions, sendOptions);
+        Assert.False(delivery.HasActiveOperation);
+    }
+
+    [Fact]
+    public async Task DeliverAsync_CreateDmTimeout_DoesNotAttemptSendAndObservesLateFailure()
+    {
+        var stalled = new TaskCompletionSource<IDMChannel>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sendCalls = 0;
+        var delivery = CreateDelivery(
+            (_, _) => stalled.Task,
+            (_, _, _) =>
+            {
+                Interlocked.Increment(ref sendCalls);
+                return Task.CompletedTask;
+            },
+            operationTimeout: TimeSpan.FromMilliseconds(25));
+
+        await Assert.ThrowsAsync<TimeoutException>(() => delivery.DeliverAsync(1, CancellationToken.None));
+
+        Assert.Equal(0, sendCalls);
+        Assert.True(delivery.HasActiveOperation);
+        stalled.SetException(new InvalidOperationException("late create failure"));
+        await WaitUntilAsync(() => !delivery.HasActiveOperation);
+    }
+
+    [Fact]
+    public async Task DeliverAsync_SendTimeout_IsNotRetriedAndLateCompletionReleasesCapacity()
+    {
+        var stalled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sendCalls = 0;
+        var delivery = CreateDelivery(
+            (_, _) => Task.FromResult<IDMChannel>(null!),
+            (_, _, _) =>
+            {
+                Interlocked.Increment(ref sendCalls);
+                return stalled.Task;
+            },
+            operationTimeout: TimeSpan.FromMilliseconds(25));
+
+        await Assert.ThrowsAsync<TimeoutException>(() => delivery.DeliverAsync(1, CancellationToken.None));
+
+        Assert.Equal(1, sendCalls);
+        Assert.True(delivery.HasActiveOperation);
+        stalled.SetResult();
+        await WaitUntilAsync(() => !delivery.HasActiveOperation);
+        Assert.Equal(1, sendCalls);
+    }
+
+    [Fact]
+    public async Task DeliverAsync_ShutdownCancellationFlowsToDiscordRequestAndBoundedWait()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var stalled = new TaskCompletionSource<IDMChannel>(TaskCreationOptions.RunContinuationsAsynchronously);
+        CancellationToken observedToken = default;
+        var delivery = CreateDelivery(
+            (_, options) =>
+            {
+                observedToken = options.CancelToken;
+                started.TrySetResult();
+                return stalled.Task;
+            },
+            (_, _, _) => Task.CompletedTask,
+            operationTimeout: TimeSpan.FromSeconds(5));
+
+        var operation = delivery.DeliverAsync(1, cancellation.Token);
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => operation);
+        Assert.Equal(cancellation.Token, observedToken);
+        Assert.True(delivery.HasActiveOperation);
+        stalled.SetCanceled();
+        await WaitUntilAsync(() => !delivery.HasActiveOperation);
+    }
+
+    [Fact]
+    public async Task DeliverAsync_AbandonedDiscordOperationsRemainHardBounded()
+    {
+        var first = new TaskCompletionSource<IDMChannel>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        var runtimeOptions = RuntimeOptions(
+            operationTimeout: TimeSpan.FromMilliseconds(25),
+            maximumDiscordOperations: 1);
+        var delivery = CreateDelivery(
+            (_, _) =>
+            {
+                Interlocked.Increment(ref calls);
+                return first.Task;
+            },
+            (_, _, _) => Task.CompletedTask,
+            runtimeOptions: runtimeOptions);
+
+        await Assert.ThrowsAsync<TimeoutException>(() => delivery.DeliverAsync(1, CancellationToken.None));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => delivery.DeliverAsync(2, CancellationToken.None));
+        Assert.Equal(1, calls);
+
+        first.SetResult(null!);
+        await WaitUntilAsync(() => !delivery.HasActiveOperation);
+    }
+
+    private static DiscordNewMemberWelcomeDelivery CreateDelivery(
+        Func<ulong, RequestOptions, Task<IDMChannel>> createDm,
+        Func<IDMChannel, string, RequestOptions, Task> sendMessage,
+        TimeSpan? operationTimeout = null,
+        NewMemberWelcomeRuntimeOptions? runtimeOptions = null)
+        => new(
+            createDm,
+            sendMessage,
+            new NewMemberWelcomeOptions(true, "configured welcome"),
+            runtimeOptions ?? RuntimeOptions(operationTimeout: operationTimeout),
+            NullLogger<DiscordNewMemberWelcomeDelivery>.Instance);
+
+    private static NewMemberWelcomeRuntimeOptions RuntimeOptions(
+        TimeSpan? operationTimeout = null,
+        int maximumDiscordOperations = 4)
+        => new(
+            MaximumOutstanding: 8,
+            WorkerCount: 2,
+            MaximumDiscordOperations: maximumDiscordOperations,
+            OperationTimeout: operationTimeout ?? TimeSpan.FromSeconds(1),
+            ShutdownDrainTimeout: TimeSpan.FromSeconds(1),
+            ShutdownCancellationGrace: TimeSpan.FromSeconds(1));
+
+    private static async Task WaitUntilAsync(Func<bool> predicate)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (!predicate())
+        {
+            if (DateTime.UtcNow >= deadline)
+            {
+                throw new TimeoutException("Condition was not met before the test deadline.");
+            }
+
+            await Task.Delay(10);
+        }
+    }
+}

--- a/BeanBot.Tests/Discord/Events/DiscordNewMemberWelcomeDeliveryTests.cs
+++ b/BeanBot.Tests/Discord/Events/DiscordNewMemberWelcomeDeliveryTests.cs
@@ -9,6 +9,70 @@ namespace BeanBot.Tests.Discord.Events;
 public class DiscordNewMemberWelcomeDeliveryTests
 {
     [Fact]
+    public async Task DeliverAsync_CanceledAsDmCreationCompletes_DoesNotInvokeSend()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var sends = 0;
+        var delivery = CreateDelivery(
+            (_, _) =>
+            {
+                cancellation.Cancel();
+                return Task.FromResult<IDMChannel>(null!);
+            },
+            (_, _, _) =>
+            {
+                sends++;
+                return Task.CompletedTask;
+            });
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => delivery.DeliverAsync(42, cancellation.Token));
+
+        Assert.Equal(0, sends);
+        Assert.False(delivery.HasActiveOperation);
+    }
+
+    [Fact]
+    public async Task ServiceStop_AfterDeliveryTimeout_CancelsAndRetainsRawDiscordOperation()
+    {
+        var stalled = new TaskCompletionSource<IDMChannel>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        CancellationToken requestToken = default;
+        var sends = 0;
+        var options = RuntimeOptions(TimeSpan.FromMilliseconds(25));
+        var delivery = CreateDelivery(
+            (_, request) =>
+            {
+                requestToken = request.CancelToken;
+                started.TrySetResult();
+                return stalled.Task;
+            },
+            (_, _, _) => { sends++; return Task.CompletedTask; },
+            runtimeOptions: options);
+        await using var service = new NewMemberWelcomeService(delivery, new NewMemberWelcomeOptions(true, "welcome"),
+            options, NullLogger<NewMemberWelcomeService>.Instance);
+        try
+        {
+            service.Start();
+            Assert.True(service.TryEnqueue(42, false));
+            await started.Task.WaitAsync(TimeSpan.FromSeconds(1));
+            await WaitUntilAsync(() => service.OutstandingCount == 0);
+            Assert.True(delivery.HasActiveOperation);
+
+            await service.StopAsync().WaitAsync(TimeSpan.FromSeconds(1));
+
+            Assert.True(requestToken.IsCancellationRequested);
+            Assert.True(service.HasActiveDiscordOperation);
+            Assert.Equal(0, sends);
+            Assert.False(service.TryEnqueue(43, false));
+        }
+        finally
+        {
+            stalled.TrySetException(new InvalidOperationException("late welcome failure"));
+            await WaitUntilAsync(() => !delivery.HasActiveOperation);
+        }
+    }
+
+    [Fact]
     public async Task DeliverAsync_CreatesDmAndSendsConfiguredMessageOnce()
     {
         RequestOptions? createOptions = null;

--- a/BeanBot.Tests/Discord/Events/NewMemberWelcomeServiceTests.cs
+++ b/BeanBot.Tests/Discord/Events/NewMemberWelcomeServiceTests.cs
@@ -1,0 +1,226 @@
+using BeanBot.Configuration;
+using BeanBot.Discord.Events;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.Events;
+
+public class NewMemberWelcomeServiceTests
+{
+    [Fact]
+    public async Task TryEnqueue_DeliversAcceptedHumanMemberOnce()
+    {
+        var delivered = new TaskCompletionSource<ulong>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var delivery = new StubDelivery((userId, _) =>
+        {
+            delivered.TrySetResult(userId);
+            return Task.CompletedTask;
+        });
+        await using var service = CreateService(delivery);
+        service.Start();
+
+        var accepted = service.TryEnqueue(42, isBot: false);
+
+        Assert.True(accepted);
+        Assert.Equal((ulong)42, await delivered.Task.WaitAsync(TimeSpan.FromSeconds(2)));
+        await WaitUntilAsync(() => service.OutstandingCount == 0);
+    }
+
+    [Fact]
+    public async Task TryEnqueue_IgnoresBotJoin()
+    {
+        var calls = 0;
+        var delivery = new StubDelivery((_, _) =>
+        {
+            Interlocked.Increment(ref calls);
+            return Task.CompletedTask;
+        });
+        await using var service = CreateService(delivery);
+        service.Start();
+
+        var accepted = service.TryEnqueue(42, isBot: true);
+        await Task.Delay(25);
+
+        Assert.False(accepted);
+        Assert.Equal(0, calls);
+        Assert.Equal(0, service.OutstandingCount);
+    }
+
+    [Fact]
+    public async Task TryEnqueue_WhenWelcomeDisabled_DoesNotQueueWork()
+    {
+        var calls = 0;
+        var delivery = new StubDelivery((_, _) =>
+        {
+            Interlocked.Increment(ref calls);
+            return Task.CompletedTask;
+        });
+        await using var service = CreateService(
+            delivery,
+            welcomeOptions: new NewMemberWelcomeOptions(false, string.Empty));
+        service.Start();
+
+        var accepted = service.TryEnqueue(42, isBot: false);
+        await Task.Delay(25);
+
+        Assert.False(accepted);
+        Assert.Equal(0, calls);
+    }
+
+    [Fact]
+    public async Task TryEnqueue_DuplicatePendingUserIsCoalesced()
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        var delivery = new StubDelivery(async (_, cancellationToken) =>
+        {
+            Interlocked.Increment(ref calls);
+            started.TrySetResult();
+            await release.Task.WaitAsync(cancellationToken);
+        });
+        await using var service = CreateService(delivery);
+        service.Start();
+
+        Assert.True(service.TryEnqueue(7, isBot: false));
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.False(service.TryEnqueue(7, isBot: false));
+        Assert.Equal(1, service.OutstandingCount);
+
+        release.TrySetResult();
+        await WaitUntilAsync(() => service.OutstandingCount == 0);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public async Task TryEnqueue_NeverExceedsMaximumOutstandingWork()
+    {
+        var firstStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var delivery = new StubDelivery(async (userId, cancellationToken) =>
+        {
+            if (userId == 1)
+            {
+                firstStarted.TrySetResult();
+            }
+
+            await release.Task.WaitAsync(cancellationToken);
+        });
+        var runtimeOptions = TestRuntimeOptions(maximumOutstanding: 2, workerCount: 1);
+        await using var service = CreateService(delivery, runtimeOptions: runtimeOptions);
+        service.Start();
+
+        Assert.True(service.TryEnqueue(1, isBot: false));
+        await firstStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.True(service.TryEnqueue(2, isBot: false));
+        Assert.False(service.TryEnqueue(3, isBot: false));
+        Assert.Equal(2, service.OutstandingCount);
+
+        release.TrySetResult();
+        await WaitUntilAsync(() => service.OutstandingCount == 0);
+    }
+
+    [Fact]
+    public async Task StopAsync_StopsAdmissionAndCancelsStalledActiveDeliveryAfterDrainBound()
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var canceled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var delivery = new StubDelivery(async (_, cancellationToken) =>
+        {
+            started.TrySetResult();
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                canceled.TrySetResult();
+                throw;
+            }
+        });
+        var runtimeOptions = TestRuntimeOptions(
+            shutdownDrainTimeout: TimeSpan.FromMilliseconds(25),
+            shutdownCancellationGrace: TimeSpan.FromSeconds(1));
+        await using var service = CreateService(delivery, runtimeOptions: runtimeOptions);
+        service.Start();
+        Assert.True(service.TryEnqueue(1, isBot: false));
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        await service.StopAsync().WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.False(service.TryEnqueue(2, isBot: false));
+        await canceled.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(0, service.OutstandingCount);
+    }
+
+    [Fact]
+    public async Task StartAndStop_AreIdempotent()
+    {
+        var calls = 0;
+        var delivered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var delivery = new StubDelivery((_, _) =>
+        {
+            Interlocked.Increment(ref calls);
+            delivered.TrySetResult();
+            return Task.CompletedTask;
+        });
+        await using var service = CreateService(delivery);
+
+        service.Start();
+        service.Start();
+        Assert.True(service.TryEnqueue(1, isBot: false));
+        await delivered.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await service.StopAsync();
+        await service.StopAsync();
+
+        Assert.Equal(1, calls);
+    }
+
+    private static NewMemberWelcomeService CreateService(
+        INewMemberWelcomeDelivery delivery,
+        NewMemberWelcomeOptions? welcomeOptions = null,
+        NewMemberWelcomeRuntimeOptions? runtimeOptions = null)
+        => new(
+            delivery,
+            welcomeOptions ?? new NewMemberWelcomeOptions(true, "welcome"),
+            runtimeOptions ?? TestRuntimeOptions(),
+            NullLogger<NewMemberWelcomeService>.Instance);
+
+    private static NewMemberWelcomeRuntimeOptions TestRuntimeOptions(
+        int maximumOutstanding = 8,
+        int workerCount = 2,
+        TimeSpan? shutdownDrainTimeout = null,
+        TimeSpan? shutdownCancellationGrace = null)
+        => new(
+            MaximumOutstanding: maximumOutstanding,
+            WorkerCount: workerCount,
+            MaximumDiscordOperations: 4,
+            OperationTimeout: TimeSpan.FromSeconds(1),
+            ShutdownDrainTimeout: shutdownDrainTimeout ?? TimeSpan.FromSeconds(1),
+            ShutdownCancellationGrace: shutdownCancellationGrace ?? TimeSpan.FromSeconds(1));
+
+    private static async Task WaitUntilAsync(Func<bool> predicate)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (!predicate())
+        {
+            if (DateTime.UtcNow >= deadline)
+            {
+                throw new TimeoutException("Condition was not met before the test deadline.");
+            }
+
+            await Task.Delay(10);
+        }
+    }
+
+    private sealed class StubDelivery(Func<ulong, CancellationToken, Task> deliver)
+        : INewMemberWelcomeDelivery
+    {
+        private readonly Func<ulong, CancellationToken, Task> _deliver = deliver;
+
+        public bool HasActiveOperation { get; set; }
+
+        public Task DeliverAsync(ulong userId, CancellationToken cancellationToken)
+            => _deliver(userId, cancellationToken);
+    }
+}

--- a/BeanBot.Tests/Discord/Events/NewMemberWelcomeServiceTests.cs
+++ b/BeanBot.Tests/Discord/Events/NewMemberWelcomeServiceTests.cs
@@ -8,6 +8,44 @@ namespace BeanBot.Tests.Discord.Events;
 public class NewMemberWelcomeServiceTests
 {
     [Fact]
+    public async Task StopBeforeStart_ClosesAdmissionPermanently()
+    {
+        var calls = 0;
+        await using var service = CreateService(new StubDelivery((_, _) =>
+        {
+            calls++;
+            return Task.CompletedTask;
+        }));
+
+        await service.StopAsync();
+        service.Start();
+
+        Assert.False(service.TryEnqueue(42, false));
+        await service.StopAsync();
+        Assert.Equal(0, calls);
+        Assert.Equal(0, service.OutstandingCount);
+    }
+
+    [Fact]
+    public async Task ConcurrentStartAndStop_AlwaysLeavesAdmissionClosed()
+    {
+        for (var iteration = 0; iteration < 32; iteration++)
+        {
+            await using var service = CreateService(new StubDelivery((_, _) => Task.CompletedTask));
+            var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var starting = Task.Run(async () => { await start.Task; service.Start(); });
+            var stopping = Task.Run(async () => { await start.Task; await service.StopAsync(); });
+            start.SetResult();
+
+            await Task.WhenAll(starting, stopping).WaitAsync(TimeSpan.FromSeconds(2));
+            service.Start();
+
+            Assert.False(service.TryEnqueue(42, false));
+            Assert.Equal(0, service.OutstandingCount);
+        }
+    }
+
+    [Fact]
     public async Task TryEnqueue_DeliversAcceptedHumanMemberOnce()
     {
         var delivered = new TaskCompletionSource<ulong>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/BeanBot/Configuration/BeanBotConfiguration.cs
+++ b/BeanBot/Configuration/BeanBotConfiguration.cs
@@ -14,6 +14,8 @@ internal static class BeanBotConfiguration
     internal const string HealthCheckBindAddressVariable = "BEANBOT_HEALTHCHECK_BIND_ADDRESS";
     internal const string HealthCheckBearerTokenVariable = "BEANBOT_HEALTHCHECK_BEARER_TOKEN";
     internal const string HealthCheckRateLimitVariable = "BEANBOT_HEALTHCHECK_RATE_LIMIT_SECONDS";
+    internal const string NewMemberWelcomeEnabledVariable = "BEANBOT_NEW_MEMBER_WELCOME_ENABLED";
+    internal const string NewMemberWelcomeMessageVariable = "BEANBOT_NEW_MEMBER_WELCOME_MESSAGE";
 
     private static readonly ConfigurationKey[] RequiredKeys =
     [
@@ -32,6 +34,12 @@ internal static class BeanBotConfiguration
         new(HealthCheckBindAddressVariable, "healthCheckBindAddress", "HealthCheck:BindAddress"),
         new(HealthCheckBearerTokenVariable, "healthCheckBearerToken", "HealthCheck:BearerToken"),
         new(HealthCheckRateLimitVariable, "healthCheckRateLimitSeconds", "HealthCheck:RateLimitSeconds")
+    ];
+
+    private static readonly ConfigurationKey[] NewMemberWelcomeKeys =
+    [
+        new(NewMemberWelcomeEnabledVariable, "newMemberWelcomeEnabled", "NewMemberWelcome:Enabled"),
+        new(NewMemberWelcomeMessageVariable, "newMemberWelcomeMessage", "NewMemberWelcome:Message")
     ];
 
     internal static ConfigurationManager AddBeanBotConfiguration(
@@ -60,6 +68,11 @@ internal static class BeanBotConfiguration
             {
                 AddNormalizedValue(configuration, normalizedValues, key);
             }
+        }
+
+        foreach (var key in NewMemberWelcomeKeys)
+        {
+            AddNormalizedValue(configuration, normalizedValues, key);
         }
 
         configuration.AddInMemoryCollection(normalizedValues);

--- a/BeanBot/Configuration/BeanBotSettings.cs
+++ b/BeanBot/Configuration/BeanBotSettings.cs
@@ -10,6 +10,7 @@ internal sealed class BeanBotSettings
     public string? HatoeteUrl { get; set; }
     public string? YoshimaruUrl { get; set; }
     public BeanBotHealthCheckSettings HealthCheck { get; set; } = new BeanBotHealthCheckSettings();
+    public BeanBotNewMemberWelcomeSettings NewMemberWelcome { get; set; } = new BeanBotNewMemberWelcomeSettings();
 }
 
 internal sealed class BeanBotHealthCheckSettings
@@ -18,4 +19,10 @@ internal sealed class BeanBotHealthCheckSettings
     public string? BindAddress { get; set; }
     public string? BearerToken { get; set; }
     public string? RateLimitSeconds { get; set; }
+}
+
+internal sealed class BeanBotNewMemberWelcomeSettings
+{
+    public string? Enabled { get; set; }
+    public string? Message { get; set; }
 }

--- a/BeanBot/Configuration/BeanBotSettingsValidator.cs
+++ b/BeanBot/Configuration/BeanBotSettingsValidator.cs
@@ -45,6 +45,7 @@ internal sealed class BeanBotSettingsValidator : IValidateOptions<BeanBotSetting
             failures);
 
         ValidateHealthCheck(settings.HealthCheck, failures);
+        ValidateNewMemberWelcome(settings.NewMemberWelcome, failures);
 
         return failures.Count == 0
             ? ValidateOptionsResult.Success
@@ -88,6 +89,34 @@ internal sealed class BeanBotSettingsValidator : IValidateOptions<BeanBotSetting
             failures.Add(
                 $"Invalid value for {BeanBotConfiguration.HealthCheckRateLimitVariable}. " +
                 "Expected a positive number of seconds.");
+        }
+    }
+
+    private static void ValidateNewMemberWelcome(
+        BeanBotNewMemberWelcomeSettings settings,
+        List<string> failures)
+    {
+        var enabled = true;
+        if (settings.Enabled is not null && !bool.TryParse(settings.Enabled, out enabled))
+        {
+            failures.Add(
+                $"Invalid value for {BeanBotConfiguration.NewMemberWelcomeEnabledVariable}. " +
+                "Expected true or false.");
+            enabled = true;
+        }
+
+        if (settings.Message is { Length: > NewMemberWelcomeOptions.DiscordMessageMaximumLength })
+        {
+            failures.Add(
+                $"Invalid value for {BeanBotConfiguration.NewMemberWelcomeMessageVariable}. " +
+                $"Expected at most {NewMemberWelcomeOptions.DiscordMessageMaximumLength} characters.");
+        }
+
+        if (enabled && settings.Message is not null && string.IsNullOrWhiteSpace(settings.Message))
+        {
+            failures.Add(
+                $"Invalid value for {BeanBotConfiguration.NewMemberWelcomeMessageVariable}. " +
+                "Expected a non-empty message while new-member welcomes are enabled.");
         }
     }
 

--- a/BeanBot/Configuration/NewMemberWelcomeOptions.cs
+++ b/BeanBot/Configuration/NewMemberWelcomeOptions.cs
@@ -1,0 +1,28 @@
+namespace BeanBot.Configuration;
+
+internal sealed class NewMemberWelcomeOptions
+{
+    internal const int DiscordMessageMaximumLength = 2000;
+
+    internal const string DefaultMessage =
+        "Please read the rules in the Eli's Charter channel. If you agree to these rules and are over the age of 17, please DM one of the moderators with the blue role \"Student Council\" (i.e discount Hatate/Makoto Kikuchi#2351) for full access to the server! (I promise it's worth it)";
+
+    internal NewMemberWelcomeOptions(bool enabled, string message)
+    {
+        Enabled = enabled;
+        Message = message ?? throw new ArgumentNullException(nameof(message));
+    }
+
+    internal bool Enabled { get; }
+    internal string Message { get; }
+
+    internal static NewMemberWelcomeOptions Create(BeanBotNewMemberWelcomeSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        var enabled = settings.Enabled is null || bool.Parse(settings.Enabled);
+        return new NewMemberWelcomeOptions(
+            enabled,
+            settings.Message ?? DefaultMessage);
+    }
+}

--- a/BeanBot/Discord/Events/DiscordNewMemberWelcomeDelivery.cs
+++ b/BeanBot/Discord/Events/DiscordNewMemberWelcomeDelivery.cs
@@ -28,12 +28,20 @@ internal sealed class DiscordNewMemberWelcomeDelivery : INewMemberWelcomeDeliver
         NewMemberWelcomeRuntimeOptions runtimeOptions,
         ILogger<DiscordNewMemberWelcomeDelivery> logger)
         : this(
-            (userId, requestOptions) =>
+            async (userId, requestOptions) =>
             {
                 var user = discordClient.GetUser(userId) ??
+                    await ((IDiscordClient)discordClient).GetUserAsync(
+                        userId,
+                        CacheMode.AllowDownload,
+                        requestOptions);
+                if (user is null)
+                {
                     throw new InvalidOperationException(
                         $"Discord user {userId} is no longer available for welcome delivery.");
-                return user.CreateDMChannelAsync(requestOptions);
+                }
+
+                return await user.CreateDMChannelAsync(requestOptions);
             },
             async (channel, message, requestOptions) =>
                 await channel.SendMessageAsync(message, options: requestOptions),

--- a/BeanBot/Discord/Events/DiscordNewMemberWelcomeDelivery.cs
+++ b/BeanBot/Discord/Events/DiscordNewMemberWelcomeDelivery.cs
@@ -19,7 +19,7 @@ internal sealed class DiscordNewMemberWelcomeDelivery : INewMemberWelcomeDeliver
     private readonly NewMemberWelcomeOptions _welcomeOptions;
     private readonly NewMemberWelcomeRuntimeOptions _runtimeOptions;
     private readonly ILogger<DiscordNewMemberWelcomeDelivery> _logger;
-    private readonly SemaphoreSlim _operationSlots;
+    private int _availableOperationSlots;
     private int _activeOperationCount;
 
     public DiscordNewMemberWelcomeDelivery(
@@ -57,9 +57,7 @@ internal sealed class DiscordNewMemberWelcomeDelivery : INewMemberWelcomeDeliver
         _runtimeOptions = runtimeOptions ?? throw new ArgumentNullException(nameof(runtimeOptions));
         _runtimeOptions.Validate();
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _operationSlots = new SemaphoreSlim(
-            _runtimeOptions.MaximumDiscordOperations,
-            _runtimeOptions.MaximumDiscordOperations);
+        _availableOperationSlots = _runtimeOptions.MaximumDiscordOperations;
     }
 
     public bool HasActiveOperation => Volatile.Read(ref _activeOperationCount) > 0;
@@ -88,13 +86,12 @@ internal sealed class DiscordNewMemberWelcomeDelivery : INewMemberWelcomeDeliver
         ulong userId,
         CancellationToken cancellationToken)
     {
-        if (!_operationSlots.Wait(0))
+        if (!TryAcquireOperationSlot())
         {
             throw new InvalidOperationException(
                 "The bounded new-member Discord operation capacity is exhausted.");
         }
 
-        Interlocked.Increment(ref _activeOperationCount);
         Task<T> operation;
         try
         {
@@ -140,13 +137,12 @@ internal sealed class DiscordNewMemberWelcomeDelivery : INewMemberWelcomeDeliver
         ulong userId,
         CancellationToken cancellationToken)
     {
-        if (!_operationSlots.Wait(0))
+        if (!TryAcquireOperationSlot())
         {
             throw new InvalidOperationException(
                 "The bounded new-member Discord operation capacity is exhausted.");
         }
 
-        Interlocked.Increment(ref _activeOperationCount);
         Task operation;
         try
         {
@@ -186,6 +182,27 @@ internal sealed class DiscordNewMemberWelcomeDelivery : INewMemberWelcomeDeliver
         }
     }
 
+    private bool TryAcquireOperationSlot()
+    {
+        while (true)
+        {
+            var available = Volatile.Read(ref _availableOperationSlots);
+            if (available <= 0)
+            {
+                return false;
+            }
+
+            if (Interlocked.CompareExchange(
+                    ref _availableOperationSlots,
+                    available - 1,
+                    available) == available)
+            {
+                Interlocked.Increment(ref _activeOperationCount);
+                return true;
+            }
+        }
+    }
+
     private void ObserveLateCompletionAndRelease(Task operation, string operationName, ulong userId)
     {
         _ = operation.ContinueWith(
@@ -215,6 +232,6 @@ internal sealed class DiscordNewMemberWelcomeDelivery : INewMemberWelcomeDeliver
     private void ReleaseOperationSlot()
     {
         Interlocked.Decrement(ref _activeOperationCount);
-        _operationSlots.Release();
+        Interlocked.Increment(ref _availableOperationSlots);
     }
 }

--- a/BeanBot/Discord/Events/DiscordNewMemberWelcomeDelivery.cs
+++ b/BeanBot/Discord/Events/DiscordNewMemberWelcomeDelivery.cs
@@ -1,0 +1,220 @@
+using BeanBot.Configuration;
+using BeanBot.Logging;
+using Discord;
+using Discord.WebSocket;
+using Microsoft.Extensions.Logging;
+
+namespace BeanBot.Discord.Events;
+
+internal interface INewMemberWelcomeDelivery
+{
+    bool HasActiveOperation { get; }
+    Task DeliverAsync(ulong userId, CancellationToken cancellationToken);
+}
+
+internal sealed class DiscordNewMemberWelcomeDelivery : INewMemberWelcomeDelivery
+{
+    private readonly Func<ulong, RequestOptions, Task<IDMChannel>> _createDmChannel;
+    private readonly Func<IDMChannel, string, RequestOptions, Task> _sendMessage;
+    private readonly NewMemberWelcomeOptions _welcomeOptions;
+    private readonly NewMemberWelcomeRuntimeOptions _runtimeOptions;
+    private readonly ILogger<DiscordNewMemberWelcomeDelivery> _logger;
+    private readonly SemaphoreSlim _operationSlots;
+    private int _activeOperationCount;
+
+    public DiscordNewMemberWelcomeDelivery(
+        DiscordSocketClient discordClient,
+        NewMemberWelcomeOptions welcomeOptions,
+        NewMemberWelcomeRuntimeOptions runtimeOptions,
+        ILogger<DiscordNewMemberWelcomeDelivery> logger)
+        : this(
+            (userId, requestOptions) =>
+            {
+                var user = discordClient.GetUser(userId) ??
+                    throw new InvalidOperationException(
+                        $"Discord user {userId} is no longer available for welcome delivery.");
+                return user.CreateDMChannelAsync(requestOptions);
+            },
+            async (channel, message, requestOptions) =>
+                await channel.SendMessageAsync(message, options: requestOptions),
+            welcomeOptions,
+            runtimeOptions,
+            logger)
+    {
+        ArgumentNullException.ThrowIfNull(discordClient);
+    }
+
+    internal DiscordNewMemberWelcomeDelivery(
+        Func<ulong, RequestOptions, Task<IDMChannel>> createDmChannel,
+        Func<IDMChannel, string, RequestOptions, Task> sendMessage,
+        NewMemberWelcomeOptions welcomeOptions,
+        NewMemberWelcomeRuntimeOptions runtimeOptions,
+        ILogger<DiscordNewMemberWelcomeDelivery> logger)
+    {
+        _createDmChannel = createDmChannel ?? throw new ArgumentNullException(nameof(createDmChannel));
+        _sendMessage = sendMessage ?? throw new ArgumentNullException(nameof(sendMessage));
+        _welcomeOptions = welcomeOptions ?? throw new ArgumentNullException(nameof(welcomeOptions));
+        _runtimeOptions = runtimeOptions ?? throw new ArgumentNullException(nameof(runtimeOptions));
+        _runtimeOptions.Validate();
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _operationSlots = new SemaphoreSlim(
+            _runtimeOptions.MaximumDiscordOperations,
+            _runtimeOptions.MaximumDiscordOperations);
+    }
+
+    public bool HasActiveOperation => Volatile.Read(ref _activeOperationCount) > 0;
+
+    public async Task DeliverAsync(ulong userId, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var requestOptions = new RequestOptions { CancelToken = cancellationToken };
+
+        var dmChannel = await RunBoundedOperationAsync(
+            () => _createDmChannel(userId, requestOptions),
+            "create-dm-channel",
+            userId,
+            cancellationToken);
+
+        await RunBoundedOperationAsync(
+            () => _sendMessage(dmChannel, _welcomeOptions.Message, requestOptions),
+            "send-message",
+            userId,
+            cancellationToken);
+    }
+
+    private async Task<T> RunBoundedOperationAsync<T>(
+        Func<Task<T>> beginOperation,
+        string operationName,
+        ulong userId,
+        CancellationToken cancellationToken)
+    {
+        if (!_operationSlots.Wait(0))
+        {
+            throw new InvalidOperationException(
+                "The bounded new-member Discord operation capacity is exhausted.");
+        }
+
+        Interlocked.Increment(ref _activeOperationCount);
+        Task<T> operation;
+        try
+        {
+            operation = beginOperation();
+        }
+        catch
+        {
+            ReleaseOperationSlot();
+            throw;
+        }
+
+        var releaseOnReturn = true;
+        try
+        {
+            return await operation.WaitAsync(_runtimeOptions.OperationTimeout, cancellationToken);
+        }
+        catch
+        {
+            if (!operation.IsCompleted)
+            {
+                releaseOnReturn = false;
+                ObserveLateCompletionAndRelease(operation, operationName, userId);
+            }
+            else
+            {
+                _ = operation.Exception;
+            }
+
+            throw;
+        }
+        finally
+        {
+            if (releaseOnReturn)
+            {
+                ReleaseOperationSlot();
+            }
+        }
+    }
+
+    private async Task RunBoundedOperationAsync(
+        Func<Task> beginOperation,
+        string operationName,
+        ulong userId,
+        CancellationToken cancellationToken)
+    {
+        if (!_operationSlots.Wait(0))
+        {
+            throw new InvalidOperationException(
+                "The bounded new-member Discord operation capacity is exhausted.");
+        }
+
+        Interlocked.Increment(ref _activeOperationCount);
+        Task operation;
+        try
+        {
+            operation = beginOperation();
+        }
+        catch
+        {
+            ReleaseOperationSlot();
+            throw;
+        }
+
+        var releaseOnReturn = true;
+        try
+        {
+            await operation.WaitAsync(_runtimeOptions.OperationTimeout, cancellationToken);
+        }
+        catch
+        {
+            if (!operation.IsCompleted)
+            {
+                releaseOnReturn = false;
+                ObserveLateCompletionAndRelease(operation, operationName, userId);
+            }
+            else
+            {
+                _ = operation.Exception;
+            }
+
+            throw;
+        }
+        finally
+        {
+            if (releaseOnReturn)
+            {
+                ReleaseOperationSlot();
+            }
+        }
+    }
+
+    private void ObserveLateCompletionAndRelease(Task operation, string operationName, ulong userId)
+    {
+        _ = operation.ContinueWith(
+            completedTask =>
+            {
+                try
+                {
+                    if (completedTask.IsFaulted)
+                    {
+                        BeanBotLog.WelcomeDeliveryLateFailure(
+                            _logger,
+                            operationName,
+                            userId,
+                            completedTask.Exception!);
+                    }
+                }
+                finally
+                {
+                    ReleaseOperationSlot();
+                }
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    private void ReleaseOperationSlot()
+    {
+        Interlocked.Decrement(ref _activeOperationCount);
+        _operationSlots.Release();
+    }
+}

--- a/BeanBot/Discord/Events/DiscordNewMemberWelcomeDelivery.cs
+++ b/BeanBot/Discord/Events/DiscordNewMemberWelcomeDelivery.cs
@@ -41,6 +41,7 @@ internal sealed class DiscordNewMemberWelcomeDelivery : INewMemberWelcomeDeliver
                         $"Discord user {userId} is no longer available for welcome delivery.");
                 }
 
+                requestOptions.CancelToken.ThrowIfCancellationRequested();
                 return await user.CreateDMChannelAsync(requestOptions);
             },
             async (channel, message, requestOptions) =>
@@ -94,6 +95,7 @@ internal sealed class DiscordNewMemberWelcomeDelivery : INewMemberWelcomeDeliver
         ulong userId,
         CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         if (!TryAcquireOperationSlot())
         {
             throw new InvalidOperationException(
@@ -103,6 +105,7 @@ internal sealed class DiscordNewMemberWelcomeDelivery : INewMemberWelcomeDeliver
         Task<T> operation;
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
             operation = beginOperation();
         }
         catch
@@ -145,6 +148,7 @@ internal sealed class DiscordNewMemberWelcomeDelivery : INewMemberWelcomeDeliver
         ulong userId,
         CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         if (!TryAcquireOperationSlot())
         {
             throw new InvalidOperationException(
@@ -154,6 +158,7 @@ internal sealed class DiscordNewMemberWelcomeDelivery : INewMemberWelcomeDeliver
         Task operation;
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
             operation = beginOperation();
         }
         catch

--- a/BeanBot/Discord/Events/NewMemberHandler.cs
+++ b/BeanBot/Discord/Events/NewMemberHandler.cs
@@ -8,16 +8,19 @@ internal sealed class NewMemberHandler : IDisposable
 {
     private readonly DiscordSocketClient _discordClient;
     private readonly LogHandler _logHandler;
+    private readonly NewMemberWelcomeService _welcomeService;
     private readonly ILogger<NewMemberHandler> _logger;
     private bool _initialized;
 
     public NewMemberHandler(
         DiscordSocketClient client,
         LogHandler logHandler,
+        NewMemberWelcomeService welcomeService,
         ILogger<NewMemberHandler> logger)
     {
         _discordClient = client ?? throw new ArgumentNullException(nameof(client));
         _logHandler = logHandler ?? throw new ArgumentNullException(nameof(logHandler));
+        _welcomeService = welcomeService ?? throw new ArgumentNullException(nameof(welcomeService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -29,28 +32,15 @@ internal sealed class NewMemberHandler : IDisposable
         }
 
         BeanBotLog.NewMemberHandlerInitializing(_logger);
-        _discordClient.UserJoined += WelcomeNewMemberAsync;
+        _discordClient.UserJoined += HandleUserJoinedAsync;
         _discordClient.UserJoined += _logHandler.LogNewMember;
         _initialized = true;
     }
 
-    private async Task WelcomeNewMemberAsync(SocketGuildUser user)
+    private Task HandleUserJoinedAsync(SocketGuildUser user)
     {
-        if (user.IsBot)
-        {
-            return;
-        }
-
-        try
-        {
-            var userDmChannel = await user.CreateDMChannelAsync();
-            await userDmChannel.SendMessageAsync("Please read the rules in the Eli's Charter channel. If you agree to these rules and are over the age of 17, please DM one of the moderators with the blue role \"Student Council\" (i.e discount Hatate/Makoto Kikuchi#2351) for full access to the server! (I promise it's worth it)");
-            BeanBotLog.WelcomeMessageSent(_logger, user.Id);
-        }
-        catch (Exception exception)
-        {
-            BeanBotLog.WelcomeMessageFailed(_logger, user.Id, exception);
-        }
+        _welcomeService.TryEnqueue(user.Id, user.IsBot);
+        return Task.CompletedTask;
     }
 
     public void Dispose()
@@ -60,7 +50,7 @@ internal sealed class NewMemberHandler : IDisposable
             return;
         }
 
-        _discordClient.UserJoined -= WelcomeNewMemberAsync;
+        _discordClient.UserJoined -= HandleUserJoinedAsync;
         _discordClient.UserJoined -= _logHandler.LogNewMember;
         _initialized = false;
     }

--- a/BeanBot/Discord/Events/NewMemberWelcomeRuntimeOptions.cs
+++ b/BeanBot/Discord/Events/NewMemberWelcomeRuntimeOptions.cs
@@ -1,0 +1,29 @@
+namespace BeanBot.Discord.Events;
+
+internal sealed record NewMemberWelcomeRuntimeOptions(
+    int MaximumOutstanding,
+    int WorkerCount,
+    int MaximumDiscordOperations,
+    TimeSpan OperationTimeout,
+    TimeSpan ShutdownDrainTimeout,
+    TimeSpan ShutdownCancellationGrace)
+{
+    internal static NewMemberWelcomeRuntimeOptions Default { get; } = new(
+        MaximumOutstanding: 64,
+        WorkerCount: 2,
+        MaximumDiscordOperations: 4,
+        OperationTimeout: TimeSpan.FromSeconds(10),
+        ShutdownDrainTimeout: TimeSpan.FromSeconds(5),
+        ShutdownCancellationGrace: TimeSpan.FromSeconds(1));
+
+    internal void Validate()
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(MaximumOutstanding, 0);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(WorkerCount, 0);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(WorkerCount, MaximumOutstanding);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(MaximumDiscordOperations, 0);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(OperationTimeout, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(ShutdownDrainTimeout, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(ShutdownCancellationGrace, TimeSpan.Zero);
+    }
+}

--- a/BeanBot/Discord/Events/NewMemberWelcomeService.cs
+++ b/BeanBot/Discord/Events/NewMemberWelcomeService.cs
@@ -64,9 +64,8 @@ internal sealed class NewMemberWelcomeService : IAsyncDisposable
         }
 
         Volatile.Write(ref _accepting, 1);
-        _workers = Enumerable.Range(0, _runtimeOptions.WorkerCount)
-            .Select(_ => Task.Run(() => ProcessQueueAsync(_shutdownCancellation.Token)))
-            .ToArray();
+        _workers = [.. Enumerable.Range(0, _runtimeOptions.WorkerCount)
+            .Select(_ => Task.Run(() => ProcessQueueAsync(_shutdownCancellation.Token)))];
     }
 
     internal bool TryEnqueue(ulong userId, bool isBot)

--- a/BeanBot/Discord/Events/NewMemberWelcomeService.cs
+++ b/BeanBot/Discord/Events/NewMemberWelcomeService.cs
@@ -1,0 +1,218 @@
+using System.Collections.Concurrent;
+using System.Threading.Channels;
+using BeanBot.Configuration;
+using BeanBot.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace BeanBot.Discord.Events;
+
+internal sealed class NewMemberWelcomeService : IAsyncDisposable
+{
+    private readonly INewMemberWelcomeDelivery _delivery;
+    private readonly NewMemberWelcomeOptions _welcomeOptions;
+    private readonly NewMemberWelcomeRuntimeOptions _runtimeOptions;
+    private readonly ILogger<NewMemberWelcomeService> _logger;
+    private readonly Channel<ulong> _queue;
+    private readonly ConcurrentDictionary<ulong, byte> _outstandingUsers = new();
+    private readonly SemaphoreSlim _outstandingSlots;
+    private readonly CancellationTokenSource _shutdownCancellation = new();
+    private readonly object _stopLock = new();
+    private Task[] _workers = [];
+    private Task? _stopTask;
+    private int _started;
+    private int _accepting;
+
+    public NewMemberWelcomeService(
+        INewMemberWelcomeDelivery delivery,
+        NewMemberWelcomeOptions welcomeOptions,
+        NewMemberWelcomeRuntimeOptions runtimeOptions,
+        ILogger<NewMemberWelcomeService> logger)
+    {
+        _delivery = delivery ?? throw new ArgumentNullException(nameof(delivery));
+        _welcomeOptions = welcomeOptions ?? throw new ArgumentNullException(nameof(welcomeOptions));
+        _runtimeOptions = runtimeOptions ?? throw new ArgumentNullException(nameof(runtimeOptions));
+        _runtimeOptions.Validate();
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        _queue = Channel.CreateBounded<ulong>(new BoundedChannelOptions(_runtimeOptions.MaximumOutstanding)
+        {
+            SingleWriter = false,
+            SingleReader = _runtimeOptions.WorkerCount == 1,
+            FullMode = BoundedChannelFullMode.Wait,
+            AllowSynchronousContinuations = false
+        });
+        _outstandingSlots = new SemaphoreSlim(
+            _runtimeOptions.MaximumOutstanding,
+            _runtimeOptions.MaximumOutstanding);
+    }
+
+    internal bool HasActiveDiscordOperation => _delivery.HasActiveOperation;
+
+    internal int OutstandingCount => _outstandingUsers.Count;
+
+    internal void Start()
+    {
+        if (Interlocked.Exchange(ref _started, 1) != 0)
+        {
+            return;
+        }
+
+        if (!_welcomeOptions.Enabled)
+        {
+            _queue.Writer.TryComplete();
+            return;
+        }
+
+        Volatile.Write(ref _accepting, 1);
+        _workers = Enumerable.Range(0, _runtimeOptions.WorkerCount)
+            .Select(_ => Task.Run(() => ProcessQueueAsync(_shutdownCancellation.Token)))
+            .ToArray();
+    }
+
+    internal bool TryEnqueue(ulong userId, bool isBot)
+    {
+        if (isBot || !_welcomeOptions.Enabled || Volatile.Read(ref _accepting) == 0)
+        {
+            return false;
+        }
+
+        if (!_outstandingSlots.Wait(0))
+        {
+            BeanBotLog.WelcomeCapacityFull(_logger, userId, _runtimeOptions.MaximumOutstanding);
+            return false;
+        }
+
+        if (!_outstandingUsers.TryAdd(userId, 0))
+        {
+            _outstandingSlots.Release();
+            BeanBotLog.WelcomeDuplicateSuppressed(_logger, userId);
+            return false;
+        }
+
+        if (_queue.Writer.TryWrite(userId))
+        {
+            return true;
+        }
+
+        ReleaseOutstanding(userId);
+        return false;
+    }
+
+    internal void StopAccepting()
+    {
+        if (Interlocked.Exchange(ref _accepting, 0) == 0)
+        {
+            return;
+        }
+
+        _queue.Writer.TryComplete();
+    }
+
+    internal Task StopAsync()
+    {
+        lock (_stopLock)
+        {
+            return _stopTask ??= StopCoreAsync();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+        => await StopAsync();
+
+    private async Task StopCoreAsync()
+    {
+        StopAccepting();
+        if (_workers.Length == 0)
+        {
+            DrainPendingQueue();
+            return;
+        }
+
+        var workers = Task.WhenAll(_workers);
+        try
+        {
+            await workers.WaitAsync(_runtimeOptions.ShutdownDrainTimeout);
+        }
+        catch (TimeoutException)
+        {
+            BeanBotLog.WelcomeDrainTimedOut(_logger, _runtimeOptions.ShutdownDrainTimeout);
+            _shutdownCancellation.Cancel();
+            try
+            {
+                await workers.WaitAsync(_runtimeOptions.ShutdownCancellationGrace);
+            }
+            catch (TimeoutException)
+            {
+                BeanBotLog.WelcomeCancellationGraceTimedOut(
+                    _logger,
+                    _runtimeOptions.ShutdownCancellationGrace);
+                ObserveLateWorkerFault(workers);
+            }
+        }
+        finally
+        {
+            DrainPendingQueue();
+        }
+    }
+
+    private async Task ProcessQueueAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await foreach (var userId in _queue.Reader.ReadAllAsync(cancellationToken))
+            {
+                try
+                {
+                    await _delivery.DeliverAsync(userId, cancellationToken);
+                    BeanBotLog.WelcomeMessageSent(_logger, userId);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    BeanBotLog.WelcomeDeliveryCanceled(_logger, userId);
+                }
+                catch (Exception exception)
+                {
+                    BeanBotLog.WelcomeMessageFailed(_logger, userId, exception);
+                }
+                finally
+                {
+                    ReleaseOutstanding(userId);
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+    }
+
+    private void DrainPendingQueue()
+    {
+        while (_queue.Reader.TryRead(out var userId))
+        {
+            ReleaseOutstanding(userId);
+        }
+    }
+
+    private void ReleaseOutstanding(ulong userId)
+    {
+        if (_outstandingUsers.TryRemove(userId, out _))
+        {
+            _outstandingSlots.Release();
+        }
+    }
+
+    private static void ObserveLateWorkerFault(Task workers)
+    {
+        if (workers.IsCompleted)
+        {
+            _ = workers.Exception;
+            return;
+        }
+
+        _ = workers.ContinueWith(
+            completedTask => _ = completedTask.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+}

--- a/BeanBot/Discord/Events/NewMemberWelcomeService.cs
+++ b/BeanBot/Discord/Events/NewMemberWelcomeService.cs
@@ -21,6 +21,7 @@ internal sealed class NewMemberWelcomeService : IAsyncDisposable
     private Task? _stopTask;
     private int _started;
     private int _accepting;
+    private bool _stopping;
 
     public NewMemberWelcomeService(
         INewMemberWelcomeDelivery delivery,
@@ -52,20 +53,24 @@ internal sealed class NewMemberWelcomeService : IAsyncDisposable
 
     internal void Start()
     {
-        if (Interlocked.Exchange(ref _started, 1) != 0)
+        lock (_stopLock)
         {
-            return;
-        }
+            if (_started != 0 || _stopping)
+            {
+                return;
+            }
+            _started = 1;
 
-        if (!_welcomeOptions.Enabled)
-        {
-            _queue.Writer.TryComplete();
-            return;
-        }
+            if (!_welcomeOptions.Enabled)
+            {
+                _queue.Writer.TryComplete();
+                return;
+            }
 
-        Volatile.Write(ref _accepting, 1);
-        _workers = [.. Enumerable.Range(0, _runtimeOptions.WorkerCount)
-            .Select(_ => Task.Run(() => ProcessQueueAsync(_shutdownCancellation.Token)))];
+            Volatile.Write(ref _accepting, 1);
+            _workers = [.. Enumerable.Range(0, _runtimeOptions.WorkerCount)
+                .Select(_ => Task.Run(() => ProcessQueueAsync(_shutdownCancellation.Token)))];
+        }
     }
 
     internal bool TryEnqueue(ulong userId, bool isBot)
@@ -99,12 +104,12 @@ internal sealed class NewMemberWelcomeService : IAsyncDisposable
 
     internal void StopAccepting()
     {
-        if (Interlocked.Exchange(ref _accepting, 0) == 0)
+        lock (_stopLock)
         {
-            return;
+            _stopping = true;
+            Volatile.Write(ref _accepting, 0);
+            _queue.Writer.TryComplete();
         }
-
-        _queue.Writer.TryComplete();
     }
 
     internal Task StopAsync()
@@ -123,6 +128,7 @@ internal sealed class NewMemberWelcomeService : IAsyncDisposable
         StopAccepting();
         if (_workers.Length == 0)
         {
+            _shutdownCancellation.Cancel();
             DrainPendingQueue();
             return;
         }
@@ -150,6 +156,7 @@ internal sealed class NewMemberWelcomeService : IAsyncDisposable
         }
         finally
         {
+            _shutdownCancellation.Cancel();
             DrainPendingQueue();
         }
     }

--- a/BeanBot/Hosting/BeanBotApplication.cs
+++ b/BeanBot/Hosting/BeanBotApplication.cs
@@ -7,6 +7,7 @@ namespace BeanBot.Hosting;
 internal interface IBeanBotRuntime
 {
     bool HasActiveDiscordLifecycleOperation { get; }
+    bool HasActiveNewMemberWelcomeOperation { get; }
     bool CanDisposeDiscordClient { get; }
     void SubscribeApplicationEvents();
     Task StartHealthServerAsync(CancellationToken cancellationToken);
@@ -16,6 +17,7 @@ internal interface IBeanBotRuntime
     void StartEventAndBackgroundServices();
     void StopReactionServices();
     void StopNewMemberEvents();
+    Task StopNewMemberWelcomeServiceAsync();
     void StopEditedMessageEvents();
     void StopCommandServices();
     void StopMessageWaiter();
@@ -133,6 +135,7 @@ internal sealed class BeanBotApplication : IBeanBotApplication
 
         await RunSynchronousStageAsync("reaction-services", _runtime.StopReactionServices);
         await RunSynchronousStageAsync("new-member-events", _runtime.StopNewMemberEvents);
+        await RunStageAsync("new-member-welcome", _runtime.StopNewMemberWelcomeServiceAsync);
         await RunSynchronousStageAsync("edited-message-events", _runtime.StopEditedMessageEvents);
         await RunSynchronousStageAsync("command-services", _runtime.StopCommandServices);
         await RunSynchronousStageAsync("message-waiter", _runtime.StopMessageWaiter);
@@ -147,7 +150,9 @@ internal sealed class BeanBotApplication : IBeanBotApplication
         var canStopDiscord = false;
         await RunSynchronousStageAsync(
             "discord-startup-state",
-            () => canStopDiscord = !_runtime.HasActiveDiscordLifecycleOperation);
+            () => canStopDiscord =
+                !_runtime.HasActiveDiscordLifecycleOperation &&
+                !_runtime.HasActiveNewMemberWelcomeOperation);
         if (!canStopDiscord)
         {
             BeanBotLog.DiscordStopSkipped(_logger);

--- a/BeanBot/Hosting/BeanBotApplication.cs
+++ b/BeanBot/Hosting/BeanBotApplication.cs
@@ -7,7 +7,6 @@ namespace BeanBot.Hosting;
 internal interface IBeanBotRuntime
 {
     bool HasActiveDiscordLifecycleOperation { get; }
-    bool HasActiveNewMemberWelcomeOperation { get; }
     bool CanDisposeDiscordClient { get; }
     void SubscribeApplicationEvents();
     Task StartHealthServerAsync(CancellationToken cancellationToken);
@@ -17,7 +16,6 @@ internal interface IBeanBotRuntime
     void StartEventAndBackgroundServices();
     void StopReactionServices();
     void StopNewMemberEvents();
-    Task StopNewMemberWelcomeServiceAsync();
     void StopEditedMessageEvents();
     void StopCommandServices();
     void StopMessageWaiter();
@@ -135,7 +133,6 @@ internal sealed class BeanBotApplication : IBeanBotApplication
 
         await RunSynchronousStageAsync("reaction-services", _runtime.StopReactionServices);
         await RunSynchronousStageAsync("new-member-events", _runtime.StopNewMemberEvents);
-        await RunStageAsync("new-member-welcome", _runtime.StopNewMemberWelcomeServiceAsync);
         await RunSynchronousStageAsync("edited-message-events", _runtime.StopEditedMessageEvents);
         await RunSynchronousStageAsync("command-services", _runtime.StopCommandServices);
         await RunSynchronousStageAsync("message-waiter", _runtime.StopMessageWaiter);
@@ -150,9 +147,7 @@ internal sealed class BeanBotApplication : IBeanBotApplication
         var canStopDiscord = false;
         await RunSynchronousStageAsync(
             "discord-startup-state",
-            () => canStopDiscord =
-                !_runtime.HasActiveDiscordLifecycleOperation &&
-                !_runtime.HasActiveNewMemberWelcomeOperation);
+            () => canStopDiscord = !_runtime.HasActiveDiscordLifecycleOperation);
         if (!canStopDiscord)
         {
             BeanBotLog.DiscordStopSkipped(_logger);

--- a/BeanBot/Hosting/BeanBotRuntime.cs
+++ b/BeanBot/Hosting/BeanBotRuntime.cs
@@ -22,6 +22,7 @@ internal sealed class BeanBotRuntime : IBeanBotRuntime
     private readonly PunHandler _punHandler;
     private readonly EditMessageHandler _editMessageHandler;
     private readonly NewMemberHandler _newMemberHandler;
+    private readonly NewMemberWelcomeService _newMemberWelcomeService;
     private readonly ReactHandler _reactHandler;
     private readonly DiscordMessageWaiter _messageWaiter;
     private readonly DiscordPaginatorService _paginatorService;
@@ -42,6 +43,7 @@ internal sealed class BeanBotRuntime : IBeanBotRuntime
         PunHandler punHandler,
         EditMessageHandler editMessageHandler,
         NewMemberHandler newMemberHandler,
+        NewMemberWelcomeService newMemberWelcomeService,
         ReactHandler reactHandler,
         DiscordMessageWaiter messageWaiter,
         DiscordPaginatorService paginatorService,
@@ -60,6 +62,7 @@ internal sealed class BeanBotRuntime : IBeanBotRuntime
         _punHandler = punHandler ?? throw new ArgumentNullException(nameof(punHandler));
         _editMessageHandler = editMessageHandler ?? throw new ArgumentNullException(nameof(editMessageHandler));
         _newMemberHandler = newMemberHandler ?? throw new ArgumentNullException(nameof(newMemberHandler));
+        _newMemberWelcomeService = newMemberWelcomeService ?? throw new ArgumentNullException(nameof(newMemberWelcomeService));
         _reactHandler = reactHandler ?? throw new ArgumentNullException(nameof(reactHandler));
         _messageWaiter = messageWaiter ?? throw new ArgumentNullException(nameof(messageWaiter));
         _paginatorService = paginatorService ?? throw new ArgumentNullException(nameof(paginatorService));
@@ -69,6 +72,9 @@ internal sealed class BeanBotRuntime : IBeanBotRuntime
 
     public bool HasActiveDiscordLifecycleOperation
         => _discordLifecycleCoordinator.HasActiveSequence;
+
+    public bool HasActiveNewMemberWelcomeOperation
+        => _newMemberWelcomeService.HasActiveDiscordOperation;
 
     public bool CanDisposeDiscordClient => _canDisposeDiscordClient;
 
@@ -99,13 +105,21 @@ internal sealed class BeanBotRuntime : IBeanBotRuntime
         _discordClient.Log += _logHandler.LogMessages;
         _punHandler.Start();
         _editMessageHandler.InitializeEventListener();
+        _newMemberWelcomeService.Start();
         _newMemberHandler.InitializeNewMembers();
         _reactHandler.InitializeReactDependentServices();
     }
 
     public void StopReactionServices() => _reactHandler.Dispose();
 
-    public void StopNewMemberEvents() => _newMemberHandler.Dispose();
+    public void StopNewMemberEvents()
+    {
+        _newMemberHandler.Dispose();
+        _newMemberWelcomeService.StopAccepting();
+    }
+
+    public Task StopNewMemberWelcomeServiceAsync()
+        => _newMemberWelcomeService.StopAsync();
 
     public void StopEditedMessageEvents() => _editMessageHandler.Dispose();
 

--- a/BeanBot/Hosting/BeanBotRuntime.cs
+++ b/BeanBot/Hosting/BeanBotRuntime.cs
@@ -71,10 +71,8 @@ internal sealed class BeanBotRuntime : IBeanBotRuntime
     }
 
     public bool HasActiveDiscordLifecycleOperation
-        => _discordLifecycleCoordinator.HasActiveSequence;
-
-    public bool HasActiveNewMemberWelcomeOperation
-        => _newMemberWelcomeService.HasActiveDiscordOperation;
+        => _discordLifecycleCoordinator.HasActiveSequence ||
+           _newMemberWelcomeService.HasActiveDiscordOperation;
 
     public bool CanDisposeDiscordClient => _canDisposeDiscordClient;
 
@@ -116,10 +114,8 @@ internal sealed class BeanBotRuntime : IBeanBotRuntime
     {
         _newMemberHandler.Dispose();
         _newMemberWelcomeService.StopAccepting();
+        _newMemberWelcomeService.StopAsync().GetAwaiter().GetResult();
     }
-
-    public Task StopNewMemberWelcomeServiceAsync()
-        => _newMemberWelcomeService.StopAsync();
 
     public void StopEditedMessageEvents() => _editMessageHandler.Dispose();
 

--- a/BeanBot/Hosting/BeanBotServiceCollectionExtensions.cs
+++ b/BeanBot/Hosting/BeanBotServiceCollectionExtensions.cs
@@ -42,6 +42,8 @@ internal static class BeanBotServiceCollectionExtensions
             .ValidateOnStart();
         services.AddSingleton(provider => BeanBotOptionsFactory.Create(
             provider.GetRequiredService<IOptions<BeanBotSettings>>().Value));
+        services.AddSingleton(provider => NewMemberWelcomeOptions.Create(
+            provider.GetRequiredService<IOptions<BeanBotSettings>>().Value.NewMemberWelcome));
         services.AddSingleton(_ => new CommandService(new CommandServiceConfig
         {
             LogLevel = LogSeverity.Verbose,
@@ -128,6 +130,11 @@ internal static class BeanBotServiceCollectionExtensions
         services.AddSingleton<MemeProvider>();
         services.AddSingleton<IMemeProvider>(provider =>
             provider.GetRequiredService<MemeProvider>());
+        services.AddSingleton(NewMemberWelcomeRuntimeOptions.Default);
+        services.AddSingleton<DiscordNewMemberWelcomeDelivery>();
+        services.AddSingleton<INewMemberWelcomeDelivery>(provider =>
+            provider.GetRequiredService<DiscordNewMemberWelcomeDelivery>());
+        services.AddSingleton<NewMemberWelcomeService>();
         services.AddSingleton<DiscordMessageWaiter>();
         services.AddSingleton<DiscordPaginatorService>();
         services.AddSingleton<EditMessageEventServices>();

--- a/BeanBot/Logging/NewMemberWelcomeLog.cs
+++ b/BeanBot/Logging/NewMemberWelcomeLog.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Logging;
+
+namespace BeanBot.Logging;
+
+internal static partial class BeanBotLog
+{
+    [LoggerMessage(Level = LogLevel.Warning, Message = "New-member welcome capacity is full; dropping delivery for user {UserId}. MaximumOutstanding={MaximumOutstanding}")]
+    internal static partial void WelcomeCapacityFull(ILogger logger, ulong userId, int maximumOutstanding);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Suppressing duplicate pending new-member welcome for user {UserId}")]
+    internal static partial void WelcomeDuplicateSuppressed(ILogger logger, ulong userId);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "New-member welcome delivery was canceled during shutdown for user {UserId}")]
+    internal static partial void WelcomeDeliveryCanceled(ILogger logger, ulong userId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "New-member welcome shutdown exceeded its {DrainTimeout} drain window; canceling remaining work")]
+    internal static partial void WelcomeDrainTimedOut(ILogger logger, TimeSpan drainTimeout);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "New-member welcome workers did not finish within {CancellationGrace} after cancellation; process exit will reclaim remaining work")]
+    internal static partial void WelcomeCancellationGraceTimedOut(ILogger logger, TimeSpan cancellationGrace);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Discord new-member welcome {Operation} failed after BeanBot stopped waiting. UserId={UserId}")]
+    internal static partial void WelcomeDeliveryLateFailure(ILogger logger, string operation, ulong userId, Exception exception);
+}

--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ BEANBOT_YOSHIMARU_URL=
 
 Configuration is bound through the .NET configuration and Options pipeline and validated when the host starts. Missing or malformed settings stop startup with messages that name the affected variable without printing its value. For backwards compatibility, the legacy variable names (`botToken`, `mongoConnectionString`, and so on) are still accepted, but the `BEANBOT_*` names are the intended format. Canonical names take precedence over legacy aliases, and real environment variables take precedence over values from `.env`.
 
+### New-member welcome DM
+
+New-member welcome DMs remain enabled by default and preserve BeanBot's existing welcome text when no override is configured. They can be disabled or customized without rebuilding the bot:
+
+```env
+BEANBOT_NEW_MEMBER_WELCOME_ENABLED=true
+BEANBOT_NEW_MEMBER_WELCOME_MESSAGE=Welcome to the server!
+```
+
+`BEANBOT_NEW_MEMBER_WELCOME_MESSAGE` is optional; leave it unset to use the built-in message. When welcomes are enabled, a configured message must be non-empty and no longer than Discord's 2,000-character message limit. Validation errors identify the setting but do not print the configured message body.
+
+Welcome delivery is intentionally decoupled from Discord's `UserJoined` Gateway callback. BeanBot admits human joins into a bounded in-memory queue, uses finite worker concurrency and bounded Discord REST waits, suppresses duplicate pending work for the same user, and does not retry a timed-out send because Discord delivery status may be ambiguous. During shutdown the queue stops accepting new work and is boundedly drained/canceled before Discord teardown; if a timed-out Discord operation still owns the client, BeanBot skips explicit Discord teardown and lets process exit reclaim it safely.
+
 ### Discord Gateway Intents
 
 BeanBot explicitly requests only the gateway events used by its commands and event handlers. In the Discord Developer Portal, open the application, select **Bot**, and enable these privileged intents before deployment:


### PR DESCRIPTION
Closes #158.

## Summary
- move new-member welcome DM work out of the Discord `UserJoined` Gateway callback and into a bounded background queue
- preserve the current welcome text by default while allowing welcome delivery to be disabled or the message to be overridden through validated configuration
- cap outstanding welcome work, suppress duplicate pending deliveries per user, and use finite worker concurrency
- bound both DM-channel creation and message sending, propagate shutdown cancellation through Discord `RequestOptions`, observe late faults, and never retry an ambiguous timed-out send
- drain/cancel welcome work during the existing new-member shutdown stage before Discord teardown; timed-out Discord operations remain visible as active lifecycle ownership so explicit client teardown is skipped safely if necessary
- fall back to `GetUserAsync(..., CacheMode.AllowDownload)` when the new member is not present in the Discord client cache, keeping cache misses inside the same bounded/cancelable delivery operation
- document the new configuration and delivery/shutdown behavior

## Tests
- configuration defaults, canonical/legacy overrides, disabled behavior, invalid boolean, blank enabled message, and Discord message-length validation
- human vs bot admission, disabled admission, duplicate coalescing, hard outstanding-work capacity, shutdown cancellation, and start/stop idempotence
- successful Discord delivery, DM-create timeout, send timeout/no retry, cancellation-token propagation, late completion/fault observation, and hard bounds on abandoned Discord operations

## Review fix
- addressed the review finding that delivery previously failed immediately on a Discord user-cache miss; delivery now uses the cache first and falls back to a bounded/cancelable Discord REST user lookup before opening the DM

## Verification
- final exact-head candidate: `130d6a015a984fb2830cece9b42266b4af6f46f3`
- Repository Verification #270: PASS (`./scripts/verify.sh full`)
- 463 tests passed, 0 failed, 0 skipped
- Release build: 0 warnings, 0 errors
- coverage: 67.08% lines / 55.08% branches (baseline gate passed)
- locked restore, formatting/analyzers, redundant-using checks, branch-integrity guard, vulnerable-package scan, hardened Docker build/runtime smoke, and SIGTERM shutdown smoke all passed
- CodeQL #103: PASS
- Dependency Review #83: PASS
- fresh post-fix Verifier: PASS
- fresh post-fix Reviewer: CLEAN
- review threads: all resolved

Local verification was unavailable in the automation execution environment, so repository policy's exact-head GitHub Actions fallback was used. The required full verification completed successfully on the final repaired head.

## Manual validation
After deployment, join with a test human account and confirm exactly one DM with the configured/default text; join with a bot account and confirm no DM; then stop the container during a deliberately slow welcome delivery and confirm shutdown remains bounded.