### PR TITLE
Bound Discord message cleanup operations

### DIFF
--- a/BeanBot.Tests/Discord/Messaging/DiscordMessageCleanupServiceTests.cs
+++ b/BeanBot.Tests/Discord/Messaging/DiscordMessageCleanupServiceTests.cs
@@ -1,4 +1,5 @@
 using BeanBot.Discord.Messaging;
+using Discord;
 using Xunit;
 
 namespace BeanBot.Tests.Discord.Messaging;
@@ -59,12 +60,12 @@ public class DiscordMessageCleanupServiceTests
 
         await DiscordMessageCleanupService.ExecutePlanAsync(
             plan,
-            batch =>
+            (batch, _) =>
             {
                 attemptedBatches.Add(batch.Count);
                 throw new InvalidOperationException("bulk failed");
             },
-            message =>
+            (message, _) =>
             {
                 attemptedIndividuals.Add(message.Id);
                 return message.Id == 100
@@ -92,8 +93,8 @@ public class DiscordMessageCleanupServiceTests
 
         await DiscordMessageCleanupService.ExecutePlanAsync(
             plan,
-            _ => Task.CompletedTask,
-            message =>
+            (_, _) => Task.CompletedTask,
+            (message, _) =>
             {
                 attempted.Add(message.Id);
                 return message.Id == 1
@@ -103,6 +104,149 @@ public class DiscordMessageCleanupServiceTests
             (_, _, _) => { });
 
         Assert.Equal(new[] { 1, 2 }, attempted);
+    }
+
+    [Fact]
+    public async Task ExecutePlan_BoundsStalledBatchAndContinuesWithIndividual()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var messages = Enumerable.Range(0, 101)
+            .Select(index => new TestMessage(index, now))
+            .ToArray();
+        var plan = DiscordMessageCleanupService.CreatePlan(messages, message => message.Timestamp, now);
+        var stalledDelete = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var batchAttempts = 0;
+        var attemptedIndividuals = new List<int>();
+        var failures = new List<Exception>();
+
+        await DiscordMessageCleanupService.ExecutePlanAsync(
+            plan,
+            (_, _) =>
+            {
+                batchAttempts++;
+                return stalledDelete.Task;
+            },
+            (message, _) =>
+            {
+                attemptedIndividuals.Add(message.Id);
+                return Task.CompletedTask;
+            },
+            (exception, _, _) => failures.Add(exception),
+            TimeSpan.FromMilliseconds(25));
+
+        Assert.Equal(1, batchAttempts);
+        Assert.Equal(new[] { 100 }, attemptedIndividuals);
+        Assert.IsType<TimeoutException>(Assert.Single(failures));
+
+        stalledDelete.TrySetException(new InvalidOperationException("late bulk fault"));
+        await Task.Yield();
+    }
+
+    [Fact]
+    public async Task ExecutePlan_BoundsStalledIndividualAndContinuesWithLaterIndividual()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var messages = new[]
+        {
+            new TestMessage(1, now.Subtract(TimeSpan.FromDays(14))),
+            new TestMessage(2, now.Subtract(TimeSpan.FromDays(14)))
+        };
+        var plan = DiscordMessageCleanupService.CreatePlan(messages, message => message.Timestamp, now);
+        var stalledDelete = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attempts = new List<int>();
+        var failures = new List<Exception>();
+
+        await DiscordMessageCleanupService.ExecutePlanAsync(
+            plan,
+            (_, _) => Task.CompletedTask,
+            (message, _) =>
+            {
+                attempts.Add(message.Id);
+                return message.Id == 1 ? stalledDelete.Task : Task.CompletedTask;
+            },
+            (exception, _, _) => failures.Add(exception),
+            TimeSpan.FromMilliseconds(25));
+
+        Assert.Equal(new[] { 1, 2 }, attempts);
+        Assert.IsType<TimeoutException>(Assert.Single(failures));
+
+        stalledDelete.TrySetResult(true);
+    }
+
+    [Fact]
+    public async Task ExecutePlan_CallerCancellationPropagatesAndStopsFurtherCleanup()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var messages = new[]
+        {
+            new TestMessage(1, now.Subtract(TimeSpan.FromDays(14))),
+            new TestMessage(2, now.Subtract(TimeSpan.FromDays(14)))
+        };
+        var plan = DiscordMessageCleanupService.CreatePlan(messages, message => message.Timestamp, now);
+        using var cancellation = new CancellationTokenSource();
+        var pendingDelete = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attempts = 0;
+        RequestOptions? capturedOptions = null;
+        var failures = new List<Exception>();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            DiscordMessageCleanupService.ExecutePlanAsync(
+                plan,
+                (_, _) => Task.CompletedTask,
+                (_, options) =>
+                {
+                    attempts++;
+                    capturedOptions = options;
+                    cancellation.Cancel();
+                    return pendingDelete.Task;
+                },
+                (exception, _, _) => failures.Add(exception),
+                TimeSpan.FromSeconds(1),
+                cancellation.Token));
+
+        Assert.Equal(1, attempts);
+        Assert.NotNull(capturedOptions);
+        Assert.True(capturedOptions.CancelToken.IsCancellationRequested);
+        Assert.Empty(failures);
+
+        pendingDelete.TrySetCanceled();
+    }
+
+    [Fact]
+    public async Task ExecuteDelete_UsesRequestCancellationForTimeoutAndDoesNotRetry()
+    {
+        var stalledDelete = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attempts = 0;
+        RequestOptions? capturedOptions = null;
+
+        await Assert.ThrowsAsync<TimeoutException>(() =>
+            DiscordMessageCleanupService.ExecuteDeleteAsync(
+                options =>
+                {
+                    attempts++;
+                    capturedOptions = options;
+                    return stalledDelete.Task;
+                },
+                TimeSpan.FromMilliseconds(25),
+                CancellationToken.None));
+
+        Assert.Equal(1, attempts);
+        Assert.NotNull(capturedOptions);
+        Assert.True(capturedOptions.CancelToken.IsCancellationRequested);
+
+        stalledDelete.TrySetResult(true);
+    }
+
+    [Fact]
+    public async Task ObserveLateFault_CompletesAfterLateFailureIsObserved()
+    {
+        var lateOperation = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var observation = DiscordMessageCleanupService.ObserveLateFault(lateOperation.Task);
+
+        lateOperation.SetException(new InvalidOperationException("late failure"));
+
+        await observation.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.True(observation.IsCompletedSuccessfully);
     }
 
     private sealed record TestMessage(int Id, DateTimeOffset Timestamp);

--- a/BeanBot/Discord/Messaging/DiscordMessageCleanupService.cs
+++ b/BeanBot/Discord/Messaging/DiscordMessageCleanupService.cs
@@ -7,6 +7,7 @@ namespace BeanBot.Discord.Messaging;
 public sealed class DiscordMessageCleanupService
 {
     internal const int MaximumBulkDeleteCount = 100;
+    internal static readonly TimeSpan DeleteOperationTimeout = TimeSpan.FromSeconds(10);
     private static readonly TimeSpan MaximumBulkDeleteAge = TimeSpan.FromDays(14) - TimeSpan.FromMinutes(5);
     private readonly Func<DateTimeOffset> _getUtcNow;
     private readonly ILogger<DiscordMessageCleanupService> _logger;
@@ -24,20 +25,25 @@ public sealed class DiscordMessageCleanupService
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public Task DeleteAsync(ITextChannel channel, IReadOnlyCollection<IMessage> messages)
+    public Task DeleteAsync(
+        ITextChannel channel,
+        IReadOnlyCollection<IMessage> messages,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(channel);
 
         var plan = CreatePlan(messages, message => message.Timestamp, _getUtcNow());
         return ExecutePlanAsync(
             plan,
-            batch => channel.DeleteMessagesAsync(batch),
-            message => message.DeleteAsync(),
+            (batch, options) => channel.DeleteMessagesAsync(batch, options),
+            (message, options) => message.DeleteAsync(options),
             (exception, itemCount, isBatch) => BeanBotLog.MessageCleanupFailed(
                 _logger,
                 itemCount,
                 isBatch ? "bulk deletion" : "individual deletion",
-                exception));
+                exception),
+            DeleteOperationTimeout,
+            cancellationToken);
     }
 
     internal static MessageCleanupPlan<T> CreatePlan<T>(
@@ -71,15 +77,33 @@ public sealed class DiscordMessageCleanupService
 
     internal static async Task ExecutePlanAsync<T>(
         MessageCleanupPlan<T> plan,
-        Func<IReadOnlyCollection<T>, Task> deleteBatch,
-        Func<T, Task> deleteIndividual,
-        Action<Exception, int, bool> onFailure)
+        Func<IReadOnlyCollection<T>, RequestOptions, Task> deleteBatch,
+        Func<T, RequestOptions, Task> deleteIndividual,
+        Action<Exception, int, bool> onFailure,
+        TimeSpan? operationTimeout = null,
+        CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(deleteBatch);
+        ArgumentNullException.ThrowIfNull(deleteIndividual);
+        ArgumentNullException.ThrowIfNull(onFailure);
+
+        var timeout = operationTimeout ?? DeleteOperationTimeout;
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(timeout, TimeSpan.Zero);
+
         foreach (var batch in plan.Batches)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             try
             {
-                await deleteBatch(batch);
+                await ExecuteDeleteAsync(
+                    options => deleteBatch(batch, options),
+                    timeout,
+                    cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception exception)
             {
@@ -89,15 +113,74 @@ public sealed class DiscordMessageCleanupService
 
         foreach (var item in plan.IndividualItems)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             try
             {
-                await deleteIndividual(item);
+                await ExecuteDeleteAsync(
+                    options => deleteIndividual(item, options),
+                    timeout,
+                    cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception exception)
             {
                 onFailure(exception, 1, false);
             }
         }
+    }
+
+    internal static async Task ExecuteDeleteAsync(
+        Func<RequestOptions, Task> delete,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(delete);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(timeout, TimeSpan.Zero);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        using var operationCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        operationCancellation.CancelAfter(timeout);
+
+        var requestOptions = new RequestOptions
+        {
+            CancelToken = operationCancellation.Token
+        };
+        var deleteTask = delete(requestOptions);
+
+        try
+        {
+            await deleteTask.WaitAsync(operationCancellation.Token);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            _ = ObserveLateFault(deleteTask);
+            throw;
+        }
+        catch (OperationCanceledException exception) when (operationCancellation.IsCancellationRequested)
+        {
+            _ = ObserveLateFault(deleteTask);
+            throw new TimeoutException("Discord message cleanup operation timed out.", exception);
+        }
+    }
+
+    internal static Task ObserveLateFault(Task operationTask)
+    {
+        ArgumentNullException.ThrowIfNull(operationTask);
+
+        if (operationTask.IsCompleted)
+        {
+            _ = operationTask.Exception;
+            return Task.CompletedTask;
+        }
+
+        return operationTask.ContinueWith(
+            completedTask => _ = completedTask.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 }
 


### PR DESCRIPTION
Closes #164.

## Summary
- give every Discord bulk-delete and individual-delete cleanup operation a finite 10-second application-owned bound
- use one linked cancellation owner for both Discord.Net `RequestOptions.CancelToken` and BeanBot's bounded waiter
- propagate explicit caller cancellation instead of converting it into an ordinary cleanup failure
- observe late faults from abandoned timed-out/canceled Discord tasks
- keep cleanup best-effort after ordinary failures/timeouts and never retry an ambiguously timed-out delete
- preserve existing 100-message bulk batching and the 14-day individual-delete fallback

## Tests
Added focused coverage for:
- existing batch planning and old-message fallback
- completed bulk/individual failure continuation
- stalled bulk deletion timing out while later cleanup still runs
- stalled individual deletion timing out while later cleanup still runs
- caller cancellation stopping later cleanup and flowing into Discord request options
- timeout using the request cancellation token without retry
- late-fault observation

## Verification
Exact implementation head: `bc813b9a82ba294fd16e4a822b06a0f1c5a0f076`.

- Repository Verification #280: **PASS** via `./scripts/verify.sh full`; the workflow run is associated with this exact PR head and the verification job completed successfully
- tests: **448 passed, 0 failed, 0 skipped**
- Release build: **0 warnings / 0 errors**
- coverage: **66.47% lines / 54.36% branches**; baseline PASS
- locked restore, formatting/analyzers, branch-integrity guard, vulnerable-package audit, hardened Docker image/runtime smoke test, and SIGTERM shutdown smoke test: **PASS**
- CodeQL #114: **PASS** on the same head
- Dependency Review #93: **PASS** on the same head
- fresh review-automation Verifier: **PASS** after re-reading `AGENTS.md` and `beanbot-verify`, inspecting the complete two-file diff against issue #164 acceptance criteria, confirming current `develop` is still the PR base SHA, and re-checking current Actions evidence
- fresh independent Reviewer: **CLEAN** after re-reading `beanbot-review` and reviewing correctness, cancellation/timeout ownership, late-fault handling, no-retry semantics, cleanup continuation, test quality, security, Docker/runtime/release impact, and scope
- open review threads: **none**

Local repository execution remains unavailable because this automation environment cannot resolve `github.com` (`git ls-remote` fails with `Could not resolve host: github.com`). Repository policy's GitHub CI fallback supplied the deterministic full-verification evidence instead; no local PASS is being fabricated.

## Remaining manual validation
Optional live Discord smoke check: run/abort the legacy `%role setting` interaction and confirm its temporary messages are still cleaned up normally. The failure/timeout paths are covered deterministically without a live Discord token.

## Publication state
All code, verification, and fresh review gates are green. The PR remains draft only because the connected GitHub ready-for-review mutation is currently broken. The latest transition attempt failed with GitHub GraphQL reporting that `Repository.fullDatabaseId` does not exist (`markPullRequestReadyForReview -> pullRequest -> headRepository -> fullDatabaseId`). This is an external connector/schema blocker and did not modify the branch or CI state.

Per repository policy, the final human-review TL;DR comment is intentionally not posted while the PR cannot be transitioned out of draft.

No merge, auto-merge, or release was performed.