### PR TITLE
Bound and drain edited-fortune message handling

### DIFF
--- a/BeanBot.Tests/Discord/Events/EditMessageEventServicesTests.cs
+++ b/BeanBot.Tests/Discord/Events/EditMessageEventServicesTests.cs
@@ -1,4 +1,6 @@
 using BeanBot.Discord.Events;
+using Discord;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace BeanBot.Tests.Discord.Events;
@@ -39,5 +41,143 @@ public class EditMessageEventServicesTests
     public void IsFortuneCommand_RejectsAnotherUsersMentionPrefix()
     {
         Assert.False(EditMessageEventServices.IsFortuneCommand("<@456> fortune question", 123));
+    }
+
+    [Fact]
+    public async Task ReplaceResponseAsync_Success_PreservesWarningAndUsesCancelableRequest()
+    {
+        string? content = null;
+        CancellationToken requestToken = default;
+
+        await EditMessageEventServices.ReplaceResponseAsync(
+            (replacement, options) =>
+            {
+                content = replacement;
+                requestToken = options.CancelToken;
+                return Task.CompletedTask;
+            },
+            42,
+            NullLogger.Instance,
+            CancellationToken.None,
+            TimeSpan.FromSeconds(1));
+
+        Assert.Equal(EditMessageEventServices.EditWarning, content);
+        Assert.True(requestToken.CanBeCanceled);
+        Assert.False(requestToken.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task ReplaceResponseAsync_OrdinaryFailures_RetriesWithBoundedDelays()
+    {
+        var calls = 0;
+        var delays = new List<TimeSpan>();
+
+        await EditMessageEventServices.ReplaceResponseAsync(
+            (_, _) =>
+            {
+                calls++;
+                return calls < 3
+                    ? Task.FromException(new InvalidOperationException("retryable failure"))
+                    : Task.CompletedTask;
+            },
+            42,
+            NullLogger.Instance,
+            CancellationToken.None,
+            TimeSpan.FromSeconds(1),
+            (delay, _) =>
+            {
+                delays.Add(delay);
+                return Task.CompletedTask;
+            });
+
+        Assert.Equal(3, calls);
+        Assert.Equal(
+            [TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(200)],
+            delays);
+    }
+
+    [Fact]
+    public async Task ReplaceResponseAsync_StalledModification_TimesOutWithoutRetryAndTracksLateTask()
+    {
+        var calls = 0;
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task? trackedTask = null;
+        CancellationToken requestToken = default;
+
+        await EditMessageEventServices.ReplaceResponseAsync(
+            (_, options) =>
+            {
+                calls++;
+                requestToken = options.CancelToken;
+                return completion.Task;
+            },
+            42,
+            NullLogger.Instance,
+            CancellationToken.None,
+            TimeSpan.FromMilliseconds(25),
+            trackLateDiscordOperation: task => trackedTask = task);
+
+        Assert.Equal(1, calls);
+        Assert.Same(completion.Task, trackedTask);
+        Assert.True(requestToken.IsCancellationRequested);
+
+        completion.SetException(new InvalidOperationException("late modify failure"));
+        await Task.Yield();
+    }
+
+    [Fact]
+    public async Task ReplaceResponseAsync_ShutdownCancellation_StopsRetryDelay()
+    {
+        var calls = 0;
+        var delayStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cancellation = new CancellationTokenSource();
+
+        var operation = EditMessageEventServices.ReplaceResponseAsync(
+            (_, _) =>
+            {
+                calls++;
+                return Task.FromException(new InvalidOperationException("retryable failure"));
+            },
+            42,
+            NullLogger.Instance,
+            cancellation.Token,
+            TimeSpan.FromSeconds(1),
+            async (_, token) =>
+            {
+                delayStarted.TrySetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            });
+
+        await delayStarted.Task;
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => operation);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public async Task ResolvePreviousMessageAsync_StalledLookup_TimesOutAndTracksLateTask()
+    {
+        var completion = new TaskCompletionSource<IMessage?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        Task? trackedTask = null;
+        CancellationToken requestToken = default;
+
+        await Assert.ThrowsAsync<TimeoutException>(
+            () => EditMessageEventServices.ResolvePreviousMessageAsync(
+                options =>
+                {
+                    requestToken = options.CancelToken;
+                    return completion.Task;
+                },
+                CancellationToken.None,
+                TimeSpan.FromMilliseconds(25),
+                task => trackedTask = task));
+
+        Assert.Same(completion.Task, trackedTask);
+        Assert.True(requestToken.IsCancellationRequested);
+
+        completion.SetException(new InvalidOperationException("late lookup failure"));
+        await Task.Yield();
     }
 }

--- a/BeanBot.Tests/Discord/Events/EditMessageEventServicesTests.cs
+++ b/BeanBot.Tests/Discord/Events/EditMessageEventServicesTests.cs
@@ -118,11 +118,12 @@ public class EditMessageEventServicesTests
             trackLateDiscordOperation: task => trackedTask = task);
 
         Assert.Equal(1, calls);
-        Assert.Same(completion.Task, trackedTask);
+        var lateTask = Assert.IsAssignableFrom<Task>(trackedTask);
+        Assert.False(lateTask.IsCompleted);
         Assert.True(requestToken.IsCancellationRequested);
 
         completion.SetException(new InvalidOperationException("late modify failure"));
-        await Task.Yield();
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await lateTask);
     }
 
     [Fact]

--- a/BeanBot.Tests/Discord/Events/EditMessageHandlerTests.cs
+++ b/BeanBot.Tests/Discord/Events/EditMessageHandlerTests.cs
@@ -1,0 +1,114 @@
+using BeanBot.Discord.Events;
+using Discord.WebSocket;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.Events;
+
+public class EditMessageHandlerTests
+{
+    [Fact]
+    public void TryTrackOperation_CapacityIsBounded()
+    {
+        using var client = new DiscordSocketClient();
+        using var handler = CreateHandler(client);
+        var completions = Enumerable.Range(0, EditMessageHandler.MaximumInFlightOperations)
+            .Select(_ => new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously))
+            .ToArray();
+
+        foreach (var completion in completions)
+        {
+            Assert.True(handler.TryTrackOperation(_ => completion.Task));
+        }
+
+        Assert.False(handler.TryTrackOperation(_ => Task.CompletedTask));
+        Assert.True(handler.HasInFlightOperations);
+
+        foreach (var completion in completions)
+        {
+            completion.SetResult();
+        }
+
+        Assert.False(handler.HasInFlightOperations);
+    }
+
+    [Fact]
+    public async Task StopAsync_CancelsAndDrainsAdmittedOperationAndStopsAdmission()
+    {
+        using var client = new DiscordSocketClient();
+        using var handler = CreateHandler(client);
+        CancellationToken observedToken = default;
+
+        Assert.True(handler.TryTrackOperation(async token =>
+        {
+            observedToken = token;
+            await Task.Delay(Timeout.InfiniteTimeSpan, token);
+        }));
+
+        await handler.StopAsync(TimeSpan.FromSeconds(1));
+
+        Assert.True(observedToken.IsCancellationRequested);
+        Assert.False(handler.HasInFlightOperations);
+        Assert.False(handler.TryTrackOperation(_ => Task.CompletedTask));
+    }
+
+    [Fact]
+    public async Task StopAsync_OperationIgnoringCancellation_TimesOutAndRetainsOwnership()
+    {
+        using var client = new DiscordSocketClient();
+        using var handler = CreateHandler(client);
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Assert.True(handler.TryTrackOperation(_ => completion.Task));
+
+        await Assert.ThrowsAsync<TimeoutException>(
+            () => handler.StopAsync(TimeSpan.FromMilliseconds(25)));
+
+        Assert.True(handler.HasInFlightOperations);
+        completion.SetResult();
+        Assert.False(handler.HasInFlightOperations);
+    }
+
+    [Fact]
+    public async Task StopAsync_LateDiscordOperation_TimesOutUntilOwnedTaskSettles()
+    {
+        using var client = new DiscordSocketClient();
+        using var handler = CreateHandler(client);
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        handler.TrackOwnedDiscordOperation(completion.Task);
+
+        await Assert.ThrowsAsync<TimeoutException>(
+            () => handler.StopAsync(TimeSpan.FromMilliseconds(25)));
+
+        Assert.True(handler.HasInFlightOperations);
+        completion.SetException(new InvalidOperationException("late Discord failure"));
+        Assert.False(handler.HasInFlightOperations);
+    }
+
+    [Fact]
+    public async Task StopAsync_IsIdempotent()
+    {
+        using var client = new DiscordSocketClient();
+        using var handler = CreateHandler(client);
+
+        handler.InitializeEventListener();
+        handler.InitializeEventListener();
+
+        await handler.StopAsync(TimeSpan.FromSeconds(1));
+        await handler.StopAsync(TimeSpan.FromSeconds(1));
+
+        Assert.False(handler.HasInFlightOperations);
+    }
+
+    private static EditMessageHandler CreateHandler(DiscordSocketClient client)
+    {
+        var service = new EditMessageEventServices(
+            client,
+            NullLogger<EditMessageEventServices>.Instance);
+        return new EditMessageHandler(
+            client,
+            service,
+            NullLogger<EditMessageHandler>.Instance);
+    }
+}

--- a/BeanBot.Tests/Discord/Events/EditMessageHandlerTests.cs
+++ b/BeanBot.Tests/Discord/Events/EditMessageHandlerTests.cs
@@ -8,7 +8,7 @@ namespace BeanBot.Tests.Discord.Events;
 public class EditMessageHandlerTests
 {
     [Fact]
-    public void TryTrackOperation_CapacityIsBounded()
+    public async Task TryTrackOperation_CapacityIsBounded()
     {
         using var client = new DiscordSocketClient();
         using var handler = CreateHandler(client);
@@ -29,6 +29,7 @@ public class EditMessageHandlerTests
             completion.SetResult();
         }
 
+        await handler.StopAsync(TimeSpan.FromSeconds(1));
         Assert.False(handler.HasInFlightOperations);
     }
 
@@ -66,6 +67,7 @@ public class EditMessageHandlerTests
 
         Assert.True(handler.HasInFlightOperations);
         completion.SetResult();
+        await handler.StopAsync(TimeSpan.FromSeconds(1));
         Assert.False(handler.HasInFlightOperations);
     }
 
@@ -83,6 +85,7 @@ public class EditMessageHandlerTests
 
         Assert.True(handler.HasInFlightOperations);
         completion.SetException(new InvalidOperationException("late Discord failure"));
+        await handler.StopAsync(TimeSpan.FromSeconds(1));
         Assert.False(handler.HasInFlightOperations);
     }
 

--- a/BeanBot.Tests/Discord/Events/EditMessageHandlerTests.cs
+++ b/BeanBot.Tests/Discord/Events/EditMessageHandlerTests.cs
@@ -34,6 +34,36 @@ public class EditMessageHandlerTests
     }
 
     [Fact]
+    public async Task TryTrackOperation_LateDiscordOperationsRemainInsideCapacityBound()
+    {
+        using var client = new DiscordSocketClient();
+        using var handler = CreateHandler(client);
+        var inFlightCompletions = Enumerable.Range(0, EditMessageHandler.MaximumInFlightOperations - 1)
+            .Select(_ => new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously))
+            .ToArray();
+        var lateDiscordCompletion = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        foreach (var completion in inFlightCompletions)
+        {
+            Assert.True(handler.TryTrackOperation(_ => completion.Task));
+        }
+
+        handler.TrackOwnedDiscordOperation(lateDiscordCompletion.Task);
+
+        Assert.False(handler.TryTrackOperation(_ => Task.CompletedTask));
+
+        foreach (var completion in inFlightCompletions)
+        {
+            completion.SetResult();
+        }
+
+        lateDiscordCompletion.SetResult();
+        await handler.StopAsync(TimeSpan.FromSeconds(1));
+        Assert.False(handler.HasInFlightOperations);
+    }
+
+    [Fact]
     public async Task StopAsync_CancelsAndDrainsAdmittedOperationAndStopsAdmission()
     {
         using var client = new DiscordSocketClient();

--- a/BeanBot.Tests/Hosting/BeanBotApplicationTests.cs
+++ b/BeanBot.Tests/Hosting/BeanBotApplicationTests.cs
@@ -103,6 +103,31 @@ public class BeanBotApplicationTests
     }
 
     [Fact]
+    public async Task StopAsync_EditedMessageDrainBoundExpires_SkipsDiscordShutdownAndDisposal()
+    {
+        var editedMessageDrain = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var runtime = new RecordingRuntime
+        {
+            IncompleteOperation = "stop-edited-message",
+            IncompleteCompletion = editedMessageDrain,
+            ActivateDiscordLifecycleOnIncompleteOperation = true
+        };
+        var application = new BeanBotApplication(
+            runtime,
+            NullLogger<BeanBotApplication>.Instance,
+            TimeSpan.FromMilliseconds(25));
+
+        await Assert.ThrowsAsync<TimeoutException>(
+            () => application.StopAsync(CancellationToken.None));
+
+        Assert.Contains("stop-command", runtime.Calls);
+        Assert.Contains("stop-health", runtime.Calls);
+        Assert.DoesNotContain("stop-discord", runtime.Calls);
+        Assert.DoesNotContain("dispose-discord", runtime.Calls);
+        editedMessageDrain.SetResult();
+    }
+
+    [Fact]
     public async Task StopAsync_DiscordShutdownExceedsApplicationBound_SkipsDisposeAndRunsFinalCleanup()
     {
         var discordShutdown = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -300,7 +325,7 @@ public class BeanBotApplicationTests
         public void StartEventAndBackgroundServices() => Record("start-event-background");
         public void StopReactionServices() => Record("stop-reaction");
         public void StopNewMemberEvents() => Record("stop-new-member");
-        public void StopEditedMessageEvents() => Record("stop-edited-message");
+        public Task StopEditedMessageEventsAsync() => RecordAsync("stop-edited-message");
         public void StopCommandServices() => Record("stop-command");
         public void StopMessageWaiter() => Record("stop-message-waiter");
         public void StopPaginator() => Record("stop-paginator");

--- a/BeanBot.Tests/Integration/BeanBotHostIntegrationTests.cs
+++ b/BeanBot.Tests/Integration/BeanBotHostIntegrationTests.cs
@@ -314,7 +314,11 @@ public class BeanBotHostIntegrationTests
         public void StartEventAndBackgroundServices() => Calls.Add("start-event-background");
         public void StopReactionServices() => Calls.Add("stop-reaction");
         public void StopNewMemberEvents() => Calls.Add("stop-new-member");
-        public void StopEditedMessageEvents() => Calls.Add("stop-edited-message");
+        public Task StopEditedMessageEventsAsync()
+        {
+            Calls.Add("stop-edited-message");
+            return Task.CompletedTask;
+        }
         public void StopCommandServices() => Calls.Add("stop-command");
         public void StopMessageWaiter() => Calls.Add("stop-message-waiter");
         public void StopPaginator() => Calls.Add("stop-paginator");

--- a/BeanBot/Discord/Events/EditMessageEventServices.cs
+++ b/BeanBot/Discord/Events/EditMessageEventServices.cs
@@ -8,7 +8,9 @@ namespace BeanBot.Discord.Events;
 
 public sealed class EditMessageEventServices
 {
-    private const string EditWarning = "Do not edit your 8ball requests in my presence, mortal.";
+    internal const string EditWarning = "Do not edit your 8ball requests in my presence, mortal.";
+    internal static readonly TimeSpan DiscordOperationTimeout = TimeSpan.FromSeconds(10);
+    private const int MaximumReplaceAttempts = 3;
     private static readonly SearchValues<char> CommandSeparators = SearchValues.Create(" \t\r\n");
     private readonly DiscordSocketClient _discordClient;
     private readonly ILogger<EditMessageEventServices> _logger;
@@ -21,33 +23,74 @@ public sealed class EditMessageEventServices
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public async Task HandleUpdate(
+    internal async Task HandleUpdate(
         Cacheable<IMessage, ulong> oldMessage,
         SocketMessage newMessage,
-        ISocketMessageChannel messageChannel)
+        ISocketMessageChannel messageChannel,
+        CancellationToken cancellationToken,
+        Action<Task>? trackLateDiscordOperation = null)
     {
-        var previousMessage = await oldMessage.GetOrDownloadAsync();
-        if (previousMessage == null || _discordClient.CurrentUser == null ||
-            !IsFortuneCommand(previousMessage.Content, _discordClient.CurrentUser.Id))
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var currentUser = _discordClient.CurrentUser;
+        if (currentUser is null)
+        {
+            return;
+        }
+
+        IMessage? previousMessage;
+        try
+        {
+            previousMessage = oldMessage.HasValue
+                ? oldMessage.Value
+                : await ResolvePreviousMessageAsync(
+                    options => messageChannel.GetMessageAsync(
+                        oldMessage.Id,
+                        CacheMode.AllowDownload,
+                        options),
+                    cancellationToken,
+                    DiscordOperationTimeout,
+                    trackLateDiscordOperation).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            EditMessageLog.OriginalMessageLookupFailed(_logger, oldMessage.Id, exception);
+            return;
+        }
+
+        if (previousMessage is null ||
+            !IsFortuneCommand(previousMessage.Content, currentUser.Id))
         {
             return;
         }
 
         var botResponse = messageChannel.CachedMessages
             .OfType<SocketUserMessage>()
-            .Where(message => message.Author.Id == _discordClient.CurrentUser.Id)
+            .Where(message => message.Author.Id == currentUser.Id)
             .Where(message => message.Id > newMessage.Id)
             .Where(message => message.Timestamp - newMessage.Timestamp <= TimeSpan.FromMinutes(2))
             .OrderBy(message => message.Id)
             .FirstOrDefault();
 
-        if (botResponse == null)
+        if (botResponse is null)
         {
             BeanBotLog.FortuneResponseMissing(_logger, newMessage.Id);
             return;
         }
 
-        await ReplaceResponseAsync(botResponse);
+        await ReplaceResponseAsync(
+            (content, options) => botResponse.ModifyAsync(
+                properties => properties.Content = content,
+                options),
+            botResponse.Id,
+            _logger,
+            cancellationToken,
+            DiscordOperationTimeout,
+            trackLateDiscordOperation: trackLateDiscordOperation).ConfigureAwait(false);
     }
 
     internal static bool IsFortuneCommand(string content, ulong botUserId = 0)
@@ -84,25 +127,156 @@ public sealed class EditMessageEventServices
                string.Equals(command, "fortune", StringComparison.OrdinalIgnoreCase);
     }
 
-    private async Task ReplaceResponseAsync(SocketUserMessage botResponse)
+    internal static Task<IMessage?> ResolvePreviousMessageAsync(
+        Func<RequestOptions, Task<IMessage?>> resolveMessage,
+        CancellationToken cancellationToken,
+        TimeSpan? operationTimeout = null,
+        Action<Task>? trackLateDiscordOperation = null)
     {
-        const int maxAttempts = 3;
-        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        ArgumentNullException.ThrowIfNull(resolveMessage);
+
+        return RunBoundedDiscordOperationAsync(
+            resolveMessage,
+            operationTimeout ?? DiscordOperationTimeout,
+            cancellationToken,
+            trackLateDiscordOperation);
+    }
+
+    internal static async Task ReplaceResponseAsync(
+        Func<string, RequestOptions, Task> modifyResponse,
+        ulong messageId,
+        ILogger logger,
+        CancellationToken cancellationToken,
+        TimeSpan? operationTimeout = null,
+        Func<TimeSpan, CancellationToken, Task>? delayAsync = null,
+        Action<Task>? trackLateDiscordOperation = null)
+    {
+        ArgumentNullException.ThrowIfNull(modifyResponse);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        var timeout = operationTimeout ?? DiscordOperationTimeout;
+        if (timeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(operationTimeout), "Operation timeout must be greater than zero.");
+        }
+
+        delayAsync ??= static (delay, token) => Task.Delay(delay, token);
+
+        for (var attempt = 1; attempt <= MaximumReplaceAttempts; attempt++)
         {
             try
             {
-                await botResponse.ModifyAsync(properties => properties.Content = EditWarning);
+                await RunBoundedDiscordOperationAsync(
+                    options => modifyResponse(EditWarning, options),
+                    timeout,
+                    cancellationToken,
+                    trackLateDiscordOperation).ConfigureAwait(false);
                 return;
             }
-            catch (Exception exception) when (attempt < maxAttempts)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
-                BeanBotLog.FortuneResponseReplaceAttemptFailed(_logger, attempt, exception);
-                await Task.Delay(TimeSpan.FromMilliseconds(100 * attempt));
+                throw;
+            }
+            catch (TimeoutException exception)
+            {
+                BeanBotLog.FortuneResponseReplaceFailed(logger, messageId, exception);
+                return;
+            }
+            catch (OperationCanceledException exception)
+            {
+                BeanBotLog.FortuneResponseReplaceFailed(logger, messageId, exception);
+                return;
+            }
+            catch (Exception exception) when (attempt < MaximumReplaceAttempts)
+            {
+                BeanBotLog.FortuneResponseReplaceAttemptFailed(logger, attempt, exception);
+                await delayAsync(
+                    TimeSpan.FromMilliseconds(100 * attempt),
+                    cancellationToken).ConfigureAwait(false);
             }
             catch (Exception exception)
             {
-                BeanBotLog.FortuneResponseReplaceFailed(_logger, botResponse.Id, exception);
+                BeanBotLog.FortuneResponseReplaceFailed(logger, messageId, exception);
             }
         }
+    }
+
+    internal static async Task<T> RunBoundedDiscordOperationAsync<T>(
+        Func<RequestOptions, Task<T>> beginOperation,
+        TimeSpan timeout,
+        CancellationToken cancellationToken,
+        Action<Task>? trackLateDiscordOperation = null)
+    {
+        ArgumentNullException.ThrowIfNull(beginOperation);
+        if (timeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(timeout), "Operation timeout must be greater than zero.");
+        }
+
+        using var operationCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        operationCancellation.CancelAfter(timeout);
+        var requestOptions = new RequestOptions
+        {
+            CancelToken = operationCancellation.Token
+        };
+
+        var operation = beginOperation(requestOptions);
+        try
+        {
+            return await operation
+                .WaitAsync(operationCancellation.Token)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            TrackLateOperation(operation, trackLateDiscordOperation);
+            throw;
+        }
+        catch (OperationCanceledException) when (operationCancellation.IsCancellationRequested)
+        {
+            TrackLateOperation(operation, trackLateDiscordOperation);
+            throw new TimeoutException(
+                $"Discord edited-message operation exceeded its {timeout} timeout.");
+        }
+    }
+
+    internal static async Task RunBoundedDiscordOperationAsync(
+        Func<RequestOptions, Task> beginOperation,
+        TimeSpan timeout,
+        CancellationToken cancellationToken,
+        Action<Task>? trackLateDiscordOperation = null)
+    {
+        await RunBoundedDiscordOperationAsync(
+            async options =>
+            {
+                await beginOperation(options).ConfigureAwait(false);
+                return true;
+            },
+            timeout,
+            cancellationToken,
+            trackLateDiscordOperation).ConfigureAwait(false);
+    }
+
+    private static void TrackLateOperation(
+        Task operation,
+        Action<Task>? trackLateDiscordOperation)
+    {
+        if (operation.IsCompleted)
+        {
+            _ = operation.Exception;
+            return;
+        }
+
+        if (trackLateDiscordOperation is not null)
+        {
+            trackLateDiscordOperation(operation);
+            return;
+        }
+
+        _ = operation.ContinueWith(
+            completedTask => _ = completedTask.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 }

--- a/BeanBot/Discord/Events/EditMessageHandler.cs
+++ b/BeanBot/Discord/Events/EditMessageHandler.cs
@@ -68,7 +68,11 @@ public sealed class EditMessageHandler : IDisposable
                 return false;
             }
 
-            if (_inFlightOperations.Count >= MaximumInFlightOperations)
+            var trackedOperationCount = _inFlightOperations
+                .Concat(_ownedDiscordOperations)
+                .Distinct()
+                .Count();
+            if (trackedOperationCount >= MaximumInFlightOperations)
             {
                 EditMessageLog.AdmissionCapacityExceeded(_logger, MaximumInFlightOperations);
                 return false;

--- a/BeanBot/Discord/Events/EditMessageHandler.cs
+++ b/BeanBot/Discord/Events/EditMessageHandler.cs
@@ -1,40 +1,255 @@
+using BeanBot.Logging;
+using Discord;
 using Discord.WebSocket;
+using Microsoft.Extensions.Logging;
 
 namespace BeanBot.Discord.Events;
 
 public sealed class EditMessageHandler : IDisposable
 {
+    internal const int MaximumInFlightOperations = 64;
+    internal static readonly TimeSpan DefaultDrainTimeout = TimeSpan.FromSeconds(10);
+
     private readonly DiscordSocketClient _discordClient;
     private readonly EditMessageEventServices _editMessageEventService;
+    private readonly ILogger<EditMessageHandler> _logger;
+    private readonly CancellationTokenSource _lifetimeCancellation = new();
+    private readonly object _sync = new();
+    private readonly HashSet<Task> _inFlightOperations = [];
+    private readonly HashSet<Task> _ownedDiscordOperations = [];
     private bool _initialized;
+    private bool _stopping;
 
     public EditMessageHandler(
         DiscordSocketClient discordClient,
-        EditMessageEventServices editMessageEventService)
+        EditMessageEventServices editMessageEventService,
+        ILogger<EditMessageHandler> logger)
     {
         _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
         _editMessageEventService = editMessageEventService ?? throw new ArgumentNullException(nameof(editMessageEventService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    internal bool HasInFlightOperations
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return _inFlightOperations.Count != 0 || _ownedDiscordOperations.Count != 0;
+            }
+        }
     }
 
     public void InitializeEventListener()
     {
-        if (_initialized)
+        lock (_sync)
         {
-            return;
-        }
+            if (_stopping)
+            {
+                throw new ObjectDisposedException(nameof(EditMessageHandler));
+            }
 
-        _discordClient.MessageUpdated += _editMessageEventService.HandleUpdate;
-        _initialized = true;
+            if (_initialized)
+            {
+                return;
+            }
+
+            _discordClient.MessageUpdated += HandleUpdateAsync;
+            _initialized = true;
+        }
     }
 
-    public void Dispose()
+    internal bool TryTrackOperation(Func<CancellationToken, Task> operationFactory)
     {
-        if (!_initialized)
+        ArgumentNullException.ThrowIfNull(operationFactory);
+
+        lock (_sync)
+        {
+            if (_stopping)
+            {
+                return false;
+            }
+
+            if (_inFlightOperations.Count >= MaximumInFlightOperations)
+            {
+                EditMessageLog.AdmissionCapacityExceeded(_logger, MaximumInFlightOperations);
+                return false;
+            }
+
+            Task operation;
+            try
+            {
+                operation = operationFactory(_lifetimeCancellation.Token);
+            }
+            catch (Exception exception)
+            {
+                EditMessageLog.OperationFailed(_logger, exception);
+                return true;
+            }
+
+            _inFlightOperations.Add(operation);
+            ObserveTrackedOperation(operation, _inFlightOperations, lateDiscordOperation: false);
+            return true;
+        }
+    }
+
+    public async Task StopAsync(TimeSpan? drainTimeout = null)
+    {
+        var timeout = drainTimeout ?? DefaultDrainTimeout;
+        if (timeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(drainTimeout), "Drain timeout must be greater than zero.");
+        }
+
+        StopAdmissionAndCancel();
+
+        using var drainCancellation = new CancellationTokenSource(timeout);
+        while (true)
+        {
+            Task[] snapshot;
+            lock (_sync)
+            {
+                snapshot = _inFlightOperations
+                    .Concat(_ownedDiscordOperations)
+                    .Distinct()
+                    .ToArray();
+            }
+
+            if (snapshot.Length == 0)
+            {
+                return;
+            }
+
+            try
+            {
+                await Task.WhenAll(snapshot.Select(SettleAsync))
+                    .WaitAsync(drainCancellation.Token)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (drainCancellation.IsCancellationRequested)
+            {
+                int remainingCount;
+                lock (_sync)
+                {
+                    remainingCount = _inFlightOperations
+                        .Concat(_ownedDiscordOperations)
+                        .Distinct()
+                        .Count();
+                }
+
+                EditMessageLog.DrainTimedOut(_logger, remainingCount, timeout);
+                throw new TimeoutException(
+                    $"Timed out draining {remainingCount} edited-message operation(s) after {timeout}.");
+            }
+        }
+    }
+
+    public void Dispose() => StopAdmissionAndCancel();
+
+    private Task HandleUpdateAsync(
+        Cacheable<IMessage, ulong> oldMessage,
+        SocketMessage newMessage,
+        ISocketMessageChannel messageChannel)
+    {
+        _ = TryTrackOperation(
+            token => _editMessageEventService.HandleUpdate(
+                oldMessage,
+                newMessage,
+                messageChannel,
+                token,
+                TrackOwnedDiscordOperation));
+        return Task.CompletedTask;
+    }
+
+    internal void TrackOwnedDiscordOperation(Task operation)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+
+        lock (_sync)
+        {
+            if (operation.IsCompleted)
+            {
+                ObserveCompletedFault(operation, lateDiscordOperation: true);
+                return;
+            }
+
+            _ownedDiscordOperations.Add(operation);
+            ObserveTrackedOperation(operation, _ownedDiscordOperations, lateDiscordOperation: true);
+        }
+    }
+
+    private void ObserveTrackedOperation(
+        Task operation,
+        HashSet<Task> owner,
+        bool lateDiscordOperation)
+    {
+        _ = operation.ContinueWith(
+            completedTask =>
+            {
+                lock (_sync)
+                {
+                    owner.Remove(completedTask);
+                }
+
+                ObserveCompletedFault(completedTask, lateDiscordOperation);
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    private void ObserveCompletedFault(Task operation, bool lateDiscordOperation)
+    {
+        if (!operation.IsFaulted || operation.Exception is null)
         {
             return;
         }
 
-        _discordClient.MessageUpdated -= _editMessageEventService.HandleUpdate;
-        _initialized = false;
+        var exception = operation.Exception.Flatten();
+        if (lateDiscordOperation)
+        {
+            EditMessageLog.LateDiscordOperationFailed(_logger, exception);
+        }
+        else
+        {
+            EditMessageLog.OperationFailed(_logger, exception);
+        }
+    }
+
+    private void StopAdmissionAndCancel()
+    {
+        var cancelLifetime = false;
+        lock (_sync)
+        {
+            if (!_stopping)
+            {
+                _stopping = true;
+                cancelLifetime = true;
+            }
+
+            if (_initialized)
+            {
+                _discordClient.MessageUpdated -= HandleUpdateAsync;
+                _initialized = false;
+            }
+        }
+
+        if (cancelLifetime)
+        {
+            _lifetimeCancellation.Cancel();
+        }
+    }
+
+    private static async Task SettleAsync(Task operation)
+    {
+        try
+        {
+            await operation.ConfigureAwait(false);
+        }
+        catch
+        {
+            // Completion is observed by the tracked-operation continuation.
+        }
     }
 }

--- a/BeanBot/Discord/Events/EditMessageHandler.cs
+++ b/BeanBot/Discord/Events/EditMessageHandler.cs
@@ -110,10 +110,7 @@ public sealed class EditMessageHandler : IDisposable
             Task[] snapshot;
             lock (_sync)
             {
-                snapshot = _inFlightOperations
-                    .Concat(_ownedDiscordOperations)
-                    .Distinct()
-                    .ToArray();
+                snapshot = [.. _inFlightOperations, .. _ownedDiscordOperations];
             }
 
             if (snapshot.Length == 0)

--- a/BeanBot/Discord/Events/EditMessageHandler.cs
+++ b/BeanBot/Discord/Events/EditMessageHandler.cs
@@ -45,10 +45,7 @@ public sealed class EditMessageHandler : IDisposable
     {
         lock (_sync)
         {
-            if (_stopping)
-            {
-                throw new ObjectDisposedException(nameof(EditMessageHandler));
-            }
+            ObjectDisposedException.ThrowIf(_stopping, this);
 
             if (_initialized)
             {

--- a/BeanBot/Hosting/BeanBotApplication.cs
+++ b/BeanBot/Hosting/BeanBotApplication.cs
@@ -16,7 +16,7 @@ internal interface IBeanBotRuntime
     void StartEventAndBackgroundServices();
     void StopReactionServices();
     void StopNewMemberEvents();
-    void StopEditedMessageEvents();
+    Task StopEditedMessageEventsAsync();
     void StopCommandServices();
     void StopMessageWaiter();
     void StopPaginator();
@@ -133,7 +133,7 @@ internal sealed class BeanBotApplication : IBeanBotApplication
 
         await RunSynchronousStageAsync("reaction-services", _runtime.StopReactionServices);
         await RunSynchronousStageAsync("new-member-events", _runtime.StopNewMemberEvents);
-        await RunSynchronousStageAsync("edited-message-events", _runtime.StopEditedMessageEvents);
+        await RunStageAsync("edited-message-events", _runtime.StopEditedMessageEventsAsync);
         await RunSynchronousStageAsync("command-services", _runtime.StopCommandServices);
         await RunSynchronousStageAsync("message-waiter", _runtime.StopMessageWaiter);
         await RunSynchronousStageAsync("paginator", _runtime.StopPaginator);

--- a/BeanBot/Hosting/BeanBotRuntime.cs
+++ b/BeanBot/Hosting/BeanBotRuntime.cs
@@ -68,7 +68,8 @@ internal sealed class BeanBotRuntime : IBeanBotRuntime
     }
 
     public bool HasActiveDiscordLifecycleOperation
-        => _discordLifecycleCoordinator.HasActiveSequence;
+        => _discordLifecycleCoordinator.HasActiveSequence ||
+           _editMessageHandler.HasInFlightOperations;
 
     public bool CanDisposeDiscordClient => _canDisposeDiscordClient;
 
@@ -107,7 +108,7 @@ internal sealed class BeanBotRuntime : IBeanBotRuntime
 
     public void StopNewMemberEvents() => _newMemberHandler.Dispose();
 
-    public void StopEditedMessageEvents() => _editMessageHandler.Dispose();
+    public Task StopEditedMessageEventsAsync() => _editMessageHandler.StopAsync();
 
     public void StopCommandServices() => _commandHandler.Dispose();
 

--- a/BeanBot/Logging/EditMessageLog.cs
+++ b/BeanBot/Logging/EditMessageLog.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.Logging;
+
+namespace BeanBot.Logging;
+
+internal static partial class EditMessageLog
+{
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Dropping edited-message handling because the {MaximumInFlightOperations} operation capacity is full")]
+    internal static partial void AdmissionCapacityExceeded(
+        ILogger logger,
+        int maximumInFlightOperations);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Timed out draining {InFlightOperationCount} edited-message operation(s) after {DrainTimeout}; Discord teardown will stay blocked while they remain active")]
+    internal static partial void DrainTimedOut(
+        ILogger logger,
+        int inFlightOperationCount,
+        TimeSpan drainTimeout);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "An edited-message operation failed unexpectedly")]
+    internal static partial void OperationFailed(
+        ILogger logger,
+        Exception exception);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "A timed-out or canceled edited-message Discord operation failed after its bounded wait ended")]
+    internal static partial void LateDiscordOperationFailed(
+        ILogger logger,
+        Exception exception);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Could not resolve original Discord message {MessageId} while processing an edited fortune request")]
+    internal static partial void OriginalMessageLookupFailed(
+        ILogger logger,
+        ulong messageId,
+        Exception exception);
+}


### PR DESCRIPTION
Closes #162

## Summary
- decouple `MessageUpdated` Gateway callbacks from edited-fortune REST work behind a bounded 64-operation admission guard
- give old-message lookup and response replacement application-owned 10-second bounds with a single cancellation owner shared by the waiter and Discord.Net `RequestOptions`
- preserve the existing three-attempt replacement policy for completed failures, but make retry delays cancellation-aware and never retry an ambiguous timeout/cancellation
- retain ownership of late Discord tasks so shutdown cannot dispose the Discord client while a timed-out request may still be using it
- unsubscribe once, stop admission, cancel, and boundedly drain edited-message work before normal Discord teardown
- keep late/timed-out Discord operations inside the same admission budget so repeated timeouts cannot accumulate unbounded owned REST work
- add focused tests for success, retries, lookup/modification stalls, late-task ownership, combined capacity, cancellation, idempotent stop, and shutdown ordering

## Verification and review
Final head: `dea6e656fb9c7f70050979e97a2f616c79c42931`

A fresh review pass inspected the exact final diff against issue #162, current `develop`, `AGENTS.md`, and the repository-owned verifier/reviewer skills. Local execution is unavailable because this execution environment cannot resolve `github.com`, so the repository-approved exact-head GitHub CI evidence is used; no stale or fabricated local result is substituted.

Exact-head GitHub evidence:
- Repository Verification #279: **PASS** (`./scripts/verify.sh full`)
  - exact head `dea6e656fb9c7f70050979e97a2f616c79c42931`
  - 455 tests passed, 0 failed, 0 skipped
  - Release build: 0 warnings, 0 errors
  - coverage: 66.82% lines / 55.07% branches (baseline PASS)
  - locked restore, formatting/analyzers, branch integrity, vulnerable-package scan, Docker build/runtime, and SIGTERM shutdown smoke checks passed
- CodeQL #112: **PASS** on the same head
- Dependency Review #92: **PASS** on the same head
- Fresh Verifier: **PASS**
- Fresh independent Reviewer: **CLEAN**
- Review threads: none open

The fresh review specifically rechecked bounded admission, timeout/cancellation ownership, late-task observation, retry behavior, shutdown ordering, Discord teardown safety, duplicate subscription risk, tests, Docker/runtime impact, dependency/release scope, and unrelated churn. No consequential finding remains and no repair commit was required by this review pass.

Two issues had already been corrected before this final head:
1. The first CI pass exposed a brittle late-modification test that asserted the exact underlying task object rather than the ownership contract. The test now verifies that the tracked late task remains incomplete until the Discord operation settles and propagates/observes its late fault.
2. Implementation review found that timed-out Discord operations moved into the late-operation ownership set but were not counted toward admission capacity. Repeated timeouts could therefore have accumulated unbounded owned REST work. Admission now counts active handlers plus owned late Discord operations, with regression coverage.

## Publication status
All implementation, exact-head verification, and fresh review gates are green. This PR remains **draft only because the connected GitHub ready-for-review mutation is currently broken**: GitHub's connector GraphQL request queries the nonexistent `Repository.fullDatabaseId` field. The ready transition was retried after the fresh review and failed for that connector-only reason. No code, CI, verifier, reviewer, or review-thread blocker remains.

Because the PR cannot be transitioned out of draft, the final human-review TL;DR comment is intentionally not posted yet, per repository workflow.

## Manual validation
- edit a `%8ball` or `%fortune` request and confirm the existing warning replaces the cached bot response
- edit a non-fortune message and confirm no bot action occurs
- stop BeanBot while an edited-fortune operation is intentionally slow and confirm shutdown stays bounded and avoids competing Discord teardown

No merge, auto-merge, or release is performed by this PR workflow.