### PR TITLE
Bound paginator Discord REST operations

### DIFF
--- a/BeanBot.Tests/Discord/Messaging/DiscordPaginatorLifecycleTests.cs
+++ b/BeanBot.Tests/Discord/Messaging/DiscordPaginatorLifecycleTests.cs
@@ -1,0 +1,221 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using BeanBot.Discord.Messaging;
+using Discord;
+using Discord.Commands;
+using Discord.WebSocket;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.Messaging;
+
+public class DiscordPaginatorLifecycleTests
+{
+    [Fact]
+    public async Task SendAsync_CreatesPageAndAllControlsThenStopDeletesOnce()
+    {
+        using var fixture = new PaginatorFixture();
+
+        Assert.Same(fixture.Message, await fixture.SendAsync());
+
+        Assert.Equal("first", Assert.Single(fixture.Embeds).Description);
+        Assert.Equal("Page 1/2", fixture.Embeds[0].Footer?.Text);
+        Assert.Equal(5, fixture.AddedControls.Distinct().Count());
+        Assert.Single(fixture.Sessions);
+        Assert.Equal(DiscordPaginatorService.MaximumActivePaginators - 1, fixture.Slots.CurrentCount);
+        await fixture.StopAsync();
+        await fixture.StopAsync();
+        Assert.Equal(1, fixture.DeleteCount);
+        fixture.AssertSessionReleased();
+    }
+
+    [Fact]
+    public async Task SendAsync_StalledInitialSendReleasesSessionSlotButRetainsRawOperation()
+    {
+        using var fixture = new PaginatorFixture();
+        var stalled = new TaskCompletionSource<IUserMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+        fixture.SendMessage = () => stalled.Task;
+        try
+        {
+            await Assert.ThrowsAsync<TimeoutException>(() => fixture.SendAsync().WaitAsync(TimeSpan.FromSeconds(2)));
+            Assert.Equal(1, fixture.SendCount);
+            Assert.Empty(fixture.AddedControls);
+            fixture.AssertSessionReleased();
+            Assert.Equal(1, fixture.Operations.OwnedOperationCount);
+        }
+        finally
+        {
+            stalled.TrySetResult(fixture.Message);
+            await fixture.Operations.StopAsync().WaitAsync(TimeSpan.FromSeconds(1));
+        }
+        Assert.Equal(0, fixture.Operations.OwnedOperationCount);
+        fixture.AssertSessionReleased();
+    }
+
+    [Fact]
+    public async Task SendAsync_StalledControlSetupStopsSessionWithoutRetrying()
+    {
+        using var fixture = new PaginatorFixture();
+        var stalled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        fixture.AddControl = () => stalled.Task;
+        try
+        {
+            await Assert.ThrowsAsync<TimeoutException>(() => fixture.SendAsync().WaitAsync(TimeSpan.FromSeconds(2)));
+            Assert.Equal(1, fixture.SendCount);
+            Assert.Single(fixture.AddedControls);
+            fixture.AssertSessionReleased();
+            Assert.Equal(1, fixture.Operations.OwnedOperationCount);
+            Assert.Equal(0, fixture.DeleteCount);
+        }
+        finally
+        {
+            stalled.TrySetException(new InvalidOperationException("late control failure"));
+            await fixture.Operations.StopAsync().WaitAsync(TimeSpan.FromSeconds(1));
+        }
+        Assert.Equal(0, fixture.Operations.OwnedOperationCount);
+        fixture.AssertSessionReleased();
+    }
+
+    [Fact]
+    public async Task Expiration_StalledControlRemovalRemainsBoundedAndRetainsEachRawOperation()
+    {
+        using var fixture = new PaginatorFixture();
+        var stalled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        fixture.RemoveControl = () => stalled.Task;
+        try
+        {
+            await fixture.SendAsync(TimeSpan.FromMilliseconds(100));
+            var session = Assert.Single(fixture.Sessions).Value;
+            await session.CompletionTask.WaitAsync(TimeSpan.FromSeconds(2));
+
+            Assert.Equal(5, fixture.RemovedControls.Count);
+            Assert.Equal(5, fixture.RemovedControls.Distinct().Count());
+            Assert.All(fixture.RemovedUserIds, id => Assert.Equal(99UL, id));
+            Assert.Equal(5, fixture.Operations.OwnedOperationCount);
+            fixture.AssertSessionReleased();
+            await fixture.StopAsync();
+            Assert.Equal(0, fixture.DeleteCount);
+        }
+        finally
+        {
+            stalled.TrySetResult();
+            await fixture.Operations.StopAsync().WaitAsync(TimeSpan.FromSeconds(1));
+        }
+        Assert.Equal(0, fixture.Operations.OwnedOperationCount);
+        fixture.AssertSessionReleased();
+    }
+
+    [Fact]
+    public async Task Stop_StalledDeleteCompletesSessionOnceAndRetainsRawOperation()
+    {
+        using var fixture = new PaginatorFixture();
+        var stalled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        fixture.DeleteMessage = () => stalled.Task;
+        try
+        {
+            await fixture.SendAsync();
+            var session = Assert.Single(fixture.Sessions).Value;
+            await Task.WhenAll(fixture.StopAsync(), fixture.StopAsync()).WaitAsync(TimeSpan.FromSeconds(2));
+
+            Assert.True(session.CompletionTask.IsCompletedSuccessfully);
+            Assert.Equal(1, fixture.DeleteCount);
+            Assert.Equal(1, fixture.Operations.OwnedOperationCount);
+            fixture.AssertSessionReleased();
+        }
+        finally
+        {
+            stalled.TrySetResult();
+            await fixture.Operations.StopAsync().WaitAsync(TimeSpan.FromSeconds(1));
+        }
+        fixture.AssertSessionReleased();
+    }
+
+    private sealed class PaginatorFixture : IDisposable
+    {
+        private readonly DiscordSocketClient _client = new();
+        private readonly ICommandContext _context;
+        private readonly DiscordPaginatorService _paginator;
+        public IUserMessage Message { get; }
+        public Func<Task<IUserMessage>> SendMessage { get; set; }
+        public Func<Task> AddControl { get; set; } = () => Task.CompletedTask;
+        public Func<Task> RemoveControl { get; set; } = () => Task.CompletedTask;
+        public Func<Task> DeleteMessage { get; set; } = () => Task.CompletedTask;
+        public List<Embed> Embeds { get; } = [];
+        public List<string> AddedControls { get; } = [];
+        public List<string> RemovedControls { get; } = [];
+        public List<ulong> RemovedUserIds { get; } = [];
+        public int SendCount { get; private set; }
+        public int DeleteCount { get; private set; }
+        public ConcurrentDictionary<ulong, DiscordPaginatorService.PaginationSession> Sessions =>
+            GetField<ConcurrentDictionary<ulong, DiscordPaginatorService.PaginationSession>>("_sessions");
+        public SemaphoreSlim Slots => GetField<SemaphoreSlim>("_availableSlots");
+        public PaginatorDiscordOperationTracker Operations => GetField<PaginatorDiscordOperationTracker>("_discordOperations");
+
+        public PaginatorFixture()
+        {
+            _paginator = new DiscordPaginatorService(_client, NullLogger<DiscordPaginatorService>.Instance,
+                TimeSpan.FromMilliseconds(25), () => 99);
+            Message = CreateProxy<IUserMessage>((method, args) =>
+            {
+                switch (method.Name)
+                {
+                    case "get_Id": return 7UL;
+                    case nameof(IMessage.AddReactionAsync):
+                        AddedControls.Add(args[0]!.ToString()!);
+                        return AddControl();
+                    case nameof(IMessage.RemoveReactionAsync):
+                        RemovedControls.Add(args[0]!.ToString()!);
+                        RemovedUserIds.Add(Assert.IsType<ulong>(args[1]));
+                        return RemoveControl();
+                    case nameof(IMessage.DeleteAsync):
+                        DeleteCount++;
+                        return DeleteMessage();
+                    default: throw new InvalidOperationException(method.Name);
+                }
+            });
+            SendMessage = () => Task.FromResult(Message);
+            var channel = CreateProxy<IMessageChannel>((method, args) =>
+            {
+                Assert.Equal(nameof(IMessageChannel.SendMessageAsync), method.Name);
+                SendCount++;
+                Embeds.Add(Assert.Single(args.OfType<Embed>()));
+                return SendMessage();
+            });
+            var user = CreateProxy<IUser>((method, _) => method.Name == "get_Id" ? 42UL : throw new InvalidOperationException(method.Name));
+            _context = CreateProxy<ICommandContext>((method, _) => method.Name switch
+            {
+                "get_Channel" => channel,
+                "get_User" => user,
+                _ => throw new InvalidOperationException(method.Name)
+            });
+        }
+
+        public Task<IUserMessage> SendAsync(TimeSpan? timeout = null) => _paginator.SendAsync(_context, ["first", "second"], timeout);
+        public Task StopAsync() => _paginator.HandleReactionAsync(7, 42, new Emoji("\u23f9"));
+        public void AssertSessionReleased()
+        {
+            Assert.Empty(Sessions);
+            Assert.Equal(DiscordPaginatorService.MaximumActivePaginators, Slots.CurrentCount);
+        }
+        private T GetField<T>(string name) => Assert.IsType<T>(typeof(DiscordPaginatorService)
+            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(_paginator));
+        public void Dispose()
+        {
+            _paginator.Dispose();
+            _client.Dispose();
+        }
+    }
+
+    private static T CreateProxy<T>(Func<MethodInfo, object?[], object?> invoke) where T : class
+    {
+        var proxy = DispatchProxy.Create<T, DiscordProxy>();
+        ((DiscordProxy)(object)proxy).InvokeMethod = invoke;
+        return proxy;
+    }
+
+    public class DiscordProxy : DispatchProxy
+    {
+        public Func<MethodInfo, object?[], object?>? InvokeMethod { get; set; }
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args) => InvokeMethod!(targetMethod!, args ?? []);
+    }
+}

--- a/BeanBot.Tests/Discord/Messaging/DiscordPaginatorLifecycleTests.cs
+++ b/BeanBot.Tests/Discord/Messaging/DiscordPaginatorLifecycleTests.cs
@@ -1,9 +1,13 @@
 using System.Collections.Concurrent;
 using System.Reflection;
 using BeanBot.Discord.Messaging;
+using BeanBot.Hosting;
 using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -11,6 +15,64 @@ namespace BeanBot.Tests.Discord.Messaging;
 
 public class DiscordPaginatorLifecycleTests
 {
+    [Fact]
+    public async Task ApplicationShutdown_PaginatorRestSurvivesDrain_PreventsDiscordTeardown()
+    {
+        var builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["BeanBot:BotToken"] = "test-token",
+            ["BeanBot:MongoConnectionString"] = "mongodb://127.0.0.1:27017",
+            ["BeanBot:GeneralChannelId"] = "1",
+            ["BeanBot:HatoeteUrl"] = "https://example.com/a.png",
+            ["BeanBot:YoshimaruUrl"] = "https://example.com/b.png"
+        });
+        builder.Services.AddBeanBot(builder.Configuration);
+        builder.Services.AddSingleton(provider => new DiscordPaginatorService(
+            provider.GetRequiredService<DiscordSocketClient>(), NullLogger<DiscordPaginatorService>.Instance,
+            TimeSpan.FromMilliseconds(25), shutdownTimeout: TimeSpan.FromMilliseconds(25)));
+        using var host = builder.Build();
+        using var client = host.Services.GetRequiredService<DiscordSocketClient>();
+        var realRuntime = host.Services.GetRequiredService<IBeanBotRuntime>();
+        var paginator = host.Services.GetRequiredService<DiscordPaginatorService>();
+        var stalled = new TaskCompletionSource<IUserMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var channel = CreateProxy<IMessageChannel>((_, _) => stalled.Task);
+        var context = CreateProxy<ICommandContext>((method, _) => method.Name == "get_Channel"
+            ? channel : throw new InvalidOperationException(method.Name));
+        var calls = new List<string>();
+        var runtime = CreateProxy<IBeanBotRuntime>((method, _) =>
+        {
+            calls.Add(method.Name);
+            if (method.Name == "get_HasActiveDiscordLifecycleOperation") return realRuntime.HasActiveDiscordLifecycleOperation;
+            if (method.Name == "get_CanDisposeDiscordClient") return true;
+            if (method.Name == nameof(IBeanBotRuntime.StopPaginator)) realRuntime.StopPaginator();
+            if (method.ReturnType == typeof(Task<bool>)) return Task.FromResult(true);
+            if (method.ReturnType == typeof(Task)) return Task.CompletedTask;
+            return null;
+        });
+        try
+        {
+            await Assert.ThrowsAsync<TimeoutException>(() => paginator.SendAsync(context, ["first"]));
+            var application = new BeanBotApplication(runtime, NullLogger<BeanBotApplication>.Instance);
+
+            await application.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(2));
+
+            Assert.Contains(nameof(IBeanBotRuntime.StopPaginator), calls);
+            Assert.True(paginator.HasPendingOperations);
+            Assert.True(realRuntime.HasActiveDiscordLifecycleOperation);
+            Assert.DoesNotContain(nameof(IBeanBotRuntime.StopDiscordAsync), calls);
+            Assert.DoesNotContain(nameof(IBeanBotRuntime.DisposeDiscordClient), calls);
+        }
+        finally
+        {
+            stalled.TrySetException(new InvalidOperationException("late paginator send"));
+            var deadline = DateTime.UtcNow.AddSeconds(1);
+            while (paginator.HasPendingOperations && DateTime.UtcNow < deadline) await Task.Delay(5);
+        }
+        Assert.False(paginator.HasPendingOperations);
+        Assert.False(realRuntime.HasActiveDiscordLifecycleOperation);
+    }
+
     [Fact]
     public async Task SendAsync_CreatesPageAndAllControlsThenStopDeletesOnce()
     {

--- a/BeanBot.Tests/Discord/Messaging/DiscordPaginatorServiceTests.cs
+++ b/BeanBot.Tests/Discord/Messaging/DiscordPaginatorServiceTests.cs
@@ -171,23 +171,52 @@ public class DiscordPaginatorServiceTests
     [Fact]
     public async Task ReactionRemoval_UsesUserIdForRepeatedControlsWithoutCachedUser()
     {
+        using var client = new DiscordSocketClient();
+        using var paginator = new DiscordPaginatorService(
+            client,
+            NullLogger<DiscordPaginatorService>.Instance,
+            TimeSpan.FromSeconds(1));
         var message = DispatchProxy.Create<IUserMessage, ReactionRemovalMessageProxy>();
         var recorder = (ReactionRemovalMessageProxy)message;
         var control = new Emoji("▶");
 
-        await DiscordPaginatorService.TryRemoveUserReactionAsync(
+        await paginator.TryRemoveUserReactionAsync(
             message,
             control,
-            42,
-            NullLogger<DiscordPaginatorService>.Instance);
-        await DiscordPaginatorService.TryRemoveUserReactionAsync(
+            42);
+        await paginator.TryRemoveUserReactionAsync(
             message,
             control,
-            42,
-            NullLogger<DiscordPaginatorService>.Instance);
+            42);
 
         Assert.Equal(new ulong[] { 42, 42 }, recorder.RemovedUserIds);
         Assert.All(recorder.RemovedEmotes, emote => Assert.Equal(control, emote));
+    }
+
+    [Fact]
+    public async Task ReactionRemoval_TimeoutCancelsRequestWithoutRetrying()
+    {
+        using var client = new DiscordSocketClient();
+        using var paginator = new DiscordPaginatorService(
+            client,
+            NullLogger<DiscordPaginatorService>.Instance,
+            TimeSpan.FromMilliseconds(25));
+        var message = DispatchProxy.Create<IUserMessage, ReactionRemovalMessageProxy>();
+        var recorder = (ReactionRemovalMessageProxy)message;
+        var stalledRemoval = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        recorder.RemoveReactionTask = stalledRemoval.Task;
+
+        await paginator.TryRemoveUserReactionAsync(
+            message,
+            new Emoji("▶"),
+            42);
+
+        Assert.Single(recorder.RemovedUserIds);
+        Assert.Single(recorder.RequestCancellationTokens);
+        Assert.True(recorder.RequestCancellationTokens[0].IsCancellationRequested);
+
+        stalledRemoval.SetResult();
     }
 
     [Fact]
@@ -260,6 +289,8 @@ public class DiscordPaginatorServiceTests
     {
         public List<ulong> RemovedUserIds { get; } = [];
         public List<IEmote> RemovedEmotes { get; } = [];
+        public List<CancellationToken> RequestCancellationTokens { get; } = [];
+        public Task RemoveReactionTask { get; set; } = Task.CompletedTask;
 
         protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
         {
@@ -268,7 +299,13 @@ public class DiscordPaginatorServiceTests
             {
                 RemovedEmotes.Add(emote);
                 RemovedUserIds.Add(userId);
-                return Task.CompletedTask;
+                var requestOptions = args.OfType<RequestOptions>().SingleOrDefault();
+                if (requestOptions is not null)
+                {
+                    RequestCancellationTokens.Add(requestOptions.CancelToken);
+                }
+
+                return RemoveReactionTask;
             }
 
             throw new NotSupportedException(targetMethod?.Name);

--- a/BeanBot.Tests/Discord/Messaging/DiscordPaginatorServiceTests.cs
+++ b/BeanBot.Tests/Discord/Messaging/DiscordPaginatorServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
 using BeanBot.Discord.Messaging;
@@ -169,6 +170,51 @@ public class DiscordPaginatorServiceTests
     }
 
     [Fact]
+    public async Task PageEditTimeout_StopsQueuedNavigationBeforeAnotherEditCanStart()
+    {
+        using var client = new DiscordSocketClient();
+        using var paginator = new DiscordPaginatorService(
+            client,
+            NullLogger<DiscordPaginatorService>.Instance,
+            TimeSpan.FromMilliseconds(25));
+        var message = DispatchProxy.Create<IUserMessage, PageEditMessageProxy>();
+        var recorder = (PageEditMessageProxy)message;
+        var session = new DiscordPaginatorService.PaginationSession(
+            message,
+            42,
+            ["first", "second", "third"],
+            new PaginationCursor(3),
+            CancellationToken.None);
+        var sessions = Assert.IsType<ConcurrentDictionary<ulong, DiscordPaginatorService.PaginationSession>>(
+            typeof(DiscordPaginatorService).GetField("_sessions", BindingFlags.Instance | BindingFlags.NonPublic)
+                ?.GetValue(paginator));
+        var slots = Assert.IsType<SemaphoreSlim>(
+            typeof(DiscordPaginatorService).GetField("_availableSlots", BindingFlags.Instance | BindingFlags.NonPublic)
+                ?.GetValue(paginator));
+        Assert.True(slots.Wait(0));
+        Assert.True(sessions.TryAdd(7, session));
+
+        try
+        {
+            var firstNavigation = paginator.HandleReactionAsync(7, 42, new Emoji("▶"));
+            await recorder.EditStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+            var queuedNavigation = paginator.HandleReactionAsync(7, 42, new Emoji("▶"));
+
+            await Task.WhenAll(firstNavigation, queuedNavigation).WaitAsync(TimeSpan.FromSeconds(2));
+
+            Assert.Equal(1, recorder.EditCount);
+            Assert.True(session.CompletionStarted);
+            Assert.True(session.CompletionTask.IsCompletedSuccessfully);
+            Assert.Empty(sessions);
+            Assert.Equal(DiscordPaginatorService.MaximumActivePaginators, slots.CurrentCount);
+        }
+        finally
+        {
+            recorder.CompleteEdit.TrySetResult();
+        }
+    }
+
+    [Fact]
     public async Task ReactionRemoval_UsesUserIdForRepeatedControlsWithoutCachedUser()
     {
         using var client = new DiscordSocketClient();
@@ -282,6 +328,30 @@ public class DiscordPaginatorServiceTests
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+        }
+    }
+
+    public class PageEditMessageProxy : DispatchProxy
+    {
+        public TaskCompletionSource EditStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource CompleteEdit { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int EditCount { get; private set; }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod?.Name == nameof(IUserMessage.ModifyAsync))
+            {
+                EditCount++;
+                EditStarted.TrySetResult();
+                return CompleteEdit.Task;
+            }
+
+            if (targetMethod?.Name == "get_Id")
+            {
+                return 7UL;
+            }
+
+            throw new NotSupportedException(targetMethod?.Name);
         }
     }
 

--- a/BeanBot.Tests/Discord/Messaging/PaginatorDiscordOperationTrackerTests.cs
+++ b/BeanBot.Tests/Discord/Messaging/PaginatorDiscordOperationTrackerTests.cs
@@ -159,8 +159,8 @@ public class PaginatorDiscordOperationTrackerTests
     private static PaginatorDiscordOperationTracker CreateTracker(
         int maximumOperations,
         TimeSpan? operationTimeout = null,
-        CancellationToken shutdownCancellation = default,
-        Action<Exception, string>? lateFailureObserver = null)
+        Action<Exception, string>? lateFailureObserver = null,
+        CancellationToken shutdownCancellation = default)
         => new(
             maximumOperations,
             operationTimeout ?? TimeSpan.FromSeconds(1),

--- a/BeanBot.Tests/Discord/Messaging/PaginatorDiscordOperationTrackerTests.cs
+++ b/BeanBot.Tests/Discord/Messaging/PaginatorDiscordOperationTrackerTests.cs
@@ -1,0 +1,170 @@
+using BeanBot.Discord.Messaging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.Messaging;
+
+public class PaginatorDiscordOperationTrackerTests
+{
+    [Fact]
+    public async Task RunAsync_SuccessExecutesOnceAndReclaimsOwnership()
+    {
+        var tracker = CreateTracker(maximumOperations: 1);
+        var calls = 0;
+        CancellationToken requestToken = default;
+
+        var result = await tracker.RunAsync(
+            "send message",
+            options =>
+            {
+                calls++;
+                requestToken = options.CancelToken;
+                return Task.FromResult(42);
+            });
+
+        Assert.Equal(42, result);
+        Assert.Equal(1, calls);
+        Assert.True(requestToken.CanBeCanceled);
+        Assert.False(requestToken.IsCancellationRequested);
+        Assert.True(SpinWait.SpinUntil(
+            () => tracker.OwnedOperationCount == 0,
+            TimeSpan.FromSeconds(1)));
+
+        await tracker.StopAsync().WaitAsync(TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task RunAsync_TimeoutCancelsSharedRequestTokenAndObservesLateFailure()
+    {
+        var lateFailure = new TaskCompletionSource<(Exception Exception, string Operation)>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var tracker = CreateTracker(
+            maximumOperations: 1,
+            operationTimeout: TimeSpan.FromMilliseconds(25),
+            lateFailureObserver: (exception, operation) =>
+                lateFailure.TrySetResult((exception, operation)));
+        var operation = new TaskCompletionSource<int>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        CancellationToken requestToken = default;
+
+        await Assert.ThrowsAsync<TimeoutException>(() => tracker.RunAsync(
+            "modify page",
+            options =>
+            {
+                calls++;
+                requestToken = options.CancelToken;
+                return operation.Task;
+            }));
+
+        Assert.Equal(1, calls);
+        Assert.True(requestToken.IsCancellationRequested);
+        Assert.Equal(1, tracker.OwnedOperationCount);
+
+        var lateException = new InvalidOperationException("late paginator failure");
+        operation.SetException(lateException);
+        var observed = await lateFailure.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.Same(lateException, observed.Exception);
+        Assert.Equal("modify page", observed.Operation);
+        Assert.True(SpinWait.SpinUntil(
+            () => tracker.OwnedOperationCount == 0,
+            TimeSpan.FromSeconds(1)));
+
+        await tracker.StopAsync().WaitAsync(TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task RunAsync_RepeatedTimeoutsCannotExceedHardOperationBound()
+    {
+        var tracker = CreateTracker(
+            maximumOperations: 2,
+            operationTimeout: TimeSpan.FromMilliseconds(25));
+        var first = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var second = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await Assert.ThrowsAsync<TimeoutException>(() =>
+            tracker.RunAsync("first operation", _ => first.Task));
+        await Assert.ThrowsAsync<TimeoutException>(() =>
+            tracker.RunAsync("second operation", _ => second.Task));
+
+        Assert.Equal(2, tracker.OwnedOperationCount);
+
+        var thirdCalls = 0;
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            tracker.RunAsync(
+                "third operation",
+                _ =>
+                {
+                    thirdCalls++;
+                    return Task.CompletedTask;
+                }));
+        Assert.Equal(0, thirdCalls);
+        Assert.Equal(2, tracker.OwnedOperationCount);
+
+        first.SetResult();
+        Assert.True(SpinWait.SpinUntil(
+            () => tracker.OwnedOperationCount == 1,
+            TimeSpan.FromSeconds(1)));
+
+        await tracker.RunAsync("replacement operation", _ => Task.CompletedTask);
+        Assert.True(SpinWait.SpinUntil(
+            () => tracker.OwnedOperationCount == 1,
+            TimeSpan.FromSeconds(1)));
+
+        second.SetResult();
+        await tracker.StopAsync().WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.Equal(0, tracker.OwnedOperationCount);
+    }
+
+    [Fact]
+    public async Task RunAsync_ShutdownCancellationIsNotReportedAsTimeout()
+    {
+        using var shutdown = new CancellationTokenSource();
+        var tracker = CreateTracker(
+            maximumOperations: 1,
+            operationTimeout: TimeSpan.FromSeconds(1),
+            shutdownCancellation: shutdown.Token);
+        var operation = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        CancellationToken requestToken = default;
+
+        var run = tracker.RunAsync(
+            "remove expired control",
+            options =>
+            {
+                requestToken = options.CancelToken;
+                return operation.Task;
+            });
+        shutdown.Cancel();
+
+        var exception = await Record.ExceptionAsync(async () => await run);
+
+        Assert.IsAssignableFrom<OperationCanceledException>(exception);
+        Assert.True(requestToken.IsCancellationRequested);
+        Assert.Equal(1, tracker.OwnedOperationCount);
+
+        var firstStop = tracker.StopAsync();
+        var repeatedStop = tracker.StopAsync();
+        Assert.Same(firstStop, repeatedStop);
+        Assert.False(firstStop.IsCompleted);
+
+        operation.SetResult();
+        await firstStop.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.Equal(0, tracker.OwnedOperationCount);
+    }
+
+    private static PaginatorDiscordOperationTracker CreateTracker(
+        int maximumOperations,
+        TimeSpan? operationTimeout = null,
+        CancellationToken shutdownCancellation = default,
+        Action<Exception, string>? lateFailureObserver = null)
+        => new(
+            maximumOperations,
+            operationTimeout ?? TimeSpan.FromSeconds(1),
+            shutdownCancellation,
+            NullLogger<DiscordPaginatorService>.Instance,
+            lateFailureObserver);
+}

--- a/BeanBot.Tests/Discord/Messaging/PaginatorDiscordOperationTrackerTests.cs
+++ b/BeanBot.Tests/Discord/Messaging/PaginatorDiscordOperationTrackerTests.cs
@@ -164,7 +164,7 @@ public class PaginatorDiscordOperationTrackerTests
         => new(
             maximumOperations,
             operationTimeout ?? TimeSpan.FromSeconds(1),
-            shutdownCancellation,
             NullLogger<DiscordPaginatorService>.Instance,
-            lateFailureObserver);
+            lateFailureObserver,
+            shutdownCancellation);
 }

--- a/BeanBot/Discord/Messaging/DiscordPaginatorService.cs
+++ b/BeanBot/Discord/Messaging/DiscordPaginatorService.cs
@@ -12,6 +12,7 @@ public sealed class DiscordPaginatorService : IDisposable
 {
     internal const int MaximumActivePaginators = 64;
     internal static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(5);
+    internal static readonly TimeSpan DiscordOperationTimeout = TimeSpan.FromSeconds(10);
     internal static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(5);
     private static readonly Emoji FirstPage = new("⏮");
     private static readonly Emoji PreviousPage = new("◀");
@@ -31,16 +32,36 @@ public sealed class DiscordPaginatorService : IDisposable
     private readonly ConcurrentDictionary<ulong, PaginationSession> _sessions = new();
     private readonly SemaphoreSlim _availableSlots = new(MaximumActivePaginators, MaximumActivePaginators);
     private readonly CancellationTokenSource _shutdown = new();
+    private readonly CancellationToken _shutdownToken;
     private readonly object _syncRoot = new();
     private readonly ILogger<DiscordPaginatorService> _logger;
+    private readonly PaginatorDiscordOperationTracker _discordOperations;
     private int _disposed;
 
     public DiscordPaginatorService(
         DiscordSocketClient discordClient,
         ILogger<DiscordPaginatorService> logger)
+        : this(discordClient, logger, DiscordOperationTimeout)
     {
+    }
+
+    internal DiscordPaginatorService(
+        DiscordSocketClient discordClient,
+        ILogger<DiscordPaginatorService> logger,
+        TimeSpan discordOperationTimeout)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(
+            discordOperationTimeout,
+            TimeSpan.Zero);
+
         _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _shutdownToken = _shutdown.Token;
+        _discordOperations = new PaginatorDiscordOperationTracker(
+            MaximumActivePaginators,
+            discordOperationTimeout,
+            _shutdownToken,
+            _logger);
         _discordClient.ReactionAdded += HandleReactionAsync;
     }
 
@@ -81,10 +102,12 @@ public sealed class DiscordPaginatorService : IDisposable
         try
         {
             var cursor = new PaginationCursor(pageList.Count);
-            message = await context.Channel.SendMessageAsync(
-                embed: BuildEmbed(pageList, cursor),
-                options: CreateRequestOptions(_shutdown.Token));
-            session = new PaginationSession(message, context.User.Id, pageList, cursor, _shutdown.Token);
+            message = await _discordOperations.RunAsync(
+                "send message",
+                options => context.Channel.SendMessageAsync(
+                    embed: BuildEmbed(pageList, cursor),
+                    options: options));
+            session = new PaginationSession(message, context.User.Id, pageList, cursor, _shutdownToken);
             await session.Access.WaitAsync();
             sessionAccessHeld = true;
             lock (_syncRoot)
@@ -100,7 +123,9 @@ public sealed class DiscordPaginatorService : IDisposable
 
             foreach (var control in Controls)
             {
-                await message.AddReactionAsync(control, CreateRequestOptions(_shutdown.Token));
+                await _discordOperations.RunAsync(
+                    "add control reaction",
+                    options => message.AddReactionAsync(control, options));
             }
 
             ObjectDisposedException.ThrowIf(
@@ -157,10 +182,11 @@ public sealed class DiscordPaginatorService : IDisposable
             return;
         }
 
+        var terminateAfterAmbiguousEdit = false;
         try
         {
             var stopRequested = false;
-            await session.Access.WaitAsync(_shutdown.Token);
+            await session.Access.WaitAsync(_shutdownToken);
             try
             {
                 if (!_sessions.TryGetValue(message.Id, out var currentSession)
@@ -178,17 +204,26 @@ public sealed class DiscordPaginatorService : IDisposable
                 {
                     if (session.Cursor.Move(action))
                     {
-                        await session.Message.ModifyAsync(
-                            properties => properties.Embed = BuildEmbed(session.Pages, session.Cursor),
-                            options: CreateRequestOptions(_shutdown.Token));
+                        try
+                        {
+                            await _discordOperations.RunAsync(
+                                "modify page",
+                                options => session.Message.ModifyAsync(
+                                    properties => properties.Embed = BuildEmbed(session.Pages, session.Cursor),
+                                    options));
+                        }
+                        catch (TimeoutException)
+                        {
+                            terminateAfterAmbiguousEdit = true;
+                            throw;
+                        }
                     }
 
                     await TryRemoveUserReactionAsync(
                         session.Message,
                         reaction.Emote,
                         reaction.UserId,
-                        _logger,
-                        _shutdown.Token);
+                        _shutdownToken);
                 }
             }
             finally
@@ -201,11 +236,29 @@ public sealed class DiscordPaginatorService : IDisposable
                 await StopSessionAsync(message.Id, session, deleteMessage: true);
             }
         }
-        catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
+        catch (OperationCanceledException) when (_shutdownToken.IsCancellationRequested)
         {
         }
         catch (Exception exception)
         {
+            if (terminateAfterAmbiguousEdit)
+            {
+                try
+                {
+                    await StopSessionAsync(message.Id, session, deleteMessage: false);
+                }
+                catch (OperationCanceledException) when (_shutdownToken.IsCancellationRequested)
+                {
+                }
+                catch (Exception completionException)
+                {
+                    BeanBotLog.PaginatorReactionFailed(
+                        _logger,
+                        message.Id,
+                        completionException);
+                }
+            }
+
             BeanBotLog.PaginatorReactionFailed(_logger, message.Id, exception);
         }
     }
@@ -238,17 +291,24 @@ public sealed class DiscordPaginatorService : IDisposable
 
             foreach (var control in Controls)
             {
-                if (_shutdown.IsCancellationRequested)
+                if (_shutdownToken.IsCancellationRequested)
                 {
                     return;
                 }
 
                 try
                 {
-                    await session.Message.RemoveReactionAsync(
-                        control,
-                        currentUser,
-                        CreateRequestOptions(expirationCancellation));
+                    await _discordOperations.RunAsync(
+                        "remove expired control",
+                        options => session.Message.RemoveReactionAsync(
+                            control,
+                            currentUser,
+                            options),
+                        expirationCancellation);
+                }
+                catch (OperationCanceledException) when (expirationCancellation.IsCancellationRequested)
+                {
+                    return;
                 }
                 catch (Exception exception)
                 {
@@ -291,9 +351,12 @@ public sealed class DiscordPaginatorService : IDisposable
         try
         {
             await session.ExpirationTask;
-            if (deleteMessage && !_shutdown.IsCancellationRequested)
+            if (deleteMessage && !_shutdownToken.IsCancellationRequested)
             {
-                await session.Message.DeleteAsync(CreateRequestOptions(_shutdown.Token));
+                await _discordOperations.RunAsync(
+                    "delete stopped paginator",
+                    options => session.Message.DeleteAsync(options),
+                    _shutdownToken);
             }
         }
         finally
@@ -302,24 +365,31 @@ public sealed class DiscordPaginatorService : IDisposable
         }
     }
 
-    internal static async Task TryRemoveUserReactionAsync(
+    internal async Task TryRemoveUserReactionAsync(
         IUserMessage message,
         IEmote emote,
         ulong userId,
-        ILogger<DiscordPaginatorService> logger,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(logger);
         try
         {
-            await message.RemoveReactionAsync(
-                emote,
-                userId,
-                CreateRequestOptions(cancellationToken));
+            await _discordOperations.RunAsync(
+                "remove user reaction",
+                options => message.RemoveReactionAsync(
+                    emote,
+                    userId,
+                    options),
+                cancellationToken);
+        }
+        catch (OperationCanceledException)
+            when (cancellationToken.IsCancellationRequested
+                || _shutdownToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception exception)
         {
-            BeanBotLog.PaginatorUserReactionRemoveFailed(logger, userId, exception);
+            BeanBotLog.PaginatorUserReactionRemoveFailed(_logger, userId, exception);
         }
     }
 
@@ -359,9 +429,6 @@ public sealed class DiscordPaginatorService : IDisposable
         }
     }
 
-    private static RequestOptions CreateRequestOptions(CancellationToken cancellationToken)
-        => new() { CancelToken = cancellationToken };
-
     private static PaginationAction GetAction(IEmote emote)
     {
         if (emote.Equals(FirstPage)) return PaginationAction.First;
@@ -390,7 +457,10 @@ public sealed class DiscordPaginatorService : IDisposable
 
             _discordClient.ReactionAdded -= HandleReactionAsync;
             _shutdown.Cancel();
-            shutdownTasks = new List<Task>(_sessions.Count);
+            shutdownTasks = new List<Task>(_sessions.Count + 1)
+            {
+                _discordOperations.StopAsync()
+            };
             foreach (var session in _sessions)
             {
                 session.Value.CancelExpiration();

--- a/BeanBot/Discord/Messaging/DiscordPaginatorService.cs
+++ b/BeanBot/Discord/Messaging/DiscordPaginatorService.cs
@@ -60,8 +60,9 @@ public sealed class DiscordPaginatorService : IDisposable
         _discordOperations = new PaginatorDiscordOperationTracker(
             MaximumActivePaginators,
             discordOperationTimeout,
-            _shutdownToken,
-            _logger);
+            _logger,
+            lateFailureObserver: null,
+            _shutdownToken);
         _discordClient.ReactionAdded += HandleReactionAsync;
     }
 

--- a/BeanBot/Discord/Messaging/DiscordPaginatorService.cs
+++ b/BeanBot/Discord/Messaging/DiscordPaginatorService.cs
@@ -2,7 +2,6 @@ using System.Collections.Concurrent;
 using BeanBot.Logging;
 using Discord;
 using Discord.Commands;
-using Discord.Rest;
 using Discord.WebSocket;
 using Microsoft.Extensions.Logging;
 
@@ -29,6 +28,7 @@ public sealed class DiscordPaginatorService : IDisposable
     };
 
     private readonly DiscordSocketClient _discordClient;
+    private readonly Func<ulong?> _getCurrentUserId;
     private readonly ConcurrentDictionary<ulong, PaginationSession> _sessions = new();
     private readonly SemaphoreSlim _availableSlots = new(MaximumActivePaginators, MaximumActivePaginators);
     private readonly CancellationTokenSource _shutdown = new();
@@ -48,13 +48,15 @@ public sealed class DiscordPaginatorService : IDisposable
     internal DiscordPaginatorService(
         DiscordSocketClient discordClient,
         ILogger<DiscordPaginatorService> logger,
-        TimeSpan discordOperationTimeout)
+        TimeSpan discordOperationTimeout,
+        Func<ulong?>? getCurrentUserId = null)
     {
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(
             discordOperationTimeout,
             TimeSpan.Zero);
 
         _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
+        _getCurrentUserId = getCurrentUserId ?? (() => _discordClient.CurrentUser?.Id);
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _shutdownToken = _shutdown.Token;
         _discordOperations = new PaginatorDiscordOperationTracker(
@@ -66,8 +68,14 @@ public sealed class DiscordPaginatorService : IDisposable
         _discordClient.ReactionAdded += HandleReactionAsync;
     }
 
-    public async Task<IUserMessage> SendAsync(
+    public Task<IUserMessage> SendAsync(
         SocketCommandContext context,
+        IReadOnlyCollection<string> pages,
+        TimeSpan? timeout = null)
+        => SendAsync((ICommandContext)context, pages, timeout);
+
+    internal async Task<IUserMessage> SendAsync(
+        ICommandContext context,
         IReadOnlyCollection<string> pages,
         TimeSpan? timeout = null)
     {
@@ -96,7 +104,7 @@ public sealed class DiscordPaginatorService : IDisposable
             }
         }
 
-        RestUserMessage? message = null;
+        IUserMessage? message = null;
         PaginationSession? session = null;
         var sessionRegistered = false;
         var sessionAccessHeld = false;
@@ -173,7 +181,7 @@ public sealed class DiscordPaginatorService : IDisposable
     internal async Task HandleReactionAsync(ulong messageId, ulong userId, IEmote emote)
     {
         if (Volatile.Read(ref _disposed) != 0
-            || userId == _discordClient.CurrentUser?.Id
+            || userId == _getCurrentUserId()
             || !_sessions.TryGetValue(messageId, out var session)
             || userId != session.UserId)
         {
@@ -296,8 +304,8 @@ public sealed class DiscordPaginatorService : IDisposable
             await session.Access.WaitAsync();
             ownsAccess = true;
 
-            var currentUser = _discordClient.CurrentUser;
-            if (currentUser == null)
+            var currentUserId = _getCurrentUserId();
+            if (currentUserId is null)
             {
                 return;
             }
@@ -315,7 +323,7 @@ public sealed class DiscordPaginatorService : IDisposable
                         "remove expired control",
                         options => session.Message.RemoveReactionAsync(
                             control,
-                            currentUser,
+                            currentUserId.Value,
                             options),
                         expirationCancellation);
                 }

--- a/BeanBot/Discord/Messaging/DiscordPaginatorService.cs
+++ b/BeanBot/Discord/Messaging/DiscordPaginatorService.cs
@@ -164,33 +164,37 @@ public sealed class DiscordPaginatorService : IDisposable
         }
     }
 
-    private async Task HandleReactionAsync(
+    private Task HandleReactionAsync(
         Cacheable<IUserMessage, ulong> message,
         Cacheable<IMessageChannel, ulong> channel,
         SocketReaction reaction)
+        => HandleReactionAsync(message.Id, reaction.UserId, reaction.Emote);
+
+    internal async Task HandleReactionAsync(ulong messageId, ulong userId, IEmote emote)
     {
         if (Volatile.Read(ref _disposed) != 0
-            || reaction.UserId == _discordClient.CurrentUser?.Id
-            || !_sessions.TryGetValue(message.Id, out var session)
-            || reaction.UserId != session.UserId)
+            || userId == _discordClient.CurrentUser?.Id
+            || !_sessions.TryGetValue(messageId, out var session)
+            || userId != session.UserId)
         {
             return;
         }
 
-        var action = GetAction(reaction.Emote);
+        var action = GetAction(emote);
         if (action == PaginationAction.None)
         {
             return;
         }
 
         var terminateAfterAmbiguousEdit = false;
+        var ownsAmbiguousEditCompletion = false;
         try
         {
             var stopRequested = false;
             await session.Access.WaitAsync(_shutdownToken);
             try
             {
-                if (!_sessions.TryGetValue(message.Id, out var currentSession)
+                if (!_sessions.TryGetValue(messageId, out var currentSession)
                     || !ReferenceEquals(currentSession, session)
                     || session.CompletionStarted)
                 {
@@ -216,14 +220,15 @@ public sealed class DiscordPaginatorService : IDisposable
                         catch (TimeoutException)
                         {
                             terminateAfterAmbiguousEdit = true;
+                            ownsAmbiguousEditCompletion = session.TryBeginCompletion();
                             throw;
                         }
                     }
 
                     await TryRemoveUserReactionAsync(
                         session.Message,
-                        reaction.Emote,
-                        reaction.UserId,
+                        emote,
+                        userId,
                         _shutdownToken);
                 }
             }
@@ -234,7 +239,7 @@ public sealed class DiscordPaginatorService : IDisposable
 
             if (stopRequested)
             {
-                await StopSessionAsync(message.Id, session, deleteMessage: true);
+                await StopSessionAsync(messageId, session, deleteMessage: true);
             }
         }
         catch (OperationCanceledException) when (_shutdownToken.IsCancellationRequested)
@@ -246,7 +251,14 @@ public sealed class DiscordPaginatorService : IDisposable
             {
                 try
                 {
-                    await StopSessionAsync(message.Id, session, deleteMessage: false);
+                    if (ownsAmbiguousEditCompletion)
+                    {
+                        await CompleteStoppedSessionAsync(messageId, session, deleteMessage: false);
+                    }
+                    else
+                    {
+                        await session.CompletionTask;
+                    }
                 }
                 catch (OperationCanceledException) when (_shutdownToken.IsCancellationRequested)
                 {
@@ -255,12 +267,12 @@ public sealed class DiscordPaginatorService : IDisposable
                 {
                     BeanBotLog.PaginatorReactionFailed(
                         _logger,
-                        message.Id,
+                        messageId,
                         completionException);
                 }
             }
 
-            BeanBotLog.PaginatorReactionFailed(_logger, message.Id, exception);
+            BeanBotLog.PaginatorReactionFailed(_logger, messageId, exception);
         }
     }
 
@@ -348,6 +360,14 @@ public sealed class DiscordPaginatorService : IDisposable
             return;
         }
 
+        await CompleteStoppedSessionAsync(messageId, session, deleteMessage);
+    }
+
+    private async Task CompleteStoppedSessionAsync(
+        ulong messageId,
+        PaginationSession session,
+        bool deleteMessage)
+    {
         session.CancelExpiration();
         try
         {
@@ -539,7 +559,7 @@ public sealed class DiscordPaginatorService : IDisposable
         ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
     }
 
-    private sealed class PaginationSession
+    internal sealed class PaginationSession
     {
         public PaginationSession(
             IUserMessage message,

--- a/BeanBot/Discord/Messaging/DiscordPaginatorService.cs
+++ b/BeanBot/Discord/Messaging/DiscordPaginatorService.cs
@@ -36,6 +36,7 @@ public sealed class DiscordPaginatorService : IDisposable
     private readonly object _syncRoot = new();
     private readonly ILogger<DiscordPaginatorService> _logger;
     private readonly PaginatorDiscordOperationTracker _discordOperations;
+    private readonly TimeSpan _shutdownTimeout;
     private int _disposed;
 
     public DiscordPaginatorService(
@@ -49,7 +50,8 @@ public sealed class DiscordPaginatorService : IDisposable
         DiscordSocketClient discordClient,
         ILogger<DiscordPaginatorService> logger,
         TimeSpan discordOperationTimeout,
-        Func<ulong?>? getCurrentUserId = null)
+        Func<ulong?>? getCurrentUserId = null,
+        TimeSpan? shutdownTimeout = null)
     {
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(
             discordOperationTimeout,
@@ -58,6 +60,8 @@ public sealed class DiscordPaginatorService : IDisposable
         _discordClient = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
         _getCurrentUserId = getCurrentUserId ?? (() => _discordClient.CurrentUser?.Id);
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _shutdownTimeout = shutdownTimeout ?? ShutdownTimeout;
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(_shutdownTimeout, TimeSpan.Zero);
         _shutdownToken = _shutdown.Token;
         _discordOperations = new PaginatorDiscordOperationTracker(
             MaximumActivePaginators,
@@ -67,6 +71,8 @@ public sealed class DiscordPaginatorService : IDisposable
             _shutdownToken);
         _discordClient.ReactionAdded += HandleReactionAsync;
     }
+
+    internal bool HasPendingOperations => _discordOperations.OwnedOperationCount > 0;
 
     public Task<IUserMessage> SendAsync(
         SocketCommandContext context,
@@ -509,13 +515,13 @@ public sealed class DiscordPaginatorService : IDisposable
         var shutdown = Task.WhenAll(shutdownTasks);
         try
         {
-            if (WaitForShutdown(shutdown, ShutdownTimeout))
+            if (WaitForShutdown(shutdown, _shutdownTimeout))
             {
                 _shutdown.Dispose();
                 return;
             }
 
-            BeanBotLog.PaginatorShutdownTimedOut(_logger, ShutdownTimeout);
+            BeanBotLog.PaginatorShutdownTimedOut(_logger, _shutdownTimeout);
         }
         catch (Exception exception)
         {

--- a/BeanBot/Discord/Messaging/PaginatorDiscordOperationTracker.cs
+++ b/BeanBot/Discord/Messaging/PaginatorDiscordOperationTracker.cs
@@ -20,20 +20,6 @@ internal sealed class PaginatorDiscordOperationTracker
     public PaginatorDiscordOperationTracker(
         int maximumOperations,
         TimeSpan operationTimeout,
-        CancellationToken shutdownCancellation,
-        ILogger<DiscordPaginatorService> logger)
-        : this(
-            maximumOperations,
-            operationTimeout,
-            logger,
-            lateFailureObserver: null,
-            shutdownCancellation)
-    {
-    }
-
-    public PaginatorDiscordOperationTracker(
-        int maximumOperations,
-        TimeSpan operationTimeout,
         ILogger<DiscordPaginatorService> logger,
         Action<Exception, string>? lateFailureObserver,
         CancellationToken shutdownCancellation)

--- a/BeanBot/Discord/Messaging/PaginatorDiscordOperationTracker.cs
+++ b/BeanBot/Discord/Messaging/PaginatorDiscordOperationTracker.cs
@@ -1,0 +1,227 @@
+using BeanBot.Logging;
+using Discord;
+using Microsoft.Extensions.Logging;
+
+namespace BeanBot.Discord.Messaging;
+
+internal sealed class PaginatorDiscordOperationTracker
+{
+    private readonly object _syncRoot = new();
+    private readonly int _maximumOperations;
+    private readonly TimeSpan _operationTimeout;
+    private readonly CancellationToken _shutdownCancellation;
+    private readonly ILogger<DiscordPaginatorService> _logger;
+    private readonly Action<Exception, string>? _lateFailureObserver;
+    private readonly TaskCompletionSource _stopped = new(
+        TaskCreationOptions.RunContinuationsAsynchronously);
+    private int _ownedOperationCount;
+    private bool _stopping;
+
+    public PaginatorDiscordOperationTracker(
+        int maximumOperations,
+        TimeSpan operationTimeout,
+        CancellationToken shutdownCancellation,
+        ILogger<DiscordPaginatorService> logger,
+        Action<Exception, string>? lateFailureObserver = null)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumOperations);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(operationTimeout, TimeSpan.Zero);
+
+        _maximumOperations = maximumOperations;
+        _operationTimeout = operationTimeout;
+        _shutdownCancellation = shutdownCancellation;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _lateFailureObserver = lateFailureObserver;
+    }
+
+    internal int OwnedOperationCount
+    {
+        get
+        {
+            lock (_syncRoot)
+            {
+                return _ownedOperationCount;
+            }
+        }
+    }
+
+    public Task RunAsync(
+        string operationName,
+        Func<RequestOptions, Task> beginOperation,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(beginOperation);
+
+        return RunAsync<object?>(
+            operationName,
+            async options =>
+            {
+                await beginOperation(options);
+                return null;
+            },
+            cancellationToken);
+    }
+
+    public async Task<TResult> RunAsync<TResult>(
+        string operationName,
+        Func<RequestOptions, Task<TResult>> beginOperation,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(operationName);
+        ArgumentNullException.ThrowIfNull(beginOperation);
+
+        AcquireOperation(operationName, cancellationToken);
+        Task<TResult>? operation = null;
+        try
+        {
+            using var operationCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                _shutdownCancellation,
+                cancellationToken);
+            operationCancellation.CancelAfter(_operationTimeout);
+            operationCancellation.Token.ThrowIfCancellationRequested();
+
+            operation = beginOperation(
+                new RequestOptions
+                {
+                    CancelToken = operationCancellation.Token
+                }) ?? throw new InvalidOperationException(
+                    $"Discord paginator operation '{operationName}' returned no task.");
+            _ = ObserveOperationCompletionAsync(operation);
+
+            try
+            {
+                return await operation.WaitAsync(operationCancellation.Token);
+            }
+            catch (OperationCanceledException)
+                when (_shutdownCancellation.IsCancellationRequested
+                    || cancellationToken.IsCancellationRequested)
+            {
+                if (!operation.IsCompleted)
+                {
+                    ObserveLateFailure(operation, operationName);
+                }
+
+                throw;
+            }
+            catch (OperationCanceledException exception)
+                when (operationCancellation.IsCancellationRequested)
+            {
+                if (!operation.IsCompleted)
+                {
+                    ObserveLateFailure(operation, operationName);
+                }
+
+                BeanBotLog.PaginatorDiscordOperationTimedOut(
+                    _logger,
+                    operationName,
+                    _operationTimeout);
+                throw new TimeoutException(
+                    $"Discord paginator operation '{operationName}' exceeded {_operationTimeout}.",
+                    exception);
+            }
+        }
+        catch
+        {
+            if (operation is null)
+            {
+                ReleaseOperation();
+            }
+
+            throw;
+        }
+    }
+
+    public Task StopAsync()
+    {
+        lock (_syncRoot)
+        {
+            _stopping = true;
+            if (_ownedOperationCount == 0)
+            {
+                _stopped.TrySetResult();
+            }
+
+            return _stopped.Task;
+        }
+    }
+
+    private void AcquireOperation(
+        string operationName,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        _shutdownCancellation.ThrowIfCancellationRequested();
+
+        lock (_syncRoot)
+        {
+            if (_stopping || _shutdownCancellation.IsCancellationRequested)
+            {
+                throw new OperationCanceledException(_shutdownCancellation);
+            }
+
+            if (_ownedOperationCount >= _maximumOperations)
+            {
+                BeanBotLog.PaginatorDiscordOperationCapacityExhausted(
+                    _logger,
+                    operationName,
+                    _maximumOperations);
+                throw new InvalidOperationException(
+                    $"Discord paginator operation capacity of {_maximumOperations} is exhausted.");
+            }
+
+            _ownedOperationCount++;
+        }
+    }
+
+    private async Task ObserveOperationCompletionAsync(Task operation)
+    {
+        try
+        {
+            await operation;
+        }
+        catch
+        {
+            // The caller observes prompt failures. Timed-out/canceled callers attach a
+            // dedicated late-failure observer before relinquishing their bounded wait.
+        }
+        finally
+        {
+            ReleaseOperation();
+        }
+    }
+
+    private void ObserveLateFailure(Task operation, string operationName)
+    {
+        _ = operation.ContinueWith(
+            completedTask =>
+            {
+                var exception = completedTask.Exception!.GetBaseException();
+                if (_lateFailureObserver is not null)
+                {
+                    _lateFailureObserver(exception, operationName);
+                }
+                else
+                {
+                    BeanBotLog.PaginatorDiscordOperationLateFailure(
+                        _logger,
+                        operationName,
+                        exception);
+                }
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    private void ReleaseOperation()
+    {
+        lock (_syncRoot)
+        {
+            _ownedOperationCount--;
+            if (_stopping && _ownedOperationCount == 0)
+            {
+                _stopped.TrySetResult();
+            }
+        }
+    }
+}

--- a/BeanBot/Discord/Messaging/PaginatorDiscordOperationTracker.cs
+++ b/BeanBot/Discord/Messaging/PaginatorDiscordOperationTracker.cs
@@ -20,9 +20,9 @@ internal sealed class PaginatorDiscordOperationTracker
     public PaginatorDiscordOperationTracker(
         int maximumOperations,
         TimeSpan operationTimeout,
-        CancellationToken shutdownCancellation,
         ILogger<DiscordPaginatorService> logger,
-        Action<Exception, string>? lateFailureObserver = null)
+        Action<Exception, string>? lateFailureObserver,
+        CancellationToken shutdownCancellation)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumOperations);
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(operationTimeout, TimeSpan.Zero);

--- a/BeanBot/Discord/Messaging/PaginatorDiscordOperationTracker.cs
+++ b/BeanBot/Discord/Messaging/PaginatorDiscordOperationTracker.cs
@@ -20,6 +20,20 @@ internal sealed class PaginatorDiscordOperationTracker
     public PaginatorDiscordOperationTracker(
         int maximumOperations,
         TimeSpan operationTimeout,
+        CancellationToken shutdownCancellation,
+        ILogger<DiscordPaginatorService> logger)
+        : this(
+            maximumOperations,
+            operationTimeout,
+            logger,
+            lateFailureObserver: null,
+            shutdownCancellation)
+    {
+    }
+
+    public PaginatorDiscordOperationTracker(
+        int maximumOperations,
+        TimeSpan operationTimeout,
         ILogger<DiscordPaginatorService> logger,
         Action<Exception, string>? lateFailureObserver,
         CancellationToken shutdownCancellation)

--- a/BeanBot/Hosting/BeanBotRuntime.cs
+++ b/BeanBot/Hosting/BeanBotRuntime.cs
@@ -72,7 +72,9 @@ internal sealed class BeanBotRuntime : IBeanBotRuntime
     }
 
     public bool HasActiveDiscordLifecycleOperation
-        => _discordLifecycleCoordinator.HasActiveSequence || _commandReplySender.HasPendingOperations;
+        => _discordLifecycleCoordinator.HasActiveSequence
+            || _commandReplySender.HasPendingOperations
+            || _paginatorService.HasPendingOperations;
 
     public bool CanDisposeDiscordClient => _canDisposeDiscordClient;
 

--- a/BeanBot/Logging/BeanBotLog.PaginatorOperations.cs
+++ b/BeanBot/Logging/BeanBotLog.PaginatorOperations.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Logging;
+
+namespace BeanBot.Logging;
+
+internal static partial class BeanBotLog
+{
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Discord paginator {Operation} could not start because all {MaximumOperations} tracked Discord operation slots are occupied")]
+    internal static partial void PaginatorDiscordOperationCapacityExhausted(
+        ILogger logger,
+        string operation,
+        int maximumOperations);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Discord paginator {Operation} exceeded its {Timeout} operation timeout; underlying Discord work remains owned until it settles")]
+    internal static partial void PaginatorDiscordOperationTimedOut(
+        ILogger logger,
+        string operation,
+        TimeSpan timeout);
+
+    [LoggerMessage(
+        Level = LogLevel.Error,
+        Message = "Discord paginator {Operation} failed after its bounded wait ended")]
+    internal static partial void PaginatorDiscordOperationLateFailure(
+        ILogger logger,
+        string operation,
+        Exception exception);
+}


### PR DESCRIPTION
Closes #168

## Summary
- Bound every Discord REST operation owned by `DiscordPaginatorService` with a 10-second application-owned deadline.
- Keep active and timed-out late Discord tasks inside a hard 64-operation ownership budget until the underlying task actually settles.
- Share one linked cancellation owner between BeanBot's bounded wait and Discord.Net `RequestOptions.CancelToken`.
- Do not retry ambiguously timed-out sends, edits, reaction mutations, or deletes.
- Terminate a paginator session after an ambiguous page-edit timeout so a late edit cannot race later navigation.
- Include outstanding paginator Discord operations in the existing bounded paginator shutdown/deferred-cleanup ownership.

## Implementation
- Added `PaginatorDiscordOperationTracker` as the paginator-local owner for finite waits, cancellation, late-fault observation, hard capacity accounting, and shutdown drain ownership.
- Routed paginator message creation, control reaction setup, page modification, user-reaction removal, expiration cleanup, and stop/delete through that tracker.
- Preserved the existing five reaction controls, navigation semantics, five-minute default expiration, and 64 active-session limit.
- Added structured warning/error logging for operation timeout, operation-budget exhaustion, and late failures.

## Tests
- Added focused operation-tracker coverage for success, timeout, shared request cancellation, late-fault observation, no retry, hard-cap rejection/reclamation, shutdown cancellation, and idempotent stop.
- Added a stalled user-reaction-removal test proving the request token is canceled and the ambiguous operation is not retried.
- Existing cursor, session-lifetime, expiration, capacity, slot-reuse, and shutdown tests remain green.

## Verification
Final exact PR head: `a88c95d74944f6f0f6eea53d80ffc1f2209f3890`.
Current `develop`: `f896856f80a6269d5b3aebcae18fae78ba87c87a`.

The review environment still cannot resolve `github.com` for a local checkout, so no local PASS is claimed. The repository-owned exact-head GitHub Actions evidence was inspected instead.

- Repository Verification #291: **PASS** for the exact PR head / current `develop` merge result using `./scripts/verify.sh full`.
  - Release build: **0 warnings / 0 errors**
  - Tests: **448 passed / 0 failed / 0 skipped**
  - Coverage: **66.71% lines / 54.28% branches**, baseline **PASS**
  - Workflow-infrastructure tests, locked restore, formatting/analyzers, redundant-using check, branch integrity, vulnerable-package audit, Docker build/runtime smoke test, and SIGTERM shutdown smoke test: **PASS**
- CodeQL #125: **PASS** on the exact head.
- Dependency Review #102: **PASS** on the exact head.
- Fresh Verifier: **PASS** against issue #168, the accepted implementation reflected by this PR, all acceptance criteria, current `develop`, the complete five-file diff, and exact-head CI evidence.
- Fresh independent Reviewer: **CLEAN**. No consequential correctness, Discord lifecycle/race, duplicate-subscription/message, unbounded-wait/retry, cancellation, health/persistence, security, test-quality, Docker/runtime, dependency/release, or scope-creep finding remains.
- Review threads: **none open**.

### Review repair notes
- Fresh verification found that `develop` had advanced by three commits after this PR was opened because Dependabot PR #166 merged. The new base changes touched only `Directory.Packages.props` and the two package lockfiles, with no overlap with the paginator implementation.
- The existing PR branch was synchronized with current `develop` in merge commit `a88c95d74944f6f0f6eea53d80ffc1f2209f3890`; the branch is now **8 commits ahead / 0 behind** current `develop`, and the resulting PR diff remains exactly the same five paginator/test/logging files.
- Exact-head CI was then rerun and passed before the fresh Verifier PASS and Reviewer CLEAN were recorded.
- Earlier implementation CI had also caught and fixed three ordinary analyzer/construction issues: a missing tracker constructor argument, a CA1068 cancellation-token ordering violation in production code, and the same CA1068 rule in the test helper. No validation was weakened or suppressed.

## Publication status
All implementation and exact-head verification/review gates are green. The PR remains **draft only because the connected GitHub ready-for-review mutation is broken**. Two fresh transition attempts failed with the same connector GraphQL error: it queries the unsupported field `Repository.fullDatabaseId`.

Per the review workflow, the final automation TL;DR comment was not posted while that external publication blocker remains. No merge or auto-merge was attempted.

## Remaining manual validation
A live Discord smoke check should exercise paginator creation, navigation, expiration, and explicit stop. If practical, also exercise a deliberately degraded/stalled REST path to confirm the user-visible session fails/terminates without duplicate operations. No release or deployment behavior is changed.