### PR TITLE
Bound legacy reaction-role settings cache

### DIFF
--- a/BeanBot.Tests/Discord/ReactionRoles/BoundedRoleSettingsCacheTests.cs
+++ b/BeanBot.Tests/Discord/ReactionRoles/BoundedRoleSettingsCacheTests.cs
@@ -1,0 +1,64 @@
+using BeanBot.Discord.ReactionRoles;
+using BeanBot.Persistence.Models;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.ReactionRoles;
+
+public class BoundedRoleSettingsCacheTests
+{
+    [Fact]
+    public void Set_EvictsLeastRecentlyUsedEntryAtCapacity()
+    {
+        var cache = new BoundedRoleSettingsCache(2);
+        var first = CreateRoleSettings("1");
+        var second = CreateRoleSettings("2");
+        var third = CreateRoleSettings("3");
+
+        cache.Set(first);
+        cache.Set(second);
+        Assert.True(cache.TryGet("1", out _));
+        cache.Set(third);
+
+        Assert.Equal(2, cache.Count);
+        Assert.True(cache.TryGet("1", out var cachedFirst));
+        Assert.False(cache.TryGet("2", out _));
+        Assert.True(cache.TryGet("3", out var cachedThird));
+        Assert.Same(first, cachedFirst);
+        Assert.Same(third, cachedThird);
+    }
+
+    [Fact]
+    public void Set_UpdatingExistingEntryRefreshesRecencyWithoutGrowingBookkeeping()
+    {
+        var cache = new BoundedRoleSettingsCache(2);
+        cache.Set(CreateRoleSettings("1"));
+        cache.Set(CreateRoleSettings("2"));
+        var replacement = CreateRoleSettings("1");
+
+        cache.Set(replacement);
+        cache.Set(CreateRoleSettings("3"));
+
+        Assert.Equal(2, cache.Count);
+        Assert.True(cache.TryGet("1", out var cached));
+        Assert.Same(replacement, cached);
+        Assert.False(cache.TryGet("2", out _));
+    }
+
+    [Fact]
+    public async Task ConcurrentSets_NeverExceedCapacityOrCorruptCache()
+    {
+        const int capacity = 8;
+        var cache = new BoundedRoleSettingsCache(capacity);
+
+        await Task.WhenAll(Enumerable.Range(1, 200).Select(index => Task.Run(() =>
+        {
+            cache.Set(CreateRoleSettings(index.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+            Assert.InRange(cache.Count, 0, capacity);
+        })));
+
+        Assert.Equal(capacity, cache.Count);
+    }
+
+    private static RoleSettings CreateRoleSettings(string messageId)
+        => new([], "1", "2", messageId);
+}

--- a/BeanBot.Tests/Discord/ReactionRoles/RoleReactServiceCacheConcurrencyTests.cs
+++ b/BeanBot.Tests/Discord/ReactionRoles/RoleReactServiceCacheConcurrencyTests.cs
@@ -1,0 +1,80 @@
+using BeanBot.Discord.ReactionRoles;
+using BeanBot.Persistence.Models;
+using BeanBot.Persistence.Repositories;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.ReactionRoles;
+
+public class RoleReactServiceCacheConcurrencyTests
+{
+    [Fact]
+    public async Task InitialPreload_DoesNotEvictSettingPersistedWhileQueryIsInFlight()
+    {
+        var preloadStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releasePreload = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var store = new CoordinatedRoleSettingsStore
+        {
+            GetRecent = async (_, _, cancellationToken) =>
+            {
+                preloadStarted.TrySetResult();
+                await releasePreload.Task.WaitAsync(cancellationToken);
+                return [CreateRoleSettings("1"), CreateRoleSettings("2")];
+            }
+        };
+        await using var service = CreateService(store, cacheCapacity: 2);
+        var initialLookup = service.GetCachedRoleSettingAsync(1UL, CancellationToken.None);
+        await preloadStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        var persisted = CreateRoleSettings("99");
+
+        await service.PersistRoleSettingsAsync(persisted, CancellationToken.None);
+        releasePreload.TrySetResult();
+        await initialLookup;
+        var cached = await service.GetCachedRoleSettingAsync(99UL, CancellationToken.None);
+
+        Assert.Same(persisted, cached);
+        Assert.Equal(2, service.CachedRoleSettingsCount);
+        Assert.Equal(0, store.GetByMessageIdCallCount);
+    }
+
+    private static RoleReactService CreateService(
+        IRoleSettingsStore store,
+        int cacheCapacity)
+        => new(
+            new RoleReactRepository(store, NullLogger<RoleReactRepository>.Instance),
+            client: null,
+            TimeSpan.FromSeconds(1),
+            NullLogger<RoleReactService>.Instance,
+            cacheCapacity,
+            CancellationToken.None);
+
+    private static RoleSettings CreateRoleSettings(string messageId)
+        => new([], "1", "2", messageId);
+
+    private sealed class CoordinatedRoleSettingsStore : IRoleSettingsStore
+    {
+        public Func<DateTime, int, CancellationToken, Task<List<RoleSettings>>> GetRecent { get; set; }
+            = (_, _, _) => Task.FromResult(new List<RoleSettings>());
+
+        public int GetByMessageIdCallCount { get; private set; }
+
+        public Task InsertAsync(RoleSettings roleSettings, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+
+        public Task<List<RoleSettings>> GetRecentAsync(
+            DateTime oldestLastAccessedUtc,
+            int limit,
+            CancellationToken cancellationToken)
+            => GetRecent(oldestLastAccessedUtc, limit, cancellationToken);
+
+        public Task<RoleSettings?> GetByMessageIdAsync(
+            string messageId,
+            CancellationToken cancellationToken)
+        {
+            GetByMessageIdCallCount++;
+            return Task.FromResult<RoleSettings?>(null);
+        }
+    }
+}

--- a/BeanBot.Tests/Discord/ReactionRoles/RoleReactServiceTests.cs
+++ b/BeanBot.Tests/Discord/ReactionRoles/RoleReactServiceTests.cs
@@ -73,6 +73,71 @@ public class RoleReactServiceTests
     }
 
     [Fact]
+    public async Task GetCachedRoleSettingAsync_PreloadUsesCacheCapacity()
+    {
+        var newest = CreateRoleSettings("42");
+        var older = CreateRoleSettings("41");
+        var store = new FakeRoleSettingsStore
+        {
+            GetRecent = (_, limit, _) =>
+            {
+                Assert.Equal(2, limit);
+                return Task.FromResult(new List<RoleSettings> { newest, older });
+            }
+        };
+        await using var service = CreateService(
+            TimeSpan.FromSeconds(1),
+            store,
+            cacheCapacity: 2);
+
+        var actual = await service.GetCachedRoleSettingAsync(42UL, CancellationToken.None);
+
+        Assert.Same(newest, actual);
+        Assert.Equal(2, service.CachedRoleSettingsCount);
+        Assert.Equal(1, store.GetRecentCallCount);
+        Assert.Equal(0, store.GetByMessageIdCallCount);
+    }
+
+    [Fact]
+    public async Task GetCachedRoleSettingAsync_EvictedSettingReloadsFromStore()
+    {
+        var store = new FakeRoleSettingsStore
+        {
+            GetByMessageId = (messageId, _) =>
+                Task.FromResult<RoleSettings?>(CreateRoleSettings(messageId))
+        };
+        await using var service = CreateService(
+            TimeSpan.FromSeconds(1),
+            store,
+            cacheCapacity: 2);
+
+        await service.GetCachedRoleSettingAsync(1UL, CancellationToken.None);
+        await service.GetCachedRoleSettingAsync(2UL, CancellationToken.None);
+        await service.GetCachedRoleSettingAsync(1UL, CancellationToken.None);
+        await service.GetCachedRoleSettingAsync(3UL, CancellationToken.None);
+        var reloaded = await service.GetCachedRoleSettingAsync(2UL, CancellationToken.None);
+
+        Assert.NotNull(reloaded);
+        Assert.Equal("2", reloaded.MessageId);
+        Assert.Equal(2, service.CachedRoleSettingsCount);
+        Assert.Equal(4, store.GetByMessageIdCallCount);
+    }
+
+    [Fact]
+    public async Task GetCachedRoleSettingAsync_DoesNotNegativeCacheMissingSetting()
+    {
+        var store = new FakeRoleSettingsStore();
+        await using var service = CreateService(TimeSpan.FromSeconds(1), store);
+
+        var first = await service.GetCachedRoleSettingAsync(42UL, CancellationToken.None);
+        var second = await service.GetCachedRoleSettingAsync(42UL, CancellationToken.None);
+
+        Assert.Null(first);
+        Assert.Null(second);
+        Assert.Equal(2, store.GetByMessageIdCallCount);
+    }
+
+    [Fact]
     public async Task GetCachedRoleSettingAsync_DoesNotCacheInfrastructureFailure()
     {
         var expected = CreateRoleSettings("42");
@@ -98,7 +163,7 @@ public class RoleReactServiceTests
         var expected = CreateRoleSettings("42");
         var failure = new InvalidOperationException("database unavailable");
         var store = new FakeRoleSettingsStore();
-        store.GetRecent = (_, _) => store.GetRecentCallCount == 1
+        store.GetRecent = (_, _, _) => store.GetRecentCallCount == 1
             ? Task.FromException<List<RoleSettings>>(failure)
             : Task.FromResult(new List<RoleSettings> { expected });
         await using var service = CreateService(TimeSpan.FromSeconds(1), store);
@@ -110,6 +175,21 @@ public class RoleReactServiceTests
         Assert.Same(failure, actualFailure);
         Assert.Same(expected, recovered);
         Assert.Equal(2, store.GetRecentCallCount);
+        Assert.Equal(0, store.GetByMessageIdCallCount);
+    }
+
+    [Fact]
+    public async Task PersistRoleSettingsAsync_CachesSuccessfulInsert()
+    {
+        var settings = CreateRoleSettings("42");
+        var store = new FakeRoleSettingsStore();
+        await using var service = CreateService(TimeSpan.FromSeconds(1), store);
+
+        await service.PersistRoleSettingsAsync(settings, CancellationToken.None);
+        var cached = await service.GetCachedRoleSettingAsync(42UL, CancellationToken.None);
+
+        Assert.Same(settings, cached);
+        Assert.Equal(1, service.CachedRoleSettingsCount);
         Assert.Equal(0, store.GetByMessageIdCallCount);
     }
 
@@ -140,7 +220,7 @@ public class RoleReactServiceTests
             TaskCreationOptions.RunContinuationsAsynchronously);
         var store = new FakeRoleSettingsStore
         {
-            GetRecent = async (_, cancellationToken) =>
+            GetRecent = async (_, _, cancellationToken) =>
             {
                 operationStarted.SetResult();
                 await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
@@ -197,6 +277,7 @@ public class RoleReactServiceTests
     private static RoleReactService CreateService(
         TimeSpan shutdownDrainTimeout,
         FakeRoleSettingsStore? store = null,
+        int cacheCapacity = 256,
         CancellationToken applicationStopping = default)
     {
         return new RoleReactService(
@@ -206,6 +287,7 @@ public class RoleReactServiceTests
             client: null,
             shutdownDrainTimeout,
             NullLogger<RoleReactService>.Instance,
+            cacheCapacity,
             applicationStopping);
     }
 
@@ -224,8 +306,8 @@ public class RoleReactServiceTests
     {
         public Func<RoleSettings, CancellationToken, Task> Insert { get; set; }
             = (_, _) => Task.CompletedTask;
-        public Func<DateTime, CancellationToken, Task<List<RoleSettings>>> GetRecent { get; set; }
-            = (_, _) => Task.FromResult(new List<RoleSettings>());
+        public Func<DateTime, int, CancellationToken, Task<List<RoleSettings>>> GetRecent { get; set; }
+            = (_, _, _) => Task.FromResult(new List<RoleSettings>());
         public Func<string, CancellationToken, Task<RoleSettings?>> GetByMessageId { get; set; }
             = (_, _) => Task.FromResult<RoleSettings?>(null);
 
@@ -237,10 +319,11 @@ public class RoleReactServiceTests
 
         public Task<List<RoleSettings>> GetRecentAsync(
             DateTime oldestLastAccessedUtc,
+            int limit,
             CancellationToken cancellationToken)
         {
             GetRecentCallCount++;
-            return GetRecent(oldestLastAccessedUtc, cancellationToken);
+            return GetRecent(oldestLastAccessedUtc, limit, cancellationToken);
         }
 
         public Task<RoleSettings?> GetByMessageIdAsync(

--- a/BeanBot.Tests/Integration/MongoRoleReactRepositoryIntegrationTests.cs
+++ b/BeanBot.Tests/Integration/MongoRoleReactRepositoryIntegrationTests.cs
@@ -58,6 +58,39 @@ public sealed class MongoRoleReactRepositoryIntegrationTests
     }
 
     [Fact]
+    public async Task GetRecentRoleSettings_ReturnsNewestEntriesWithinLimit()
+    {
+        var databaseName = CreateDatabaseName();
+        var client = new MongoClient(_fixture.ConnectionString);
+        var database = client.GetDatabase(databaseName);
+        var repository = CreateRepository(database);
+        var now = DateTime.UtcNow;
+        var oldest = CreateRoleSettings("1", now.AddDays(-31));
+        var older = CreateRoleSettings("2", now.AddMinutes(-2));
+        var newer = CreateRoleSettings("3", now.AddMinutes(-1));
+        var newest = CreateRoleSettings("4", now);
+
+        try
+        {
+            using var cancellation = new CancellationTokenSource(OperationTimeout);
+            await database.GetCollection<RoleSettings>("roleSettings").InsertManyAsync(
+                [oldest, older, newer, newest],
+                cancellationToken: cancellation.Token);
+
+            var recent = await repository.GetRecentRoleSettings(2, cancellation.Token);
+
+            Assert.Collection(
+                recent,
+                setting => Assert.Equal("4", setting.MessageId),
+                setting => Assert.Equal("3", setting.MessageId));
+        }
+        finally
+        {
+            await DropDatabaseAsync(client, databaseName);
+        }
+    }
+
+    [Fact]
     public async Task GetRoleSetting_ReturnsNullWhenMongoCollectionHasNoMatch()
     {
         var databaseName = CreateDatabaseName();
@@ -100,6 +133,15 @@ public sealed class MongoRoleReactRepositoryIntegrationTests
 
     private static RoleReactRepository CreateRepository(IMongoDatabase database)
         => new(database, NullLogger<RoleReactRepository>.Instance);
+
+    private static RoleSettings CreateRoleSettings(string messageId, DateTime lastAccessedUtc)
+    {
+        var settings = new RoleSettings([], "1", "2", messageId)
+        {
+            LastAccessedUtc = lastAccessedUtc
+        };
+        return settings;
+    }
 
     private static string CreateDatabaseName()
         => $"BeanBotIntegration_{Guid.NewGuid():N}";

--- a/BeanBot.Tests/Persistence/Repositories/RoleReactRepositoryTests.cs
+++ b/BeanBot.Tests/Persistence/Repositories/RoleReactRepositoryTests.cs
@@ -60,7 +60,7 @@ public class RoleReactRepositoryTests
         using var cancellation = new CancellationTokenSource();
         var store = new FakeRoleSettingsStore
         {
-            GetRecent = async (_, cancellationToken) =>
+            GetRecent = async (_, _, cancellationToken) =>
             {
                 Assert.Equal(cancellation.Token, cancellationToken);
                 await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
@@ -68,7 +68,7 @@ public class RoleReactRepositoryTests
             }
         };
         var repository = CreateRepository(store);
-        var read = repository.GetRecentRoleSettings(cancellation.Token);
+        var read = repository.GetRecentRoleSettings(10, cancellation.Token);
         cancellation.Cancel();
 
         var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(
@@ -78,26 +78,38 @@ public class RoleReactRepositoryTests
     }
 
     [Fact]
-    public async Task GetRecentRoleSettings_UsesThirtyDayUtcCutoff()
+    public async Task GetRecentRoleSettings_UsesThirtyDayUtcCutoffAndRequestedLimit()
     {
         DateTime? observedCutoff = null;
+        int? observedLimit = null;
         var beforeRead = DateTime.UtcNow.AddDays(-30);
         var store = new FakeRoleSettingsStore
         {
-            GetRecent = (oldestLastAccessedUtc, _) =>
+            GetRecent = (oldestLastAccessedUtc, limit, _) =>
             {
                 observedCutoff = oldestLastAccessedUtc;
+                observedLimit = limit;
                 return Task.FromResult(new List<RoleSettings>());
             }
         };
         var repository = CreateRepository(store);
 
-        await repository.GetRecentRoleSettings();
+        await repository.GetRecentRoleSettings(17);
         var afterRead = DateTime.UtcNow.AddDays(-30);
 
         var cutoff = Assert.IsType<DateTime>(observedCutoff);
         Assert.Equal(DateTimeKind.Utc, cutoff.Kind);
         Assert.InRange(cutoff, beforeRead, afterRead);
+        Assert.Equal(17, observedLimit);
+    }
+
+    [Fact]
+    public async Task GetRecentRoleSettings_RejectsNonPositiveLimit()
+    {
+        var repository = CreateRepository(new FakeRoleSettingsStore());
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            () => repository.GetRecentRoleSettings(0));
     }
 
     [Fact]
@@ -149,8 +161,8 @@ public class RoleReactRepositoryTests
     {
         public Func<RoleSettings, CancellationToken, Task> Insert { get; set; }
             = (_, _) => Task.CompletedTask;
-        public Func<DateTime, CancellationToken, Task<List<RoleSettings>>> GetRecent { get; set; }
-            = (_, _) => Task.FromResult(new List<RoleSettings>());
+        public Func<DateTime, int, CancellationToken, Task<List<RoleSettings>>> GetRecent { get; set; }
+            = (_, _, _) => Task.FromResult(new List<RoleSettings>());
         public Func<string, CancellationToken, Task<RoleSettings?>> GetByMessageId { get; set; }
             = (_, _) => Task.FromResult<RoleSettings?>(null);
 
@@ -159,8 +171,9 @@ public class RoleReactRepositoryTests
 
         public Task<List<RoleSettings>> GetRecentAsync(
             DateTime oldestLastAccessedUtc,
+            int limit,
             CancellationToken cancellationToken)
-            => GetRecent(oldestLastAccessedUtc, cancellationToken);
+            => GetRecent(oldestLastAccessedUtc, limit, cancellationToken);
 
         public Task<RoleSettings?> GetByMessageIdAsync(
             string messageId,

--- a/BeanBot/Discord/ReactionRoles/BoundedRoleSettingsCache.cs
+++ b/BeanBot/Discord/ReactionRoles/BoundedRoleSettingsCache.cs
@@ -1,0 +1,90 @@
+using BeanBot.Persistence.Models;
+
+namespace BeanBot.Discord.ReactionRoles;
+
+internal sealed class BoundedRoleSettingsCache
+{
+    private readonly int _capacity;
+    private readonly object _sync = new();
+    private readonly Dictionary<string, CacheEntry> _entries = [];
+    private readonly LinkedList<string> _recency = [];
+
+    public BoundedRoleSettingsCache(int capacity)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(capacity, 0);
+        _capacity = capacity;
+    }
+
+    public int Capacity => _capacity;
+
+    internal int Count
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return _entries.Count;
+            }
+        }
+    }
+
+    public bool TryGet(string messageId, out RoleSettings? settings)
+    {
+        lock (_sync)
+        {
+            if (!_entries.TryGetValue(messageId, out var entry))
+            {
+                settings = null;
+                return false;
+            }
+
+            Touch(entry);
+            settings = entry.Settings;
+            return true;
+        }
+    }
+
+    public void Set(RoleSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        if (string.IsNullOrWhiteSpace(settings.MessageId))
+        {
+            return;
+        }
+
+        lock (_sync)
+        {
+            if (_entries.TryGetValue(settings.MessageId, out var existing))
+            {
+                existing.Settings = settings;
+                Touch(existing);
+                return;
+            }
+
+            if (_entries.Count == _capacity)
+            {
+                var leastRecent = _recency.Last;
+                if (leastRecent != null)
+                {
+                    _entries.Remove(leastRecent.Value);
+                    _recency.RemoveLast();
+                }
+            }
+
+            var node = _recency.AddFirst(settings.MessageId);
+            _entries.Add(settings.MessageId, new CacheEntry(settings, node));
+        }
+    }
+
+    private void Touch(CacheEntry entry)
+    {
+        _recency.Remove(entry.Node);
+        _recency.AddFirst(entry.Node);
+    }
+
+    private sealed class CacheEntry(RoleSettings settings, LinkedListNode<string> node)
+    {
+        public RoleSettings Settings { get; set; } = settings;
+        public LinkedListNode<string> Node { get; } = node;
+    }
+}

--- a/BeanBot/Discord/ReactionRoles/BoundedRoleSettingsCache.cs
+++ b/BeanBot/Discord/ReactionRoles/BoundedRoleSettingsCache.cs
@@ -76,6 +76,26 @@ internal sealed class BoundedRoleSettingsCache
         }
     }
 
+    public void Seed(RoleSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        if (string.IsNullOrWhiteSpace(settings.MessageId))
+        {
+            return;
+        }
+
+        lock (_sync)
+        {
+            if (_entries.ContainsKey(settings.MessageId) || _entries.Count == _capacity)
+            {
+                return;
+            }
+
+            var node = _recency.AddLast(settings.MessageId);
+            _entries.Add(settings.MessageId, new CacheEntry(settings, node));
+        }
+    }
+
     private void Touch(CacheEntry entry)
     {
         _recency.Remove(entry.Node);

--- a/BeanBot/Discord/ReactionRoles/RoleReactService.cs
+++ b/BeanBot/Discord/ReactionRoles/RoleReactService.cs
@@ -227,9 +227,9 @@ public class RoleReactService : IDisposable, IAsyncDisposable
             var recentSettings = await _roleReactRepository.GetRecentRoleSettings(
                 _roleSettings.Capacity,
                 cancellationToken);
-            for (var index = recentSettings.Count - 1; index >= 0; index--)
+            foreach (var setting in recentSettings)
             {
-                _roleSettings.Set(recentSettings[index]);
+                _roleSettings.Seed(setting);
             }
 
             _cacheLoaded = true;

--- a/BeanBot/Discord/ReactionRoles/RoleReactService.cs
+++ b/BeanBot/Discord/ReactionRoles/RoleReactService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.Globalization;
 using BeanBot.Logging;
 using BeanBot.Persistence.Models;
@@ -12,11 +11,12 @@ namespace BeanBot.Discord.ReactionRoles;
 
 public class RoleReactService : IDisposable, IAsyncDisposable
 {
+    private const int DefaultRoleSettingsCacheCapacity = 256;
     private static readonly TimeSpan DefaultShutdownDrainTimeout = TimeSpan.FromSeconds(5);
     private readonly RoleReactRepository _roleReactRepository;
     private readonly DiscordSocketClient? _client;
     private readonly SemaphoreSlim _cacheLock = new(1, 1);
-    private readonly ConcurrentDictionary<string, RoleSettings> _roleSettings = [];
+    private readonly BoundedRoleSettingsCache _roleSettings;
     private readonly object _operationSync = new();
     private readonly HashSet<Task> _inFlightOperations = [];
     private readonly TimeSpan _shutdownDrainTimeout;
@@ -39,6 +39,7 @@ public class RoleReactService : IDisposable, IAsyncDisposable
             client,
             DefaultShutdownDrainTimeout,
             logger,
+            DefaultRoleSettingsCacheCapacity,
             (applicationLifetime ?? throw new ArgumentNullException(nameof(applicationLifetime)))
                 .ApplicationStopping)
     {
@@ -49,6 +50,7 @@ public class RoleReactService : IDisposable, IAsyncDisposable
         DiscordSocketClient? client,
         TimeSpan shutdownDrainTimeout,
         ILogger<RoleReactService> logger,
+        int cacheCapacity,
         CancellationToken applicationStopping)
     {
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(shutdownDrainTimeout, TimeSpan.Zero);
@@ -56,9 +58,12 @@ public class RoleReactService : IDisposable, IAsyncDisposable
         _client = client;
         _shutdownDrainTimeout = shutdownDrainTimeout;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _roleSettings = new BoundedRoleSettingsCache(cacheCapacity);
         _shutdownCancellation = CancellationTokenSource.CreateLinkedTokenSource(applicationStopping);
         _shutdownToken = _shutdownCancellation.Token;
     }
+
+    internal int CachedRoleSettingsCount => _roleSettings.Count;
 
     public Task HandleReact(Cacheable<IUserMessage, ulong> message, Cacheable<IMessageChannel, ulong> channel, SocketReaction reaction)
         => TrackHandlerAsync(cancellationToken =>
@@ -190,7 +195,7 @@ public class RoleReactService : IDisposable, IAsyncDisposable
     {
         await EnsureCacheLoadedAsync(cancellationToken);
         var messageIdText = messageId.ToString(CultureInfo.InvariantCulture);
-        if (_roleSettings.TryGetValue(messageIdText, out var cached))
+        if (_roleSettings.TryGet(messageIdText, out var cached))
         {
             return cached;
         }
@@ -198,7 +203,7 @@ public class RoleReactService : IDisposable, IAsyncDisposable
         var roleSetting = await _roleReactRepository.GetRoleSetting(messageId, cancellationToken);
         if (roleSetting != null && !string.IsNullOrWhiteSpace(roleSetting.MessageId))
         {
-            _roleSettings[roleSetting.MessageId] = roleSetting;
+            _roleSettings.Set(roleSetting);
         }
 
         return roleSetting;
@@ -219,13 +224,14 @@ public class RoleReactService : IDisposable, IAsyncDisposable
                 return;
             }
 
-            foreach (var setting in await _roleReactRepository.GetRecentRoleSettings(cancellationToken))
+            var recentSettings = await _roleReactRepository.GetRecentRoleSettings(
+                _roleSettings.Capacity,
+                cancellationToken);
+            for (var index = recentSettings.Count - 1; index >= 0; index--)
             {
-                if (!string.IsNullOrWhiteSpace(setting.MessageId))
-                {
-                    _roleSettings[setting.MessageId] = setting;
-                }
+                _roleSettings.Set(recentSettings[index]);
             }
+
             _cacheLoaded = true;
         }
         finally
@@ -273,7 +279,7 @@ public class RoleReactService : IDisposable, IAsyncDisposable
         CancellationToken cancellationToken)
     {
         await _roleReactRepository.InsertNewRoleSettings(settings, cancellationToken);
-        _roleSettings[settings.MessageId] = settings;
+        _roleSettings.Set(settings);
     }
 
     public void Dispose()

--- a/BeanBot/Persistence/Repositories/RoleReactRepository.cs
+++ b/BeanBot/Persistence/Repositories/RoleReactRepository.cs
@@ -9,7 +9,10 @@ namespace BeanBot.Persistence.Repositories;
 internal interface IRoleSettingsStore
 {
     Task InsertAsync(RoleSettings roleSettings, CancellationToken cancellationToken);
-    Task<List<RoleSettings>> GetRecentAsync(DateTime oldestLastAccessedUtc, CancellationToken cancellationToken);
+    Task<List<RoleSettings>> GetRecentAsync(
+        DateTime oldestLastAccessedUtc,
+        int limit,
+        CancellationToken cancellationToken);
     Task<RoleSettings?> GetByMessageIdAsync(string messageId, CancellationToken cancellationToken);
 }
 
@@ -26,16 +29,18 @@ internal sealed class MongoRoleSettingsStore : IRoleSettingsStore
     public Task InsertAsync(RoleSettings roleSettings, CancellationToken cancellationToken)
         => _roleSettings.InsertOneAsync(roleSettings, cancellationToken: cancellationToken);
 
-    public async Task<List<RoleSettings>> GetRecentAsync(
+    public Task<List<RoleSettings>> GetRecentAsync(
         DateTime oldestLastAccessedUtc,
+        int limit,
         CancellationToken cancellationToken)
     {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(limit, 0);
         var filter = Builders<RoleSettings>.Filter.Where(
             result => result.LastAccessedUtc >= oldestLastAccessedUtc);
-        using var results = await _roleSettings.FindAsync(
-            filter,
-            cancellationToken: cancellationToken);
-        return await results.ToListAsync(cancellationToken);
+        return _roleSettings.Find(filter)
+            .SortByDescending(result => result.LastAccessedUtc)
+            .Limit(limit)
+            .ToListAsync(cancellationToken);
     }
 
     public async Task<RoleSettings?> GetByMessageIdAsync(
@@ -79,11 +84,14 @@ public sealed class RoleReactRepository
     }
 
     public Task<List<RoleSettings>> GetRecentRoleSettings(
+        int limit,
         CancellationToken cancellationToken = default)
     {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(limit, 0);
         cancellationToken.ThrowIfCancellationRequested();
         return _roleSettingsStore.GetRecentAsync(
             DateTime.UtcNow.AddDays(-30),
+            limit,
             cancellationToken);
     }
 


### PR DESCRIPTION
Closes #170

## Summary
- replace the unbounded legacy reaction-role settings dictionary with a thread-safe 256-entry LRU cache
- refresh in-memory recency on cache hits and deterministically evict the coldest resident entry at capacity
- keep fallback Mongo lookups functional after eviction without negative-caching misses or infrastructure failures
- bound the initial Mongo preload at the query level by sorting `LastAccessedUtc` descending and applying the cache capacity as the limit
- seed preload results behind live cache activity so startup warming cannot evict a setting persisted while the Mongo query is in flight
- preserve persistence-first cache visibility, cancellation, shutdown-drain behavior, Mongo document shape, and Discord behavior

## Tests
- focused LRU capacity, recency, update, and concurrent-write coverage
- service coverage for bounded preload, fallback reload after eviction, no negative caching, persistence success/failure, and the preload-vs-persist race
- repository coverage for limit, cancellation, cutoff, and invalid-limit behavior
- Mongo integration coverage proving newest-first ordering and query-level limiting

## Verification
Final PR head: `f2854f0092c6c7cd8ba402235f86fcf2656288d4`.
Current `develop`: `f896856f80a6269d5b3aebcae18fae78ba87c87a`; PR base/target is `develop` and the PR remains mergeable.

The review automation re-read `AGENTS.md`, `.agents/skills/beanbot-verify/SKILL.md`, and `.agents/skills/beanbot-review/SKILL.md`; inspected issue #170, the complete eight-file diff, current surrounding reaction-role/persistence code, current `develop`, and exact-head GitHub Actions evidence.

Local repository execution is unavailable in this automation runtime, so no local `./scripts/verify.sh` PASS is claimed. Repository policy's exact-head GitHub CI path supplies the deterministic evidence:

- Repository Verification #295: **PASS** on exact head `f2854f0092c6c7cd8ba402235f86fcf2656288d4`. The job explicitly checked out the exact commit and completed the repository-owned `./scripts/verify.sh full` step successfully.
- The full gate includes locked restore, formatting/analyzers, Release build/tests with coverage baseline, diff checks, branch integrity, vulnerable-package audit, hardened Docker build/runtime smoke checks, and shutdown smoke checks.
- CodeQL #129: **PASS** on the same exact head.
- Dependency Review #106: **PASS** on the same exact head.
- Fresh Verifier: **PASS**. Every issue #170 acceptance criterion maps to concrete implementation/test evidence; branch/PR policy is correct; no required deterministic gate is missing from the exact-head CI evidence.
- Fresh independent Reviewer: **CLEAN**. No consequential correctness, reaction-role cache/persistence consistency, concurrent preload/save race, cancellation/shutdown, Discord lifecycle, security, test-quality, Docker/runtime, dependency/release, or unrelated-scope finding remains.
- Review threads: **none open**.
- Top-level PR comments: **none**, so there is no existing automation-authored final TL;DR comment to update.

### Review notes
The review specifically rechecked the LRU bookkeeping bound, deterministic recency refresh/eviction, fallback reload after eviction, no negative caching, persistence-before-cache semantics, query-level Mongo sort/limit/cancellation, and the startup preload-vs-live-persist race. The existing repair that separates live `Set` from preload `Seed` correctly prevents an in-flight preload from evicting a newly persisted live entry.

No source repair was required by this review pass, so the verified head did not change.

## Publication status
All code, exact-head CI, fresh Verifier, and fresh Reviewer gates are green. The PR remains **draft only because the connected GitHub ready-for-review mutation is externally broken**. A fresh transition attempt after this review again failed because the connector queries the unsupported GraphQL field `Repository.fullDatabaseId` under `markPullRequestReadyForReview -> pullRequest -> headRepository`.

Per repository policy and the review automation instructions, the final human-review TL;DR comment is intentionally **not posted** while that publication blocker remains. No merge, auto-merge, release, or additional PR was attempted.

## Manual validation
After deployment, exercise an older reaction-role panel that is unlikely to be resident after a busy process lifetime and confirm its first reaction reloads from Mongo and subsequent reactions behave normally. Also create/update a reaction-role panel near startup and confirm it remains immediately usable. No configuration, Mongo document schema, Discord UX, dependency, Docker, or release behavior is changed.