### PR TITLE
Make health readiness include MongoDB

### DIFF
--- a/BeanBot.Tests/Health/HealthCheckMongoReadinessTests.cs
+++ b/BeanBot.Tests/Health/HealthCheckMongoReadinessTests.cs
@@ -1,0 +1,111 @@
+using System.Net;
+using System.Text.Json;
+using BeanBot.Configuration;
+using BeanBot.Health;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BeanBot.Tests.Health;
+
+public class HealthCheckMongoReadinessTests
+{
+    private static readonly DiscordHealthSnapshot HealthyDiscordSnapshot = new(
+        true,
+        "BeanBot is connected to Discord.",
+        "LoggedIn",
+        "Connected",
+        new DateTimeOffset(2026, 9, 3, 13, 0, 0, TimeSpan.Zero),
+        null,
+        null,
+        null);
+
+    [Fact]
+    public async Task DiscordAndMongoReady_ReturnsOkWithSanitizedMongoMetadata()
+    {
+        var checkedAt = new DateTimeOffset(2026, 9, 3, 13, 5, 0, TimeSpan.Zero);
+        await using var server = CreateServer(
+            () => HealthyDiscordSnapshot,
+            _ => Task.FromResult(new MongoReadinessSnapshot(true, checkedAt)));
+        await server.StartAsync(CancellationToken.None);
+        using var client = CreateClient(server);
+
+        using var response = await client.GetAsync("/healthz");
+        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("ok", payload.RootElement.GetProperty("status").GetString());
+        Assert.True(payload.RootElement.GetProperty("discordConnected").GetBoolean());
+        Assert.True(payload.RootElement.GetProperty("mongoReachable").GetBoolean());
+        Assert.Equal(
+            checkedAt,
+            payload.RootElement.GetProperty("mongoLastCheckedAtUtc").GetDateTimeOffset());
+    }
+
+    [Fact]
+    public async Task DiscordReadyButMongoUnavailable_Returns503WithoutFalsifyingDiscordStateOrLeakingDetails()
+    {
+        var checkedAt = new DateTimeOffset(2026, 9, 3, 13, 5, 0, TimeSpan.Zero);
+        await using var server = CreateServer(
+            () => HealthyDiscordSnapshot,
+            _ => Task.FromResult(new MongoReadinessSnapshot(false, checkedAt)));
+        await server.StartAsync(CancellationToken.None);
+        using var client = CreateClient(server);
+
+        using var response = await client.GetAsync("/healthz");
+        var body = await response.Content.ReadAsStringAsync();
+        using var payload = JsonDocument.Parse(body);
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        Assert.Equal("unhealthy", payload.RootElement.GetProperty("status").GetString());
+        Assert.True(payload.RootElement.GetProperty("discordConnected").GetBoolean());
+        Assert.False(payload.RootElement.GetProperty("mongoReachable").GetBoolean());
+        Assert.Equal(
+            checkedAt,
+            payload.RootElement.GetProperty("mongoLastCheckedAtUtc").GetDateTimeOffset());
+        Assert.Equal("MongoDB is not reachable.", payload.RootElement.GetProperty("message").GetString());
+        Assert.DoesNotContain("mongodb://", body);
+        Assert.DoesNotContain("password", body);
+        Assert.DoesNotContain("connection string", body);
+    }
+
+    [Fact]
+    public async Task Head_PreservesCombinedReadinessStatusWithoutBody()
+    {
+        await using var server = CreateServer(
+            () => HealthyDiscordSnapshot,
+            _ => Task.FromResult(new MongoReadinessSnapshot(false, DateTimeOffset.UtcNow)));
+        await server.StartAsync(CancellationToken.None);
+        using var client = CreateClient(server);
+        using var request = new HttpRequestMessage(HttpMethod.Head, "/healthz");
+
+        using var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        Assert.Empty(await response.Content.ReadAsByteArrayAsync());
+    }
+
+    private static HealthCheckServer CreateServer(
+        Func<DiscordHealthSnapshot> createDiscordSnapshot,
+        Func<CancellationToken, Task<MongoReadinessSnapshot>> getMongoSnapshot)
+    {
+        var options = new HealthCheckOptions(
+            true,
+            IPAddress.Loopback,
+            0,
+            null,
+            TimeSpan.FromMilliseconds(1));
+        return new HealthCheckServer(
+            options,
+            createDiscordSnapshot,
+            getMongoSnapshot,
+            NullLogger<HealthCheckServer>.Instance,
+            maximumConcurrentClients: 2,
+            maximumTrackedRateLimitClients: 10);
+    }
+
+    private static HttpClient CreateClient(HealthCheckServer server)
+        => new(new SocketsHttpHandler { UseProxy = false })
+        {
+            BaseAddress = new Uri($"http://127.0.0.1:{server.BoundPort}")
+        };
+}

--- a/BeanBot.Tests/Health/MongoReadinessMonitorTests.cs
+++ b/BeanBot.Tests/Health/MongoReadinessMonitorTests.cs
@@ -113,6 +113,31 @@ public class MongoReadinessMonitorTests
     }
 
     [Fact]
+    public async Task ProbeCompletionRacingDeadline_DoesNotThrowAfterTimeoutSourceIsDisposed()
+    {
+        var clock = new SequencedTimeProvider(
+            InitialTime,
+            TimeSpan.Zero,
+            TimeSpan.Zero,
+            TimeSpan.Zero,
+            TimeSpan.FromSeconds(2));
+        var probe = new ScriptedProbe(_ => Task.CompletedTask);
+        var monitor = CreateMonitor(
+            probe,
+            clock,
+            probeTimeout: TimeSpan.FromSeconds(1),
+            freshnessWindow: TimeSpan.FromSeconds(10));
+
+        var timedOutWaiter = await monitor.GetSnapshotAsync(CancellationToken.None);
+        var completedProbeSnapshot = await monitor.GetSnapshotAsync(CancellationToken.None);
+
+        Assert.False(timedOutWaiter.IsReachable);
+        Assert.True(completedProbeSnapshot.IsReachable);
+        Assert.False(monitor.HasInFlightProbe);
+        Assert.Equal(1, probe.CallCount);
+    }
+
+    [Fact]
     public async Task StaleSuccess_IsNotTrustedWhenRefreshCannotComplete()
     {
         var clock = new ManualTimeProvider(InitialTime);
@@ -242,6 +267,33 @@ public class MongoReadinessMonitorTests
             }
 
             return step(cancellationToken);
+        }
+    }
+
+    private sealed class SequencedTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _utcNow;
+        private readonly Queue<long> _timestamps;
+        private long _lastTimestamp;
+
+        public SequencedTimeProvider(DateTimeOffset utcNow, params TimeSpan[] timestamps)
+        {
+            _utcNow = utcNow;
+            _timestamps = new Queue<long>(timestamps.Select(timestamp => timestamp.Ticks));
+        }
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public override long GetTimestamp()
+        {
+            if (_timestamps.Count > 0)
+            {
+                _lastTimestamp = _timestamps.Dequeue();
+            }
+
+            return _lastTimestamp;
         }
     }
 

--- a/BeanBot.Tests/Health/MongoReadinessMonitorTests.cs
+++ b/BeanBot.Tests/Health/MongoReadinessMonitorTests.cs
@@ -1,0 +1,287 @@
+using BeanBot.Health;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BeanBot.Tests.Health;
+
+public class MongoReadinessMonitorTests
+{
+    private static readonly DateTimeOffset InitialTime = new(
+        2026,
+        9,
+        3,
+        14,
+        0,
+        0,
+        TimeSpan.Zero);
+
+    [Fact]
+    public async Task CompletedSuccess_IsCachedUntilFreshnessWindowExpires()
+    {
+        var clock = new ManualTimeProvider(InitialTime);
+        var probe = new ScriptedProbe(
+            _ => Task.CompletedTask,
+            _ => Task.CompletedTask);
+        var monitor = CreateMonitor(
+            probe,
+            clock,
+            probeTimeout: TimeSpan.FromSeconds(1),
+            freshnessWindow: TimeSpan.FromSeconds(10));
+
+        var first = await monitor.GetSnapshotAsync(CancellationToken.None);
+        clock.Advance(TimeSpan.FromSeconds(9));
+        var cached = await monitor.GetSnapshotAsync(CancellationToken.None);
+
+        Assert.True(first.IsReachable);
+        Assert.True(cached.IsReachable);
+        Assert.Equal(1, probe.CallCount);
+
+        clock.Advance(TimeSpan.FromSeconds(2));
+        var refreshed = await monitor.GetSnapshotAsync(CancellationToken.None);
+
+        Assert.True(refreshed.IsReachable);
+        Assert.Equal(2, probe.CallCount);
+    }
+
+    [Fact]
+    public async Task ConcurrentRequests_ShareOneOutstandingProbe()
+    {
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var probe = new ScriptedProbe(_ => completion.Task);
+        var monitor = CreateMonitor(
+            probe,
+            new ManualTimeProvider(InitialTime),
+            probeTimeout: TimeSpan.FromSeconds(1),
+            freshnessWindow: TimeSpan.FromSeconds(10));
+
+        var requests = Enumerable.Range(0, 8)
+            .Select(_ => monitor.GetSnapshotAsync(CancellationToken.None))
+            .ToArray();
+        await WaitUntilAsync(() => probe.CallCount == 1);
+
+        completion.TrySetResult();
+        var snapshots = await Task.WhenAll(requests);
+
+        Assert.All(snapshots, snapshot => Assert.True(snapshot.IsReachable));
+        Assert.Equal(1, probe.CallCount);
+        Assert.False(monitor.HasInFlightProbe);
+    }
+
+    [Fact]
+    public async Task StalledProbe_TimesOutWithoutStartingOverlappingProbe_AndLateFaultIsObserved()
+    {
+        var clock = new ManualTimeProvider(InitialTime);
+        var stalled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var probeCancellation = CancellationToken.None;
+        var probe = new ScriptedProbe(
+            cancellationToken =>
+            {
+                probeCancellation = cancellationToken;
+                return stalled.Task;
+            },
+            _ => Task.CompletedTask);
+        var monitor = CreateMonitor(
+            probe,
+            clock,
+            probeTimeout: TimeSpan.FromMilliseconds(50),
+            freshnessWindow: TimeSpan.FromSeconds(10));
+
+        var timedOut = await monitor
+            .GetSnapshotAsync(CancellationToken.None)
+            .WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.False(timedOut.IsReachable);
+        Assert.True(probeCancellation.IsCancellationRequested);
+        Assert.True(monitor.HasInFlightProbe);
+        Assert.Equal(1, probe.CallCount);
+
+        clock.Advance(TimeSpan.FromSeconds(11));
+        var stillTimedOut = await monitor.GetSnapshotAsync(CancellationToken.None);
+
+        Assert.False(stillTimedOut.IsReachable);
+        Assert.Equal(1, probe.CallCount);
+
+        stalled.TrySetException(new InvalidOperationException(
+            "mongodb://user:password@should-never-be-reported"));
+        await WaitUntilAsync(() => !monitor.HasInFlightProbe);
+
+        clock.Advance(TimeSpan.FromSeconds(11));
+        var recovered = await monitor.GetSnapshotAsync(CancellationToken.None);
+
+        Assert.True(recovered.IsReachable);
+        Assert.Equal(2, probe.CallCount);
+    }
+
+    [Fact]
+    public async Task StaleSuccess_IsNotTrustedWhenRefreshCannotComplete()
+    {
+        var clock = new ManualTimeProvider(InitialTime);
+        var probe = new ScriptedProbe(
+            _ => Task.CompletedTask,
+            cancellationToken => Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken));
+        var monitor = CreateMonitor(
+            probe,
+            clock,
+            probeTimeout: TimeSpan.FromMilliseconds(50),
+            freshnessWindow: TimeSpan.FromSeconds(10));
+
+        var healthy = await monitor.GetSnapshotAsync(CancellationToken.None);
+        clock.Advance(TimeSpan.FromSeconds(11));
+        var unavailable = await monitor
+            .GetSnapshotAsync(CancellationToken.None)
+            .WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.True(healthy.IsReachable);
+        Assert.False(unavailable.IsReachable);
+        Assert.Equal(2, probe.CallCount);
+    }
+
+    [Fact]
+    public async Task RequestCancellation_StopsOnlyThatWaiter_AndSharedProbeCanStillSucceed()
+    {
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var probeCancellation = CancellationToken.None;
+        var probe = new ScriptedProbe(cancellationToken =>
+        {
+            probeCancellation = cancellationToken;
+            return completion.Task;
+        });
+        var monitor = CreateMonitor(
+            probe,
+            new ManualTimeProvider(InitialTime),
+            probeTimeout: TimeSpan.FromSeconds(5),
+            freshnessWindow: TimeSpan.FromSeconds(10));
+        using var requestCancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(25));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => monitor.GetSnapshotAsync(requestCancellation.Token));
+
+        Assert.Equal(1, probe.CallCount);
+        Assert.False(probeCancellation.IsCancellationRequested);
+        Assert.True(monitor.HasInFlightProbe);
+
+        completion.TrySetResult();
+        await WaitUntilAsync(() => !monitor.HasInFlightProbe);
+        var recovered = await monitor.GetSnapshotAsync(CancellationToken.None);
+
+        Assert.True(recovered.IsReachable);
+        Assert.Equal(1, probe.CallCount);
+    }
+
+    [Fact]
+    public async Task CompletedFailure_CanRecoverAfterFreshnessWindow()
+    {
+        var clock = new ManualTimeProvider(InitialTime);
+        var probe = new ScriptedProbe(
+            _ => Task.FromException(new InvalidOperationException(
+                "mongodb://user:password@should-never-be-reported")),
+            _ => Task.CompletedTask);
+        var monitor = CreateMonitor(
+            probe,
+            clock,
+            probeTimeout: TimeSpan.FromSeconds(1),
+            freshnessWindow: TimeSpan.FromSeconds(10));
+
+        var failed = await monitor.GetSnapshotAsync(CancellationToken.None);
+        clock.Advance(TimeSpan.FromSeconds(11));
+        var recovered = await monitor.GetSnapshotAsync(CancellationToken.None);
+
+        Assert.False(failed.IsReachable);
+        Assert.True(recovered.IsReachable);
+        Assert.Equal(2, probe.CallCount);
+    }
+
+    private static MongoReadinessMonitor CreateMonitor(
+        IMongoReadinessProbe probe,
+        TimeProvider timeProvider,
+        TimeSpan probeTimeout,
+        TimeSpan freshnessWindow)
+        => new(
+            probe,
+            NullLogger<MongoReadinessMonitor>.Instance,
+            timeProvider,
+            probeTimeout,
+            freshnessWindow);
+
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        var timeoutAt = DateTimeOffset.UtcNow.AddSeconds(2);
+        while (!condition() && DateTimeOffset.UtcNow < timeoutAt)
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(5));
+        }
+
+        Assert.True(condition(), "Condition was not reached before the test timeout.");
+    }
+
+    private sealed class ScriptedProbe : IMongoReadinessProbe
+    {
+        private readonly object _syncRoot = new();
+        private readonly Queue<Func<CancellationToken, Task>> _steps;
+        private int _callCount;
+
+        public ScriptedProbe(params Func<CancellationToken, Task>[] steps)
+        {
+            _steps = new Queue<Func<CancellationToken, Task>>(steps);
+        }
+
+        public int CallCount => Volatile.Read(ref _callCount);
+
+        public Task CheckAsync(CancellationToken cancellationToken)
+        {
+            Func<CancellationToken, Task> step;
+            lock (_syncRoot)
+            {
+                if (_steps.Count == 0)
+                {
+                    throw new InvalidOperationException("No scripted Mongo readiness probe step remains.");
+                }
+
+                step = _steps.Dequeue();
+                Interlocked.Increment(ref _callCount);
+            }
+
+            return step(cancellationToken);
+        }
+    }
+
+    private sealed class ManualTimeProvider : TimeProvider
+    {
+        private readonly object _syncRoot = new();
+        private DateTimeOffset _utcNow;
+        private long _timestamp;
+
+        public ManualTimeProvider(DateTimeOffset utcNow)
+        {
+            _utcNow = utcNow;
+        }
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override DateTimeOffset GetUtcNow()
+        {
+            lock (_syncRoot)
+            {
+                return _utcNow;
+            }
+        }
+
+        public override long GetTimestamp()
+        {
+            lock (_syncRoot)
+            {
+                return _timestamp;
+            }
+        }
+
+        public void Advance(TimeSpan elapsed)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(elapsed, TimeSpan.Zero);
+            lock (_syncRoot)
+            {
+                _utcNow += elapsed;
+                _timestamp += elapsed.Ticks;
+            }
+        }
+    }
+}

--- a/BeanBot/Health/HealthCheckServer.cs
+++ b/BeanBot/Health/HealthCheckServer.cs
@@ -36,6 +36,7 @@ public sealed class HealthCheckServer : IAsyncDisposable
     private readonly object _syncRoot = new();
     private readonly HealthCheckOptions _options;
     private readonly Func<DiscordHealthSnapshot> _createHealthSnapshot;
+    private readonly Func<CancellationToken, Task<MongoReadinessSnapshot>> _getMongoReadinessSnapshot;
     private readonly TimeSpan _requestHeadersTimeout;
     private readonly TimeSpan _shutdownTimeout;
     private readonly int _maximumConcurrentClients;
@@ -49,10 +50,12 @@ public sealed class HealthCheckServer : IAsyncDisposable
         HealthCheckOptions options,
         DiscordSocketClient discordClient,
         DiscordConnectionHealth discordConnectionHealth,
+        MongoReadinessMonitor mongoReadinessMonitor,
         ILogger<HealthCheckServer> logger)
         : this(
             options,
             CreateSnapshotFactory(discordClient, discordConnectionHealth),
+            CreateMongoReadinessFactory(mongoReadinessMonitor),
             logger,
             DefaultRequestHeadersTimeout,
             DefaultMaximumConcurrentClients,
@@ -69,9 +72,31 @@ public sealed class HealthCheckServer : IAsyncDisposable
         int maximumConcurrentClients = DefaultMaximumConcurrentClients,
         int maximumTrackedRateLimitClients = DefaultMaximumTrackedRateLimitClients,
         TimeSpan? shutdownTimeout = null)
+        : this(
+            options,
+            createHealthSnapshot,
+            CreateAssumedMongoReadinessSnapshotAsync,
+            logger,
+            requestHeadersTimeout,
+            maximumConcurrentClients,
+            maximumTrackedRateLimitClients,
+            shutdownTimeout)
+    {
+    }
+
+    internal HealthCheckServer(
+        HealthCheckOptions options,
+        Func<DiscordHealthSnapshot> createHealthSnapshot,
+        Func<CancellationToken, Task<MongoReadinessSnapshot>> getMongoReadinessSnapshot,
+        ILogger<HealthCheckServer> logger,
+        TimeSpan? requestHeadersTimeout = null,
+        int maximumConcurrentClients = DefaultMaximumConcurrentClients,
+        int maximumTrackedRateLimitClients = DefaultMaximumTrackedRateLimitClients,
+        TimeSpan? shutdownTimeout = null)
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(createHealthSnapshot);
+        ArgumentNullException.ThrowIfNull(getMongoReadinessSnapshot);
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumConcurrentClients);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumTrackedRateLimitClients);
@@ -83,6 +108,7 @@ public sealed class HealthCheckServer : IAsyncDisposable
 
         _options = options;
         _createHealthSnapshot = createHealthSnapshot;
+        _getMongoReadinessSnapshot = getMongoReadinessSnapshot;
         _logger = logger;
         _requestHeadersTimeout = effectiveRequestHeadersTimeout;
         _shutdownTimeout = effectiveShutdownTimeout;
@@ -225,6 +251,20 @@ public sealed class HealthCheckServer : IAsyncDisposable
         return () => discordConnectionHealth.CreateSnapshot(discordClient);
     }
 
+    private static Func<CancellationToken, Task<MongoReadinessSnapshot>> CreateMongoReadinessFactory(
+        MongoReadinessMonitor mongoReadinessMonitor)
+    {
+        ArgumentNullException.ThrowIfNull(mongoReadinessMonitor);
+        return mongoReadinessMonitor.GetSnapshotAsync;
+    }
+
+    private static Task<MongoReadinessSnapshot> CreateAssumedMongoReadinessSnapshotAsync(
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(new MongoReadinessSnapshot(true, DateTimeOffset.UnixEpoch));
+    }
+
     private WebApplication CreateApplication()
     {
         var builder = WebApplication.CreateSlimBuilder(new WebApplicationOptions
@@ -328,27 +368,45 @@ public sealed class HealthCheckServer : IAsyncDisposable
             return;
         }
 
-        var healthSnapshot = _createHealthSnapshot();
+        var discordSnapshot = _createHealthSnapshot();
+        var mongoSnapshot = await _getMongoReadinessSnapshot(context.RequestAborted);
+        var isHealthy = discordSnapshot.IsHealthy && mongoSnapshot.IsReachable;
         await WriteJsonResponseAsync(
             context,
-            healthSnapshot.IsHealthy
+            isHealthy
                 ? StatusCodes.Status200OK
                 : StatusCodes.Status503ServiceUnavailable,
             new
             {
-                status = healthSnapshot.IsHealthy ? "ok" : "unhealthy",
+                status = isHealthy ? "ok" : "unhealthy",
                 version = BuildIdentity.Current.Version,
                 commitSha = BuildIdentity.Current.CommitSha,
-                discordConnected = healthSnapshot.IsHealthy,
-                message = healthSnapshot.StatusMessage,
-                loginState = healthSnapshot.LoginState,
-                connectionState = healthSnapshot.ConnectionState,
-                lastReadyAtUtc = healthSnapshot.LastReadyAtUtc,
-                lastDisconnectedAtUtc = healthSnapshot.LastDisconnectedAtUtc,
-                unhealthySinceAtUtc = healthSnapshot.UnhealthySinceAtUtc,
-                mostRecentDisconnectReason = healthSnapshot.MostRecentDisconnectReason
+                discordConnected = discordSnapshot.IsHealthy,
+                mongoReachable = mongoSnapshot.IsReachable,
+                mongoLastCheckedAtUtc = mongoSnapshot.LastCheckedAtUtc,
+                message = GetStatusMessage(discordSnapshot, mongoSnapshot),
+                loginState = discordSnapshot.LoginState,
+                connectionState = discordSnapshot.ConnectionState,
+                lastReadyAtUtc = discordSnapshot.LastReadyAtUtc,
+                lastDisconnectedAtUtc = discordSnapshot.LastDisconnectedAtUtc,
+                unhealthySinceAtUtc = discordSnapshot.UnhealthySinceAtUtc,
+                mostRecentDisconnectReason = discordSnapshot.MostRecentDisconnectReason
             },
             isHeadRequest);
+    }
+
+    private static string GetStatusMessage(
+        DiscordHealthSnapshot discordSnapshot,
+        MongoReadinessSnapshot mongoSnapshot)
+    {
+        if (!discordSnapshot.IsHealthy)
+        {
+            return discordSnapshot.StatusMessage;
+        }
+
+        return mongoSnapshot.IsReachable
+            ? discordSnapshot.StatusMessage
+            : "MongoDB is not reachable.";
     }
 
     private bool IsAuthorized(HttpRequest request)

--- a/BeanBot/Health/MongoReadinessMonitor.cs
+++ b/BeanBot/Health/MongoReadinessMonitor.cs
@@ -1,0 +1,289 @@
+using BeanBot.Logging;
+using Microsoft.Extensions.Logging;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace BeanBot.Health;
+
+internal interface IMongoReadinessProbe
+{
+    Task CheckAsync(CancellationToken cancellationToken);
+}
+
+internal sealed class MongoReadinessProbe : IMongoReadinessProbe
+{
+    private readonly IMongoDatabase _database;
+
+    public MongoReadinessProbe(IMongoDatabase database)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+        _database = database;
+    }
+
+    public async Task CheckAsync(CancellationToken cancellationToken)
+    {
+        await _database.RunCommandAsync<BsonDocument>(
+            new BsonDocument("ping", 1),
+            cancellationToken: cancellationToken);
+    }
+}
+
+internal readonly record struct MongoReadinessSnapshot(
+    bool IsReachable,
+    DateTimeOffset LastCheckedAtUtc);
+
+internal sealed class MongoReadinessMonitor
+{
+    internal static readonly TimeSpan DefaultProbeTimeout = TimeSpan.FromSeconds(2);
+    internal static readonly TimeSpan DefaultFreshnessWindow = TimeSpan.FromSeconds(10);
+
+    private readonly object _syncRoot = new();
+    private readonly IMongoReadinessProbe _probe;
+    private readonly ILogger<MongoReadinessMonitor> _logger;
+    private readonly TimeProvider _timeProvider;
+    private readonly TimeSpan _probeTimeout;
+    private readonly TimeSpan _freshnessWindow;
+    private ProbeOperation? _inFlight;
+    private CachedSnapshot? _lastSnapshot;
+    private bool? _lastLoggedReachability;
+
+    public MongoReadinessMonitor(
+        IMongoReadinessProbe probe,
+        ILogger<MongoReadinessMonitor> logger)
+        : this(
+            probe,
+            logger,
+            TimeProvider.System,
+            DefaultProbeTimeout,
+            DefaultFreshnessWindow)
+    {
+    }
+
+    internal MongoReadinessMonitor(
+        IMongoReadinessProbe probe,
+        ILogger<MongoReadinessMonitor> logger,
+        TimeProvider timeProvider,
+        TimeSpan probeTimeout,
+        TimeSpan freshnessWindow)
+    {
+        ArgumentNullException.ThrowIfNull(probe);
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(probeTimeout, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(freshnessWindow, TimeSpan.Zero);
+
+        _probe = probe;
+        _logger = logger;
+        _timeProvider = timeProvider;
+        _probeTimeout = probeTimeout;
+        _freshnessWindow = freshnessWindow;
+    }
+
+    public async Task<MongoReadinessSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        ProbeOperation operation;
+        var nowTimestamp = _timeProvider.GetTimestamp();
+        lock (_syncRoot)
+        {
+            if (_lastSnapshot is { } cached
+                && _timeProvider.GetElapsedTime(cached.RecordedTimestamp, nowTimestamp) <= _freshnessWindow)
+            {
+                return cached.Snapshot;
+            }
+
+            operation = _inFlight ?? StartProbeLocked();
+        }
+
+        return await WaitForProbeAsync(operation, cancellationToken);
+    }
+
+    private ProbeOperation StartProbeLocked()
+    {
+        var timeoutCancellation = new CancellationTokenSource();
+        timeoutCancellation.CancelAfter(_probeTimeout);
+        var operation = new ProbeOperation(
+            _timeProvider.GetTimestamp(),
+            timeoutCancellation,
+            ExecuteProbeAsync(timeoutCancellation.Token));
+        _inFlight = operation;
+        _ = ObserveProbeCompletionAsync(operation);
+        return operation;
+    }
+
+    private async Task<ProbeExecutionResult> ExecuteProbeAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _probe.CheckAsync(cancellationToken);
+            return new ProbeExecutionResult(
+                true,
+                null,
+                cancellationToken.IsCancellationRequested);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return new ProbeExecutionResult(false, "timeout", true);
+        }
+        catch (Exception exception)
+        {
+            return new ProbeExecutionResult(
+                false,
+                exception.GetType().Name,
+                cancellationToken.IsCancellationRequested);
+        }
+    }
+
+    private async Task<MongoReadinessSnapshot> WaitForProbeAsync(
+        ProbeOperation operation,
+        CancellationToken cancellationToken)
+    {
+        var elapsed = _timeProvider.GetElapsedTime(operation.StartedTimestamp);
+        var remaining = _probeTimeout - elapsed;
+        if (remaining <= TimeSpan.Zero)
+        {
+            operation.Cancel();
+            return RecordTimeout(operation);
+        }
+
+        try
+        {
+            var result = await operation.Task.WaitAsync(remaining, cancellationToken);
+            return CreateSnapshot(result);
+        }
+        catch (TimeoutException)
+        {
+            operation.Cancel();
+            return RecordTimeout(operation);
+        }
+    }
+
+    private async Task ObserveProbeCompletionAsync(ProbeOperation operation)
+    {
+        var result = await operation.Task;
+        var snapshot = CreateSnapshot(result);
+        var failureKind = GetFailureKind(result);
+        var transition = MongoReadinessTransition.None;
+
+        lock (_syncRoot)
+        {
+            if (ReferenceEquals(_inFlight, operation))
+            {
+                _lastSnapshot = new CachedSnapshot(snapshot, _timeProvider.GetTimestamp());
+                _inFlight = null;
+                transition = UpdateLoggedReachabilityLocked(snapshot.IsReachable);
+            }
+        }
+
+        operation.Dispose();
+        LogTransition(transition, failureKind);
+    }
+
+    private MongoReadinessSnapshot RecordTimeout(ProbeOperation operation)
+    {
+        var snapshot = new MongoReadinessSnapshot(false, _timeProvider.GetUtcNow());
+        var transition = MongoReadinessTransition.None;
+
+        lock (_syncRoot)
+        {
+            if (ReferenceEquals(_inFlight, operation))
+            {
+                _lastSnapshot = new CachedSnapshot(snapshot, _timeProvider.GetTimestamp());
+                transition = UpdateLoggedReachabilityLocked(false);
+            }
+        }
+
+        LogTransition(transition, "timeout");
+        return snapshot;
+    }
+
+    private MongoReadinessSnapshot CreateSnapshot(ProbeExecutionResult result)
+    {
+        var isReachable = result.Succeeded && !result.CancellationRequestedAtCompletion;
+        return new MongoReadinessSnapshot(isReachable, _timeProvider.GetUtcNow());
+    }
+
+    private static string GetFailureKind(ProbeExecutionResult result)
+    {
+        if (result.CancellationRequestedAtCompletion)
+        {
+            return "timeout";
+        }
+
+        return result.FailureKind ?? "none";
+    }
+
+    private MongoReadinessTransition UpdateLoggedReachabilityLocked(bool isReachable)
+    {
+        if (_lastLoggedReachability == isReachable)
+        {
+            return MongoReadinessTransition.None;
+        }
+
+        var previous = _lastLoggedReachability;
+        _lastLoggedReachability = isReachable;
+        if (!isReachable)
+        {
+            return MongoReadinessTransition.Unavailable;
+        }
+
+        return previous == false
+            ? MongoReadinessTransition.Recovered
+            : MongoReadinessTransition.None;
+    }
+
+    private void LogTransition(MongoReadinessTransition transition, string failureKind)
+    {
+        switch (transition)
+        {
+            case MongoReadinessTransition.Unavailable:
+                BeanBotLog.MongoReadinessUnavailable(_logger, failureKind);
+                break;
+            case MongoReadinessTransition.Recovered:
+                BeanBotLog.MongoReadinessRecovered(_logger);
+                break;
+            case MongoReadinessTransition.None:
+            default:
+                break;
+        }
+    }
+
+    private sealed class ProbeOperation : IDisposable
+    {
+        private readonly CancellationTokenSource _timeoutCancellation;
+
+        public ProbeOperation(
+            long startedTimestamp,
+            CancellationTokenSource timeoutCancellation,
+            Task<ProbeExecutionResult> task)
+        {
+            StartedTimestamp = startedTimestamp;
+            _timeoutCancellation = timeoutCancellation;
+            Task = task;
+        }
+
+        public long StartedTimestamp { get; }
+        public Task<ProbeExecutionResult> Task { get; }
+
+        public void Cancel() => _timeoutCancellation.Cancel();
+
+        public void Dispose() => _timeoutCancellation.Dispose();
+    }
+
+    private readonly record struct ProbeExecutionResult(
+        bool Succeeded,
+        string? FailureKind,
+        bool CancellationRequestedAtCompletion);
+
+    private readonly record struct CachedSnapshot(
+        MongoReadinessSnapshot Snapshot,
+        long RecordedTimestamp);
+
+    private enum MongoReadinessTransition
+    {
+        None,
+        Unavailable,
+        Recovered
+    }
+}

--- a/BeanBot/Health/MongoReadinessMonitor.cs
+++ b/BeanBot/Health/MongoReadinessMonitor.cs
@@ -79,6 +79,17 @@ internal sealed class MongoReadinessMonitor
         _freshnessWindow = freshnessWindow;
     }
 
+    internal bool HasInFlightProbe
+    {
+        get
+        {
+            lock (_syncRoot)
+            {
+                return _inFlight is not null;
+            }
+        }
+    }
+
     public async Task<MongoReadinessSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();

--- a/BeanBot/Health/MongoReadinessMonitor.cs
+++ b/BeanBot/Health/MongoReadinessMonitor.cs
@@ -5,7 +5,7 @@ using MongoDB.Driver;
 
 namespace BeanBot.Health;
 
-internal interface IMongoReadinessProbe
+public interface IMongoReadinessProbe
 {
     Task CheckAsync(CancellationToken cancellationToken);
 }
@@ -32,7 +32,7 @@ internal readonly record struct MongoReadinessSnapshot(
     bool IsReachable,
     DateTimeOffset LastCheckedAtUtc);
 
-internal sealed class MongoReadinessMonitor
+public sealed class MongoReadinessMonitor
 {
     internal static readonly TimeSpan DefaultProbeTimeout = TimeSpan.FromSeconds(2);
     internal static readonly TimeSpan DefaultFreshnessWindow = TimeSpan.FromSeconds(10);
@@ -90,7 +90,7 @@ internal sealed class MongoReadinessMonitor
         }
     }
 
-    public async Task<MongoReadinessSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
+    internal async Task<MongoReadinessSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/BeanBot/Health/MongoReadinessMonitor.cs
+++ b/BeanBot/Health/MongoReadinessMonitor.cs
@@ -150,7 +150,7 @@ internal sealed class MongoReadinessMonitor
         try
         {
             var result = await operation.Task.WaitAsync(remaining, cancellationToken);
-            return CreateSnapshot(result);
+            return RecordCompleted(operation, result);
         }
         catch (TimeoutException)
         {
@@ -162,9 +162,17 @@ internal sealed class MongoReadinessMonitor
     private async Task ObserveProbeCompletionAsync(ProbeOperation operation)
     {
         var result = await operation.Task;
+        _ = RecordCompleted(operation, result);
+    }
+
+    private MongoReadinessSnapshot RecordCompleted(
+        ProbeOperation operation,
+        ProbeExecutionResult result)
+    {
         var snapshot = CreateSnapshot(result);
         var failureKind = GetFailureKind(result);
         var transition = MongoReadinessTransition.None;
+        var ownsCompletion = false;
 
         lock (_syncRoot)
         {
@@ -173,11 +181,17 @@ internal sealed class MongoReadinessMonitor
                 _lastSnapshot = new CachedSnapshot(snapshot, _timeProvider.GetTimestamp());
                 _inFlight = null;
                 transition = UpdateLoggedReachabilityLocked(snapshot.IsReachable);
+                ownsCompletion = true;
             }
         }
 
-        operation.Dispose();
-        LogTransition(transition, failureKind);
+        if (ownsCompletion)
+        {
+            operation.Dispose();
+            LogTransition(transition, failureKind);
+        }
+
+        return snapshot;
     }
 
     private MongoReadinessSnapshot RecordTimeout(ProbeOperation operation)

--- a/BeanBot/Health/MongoReadinessMonitor.cs
+++ b/BeanBot/Health/MongoReadinessMonitor.cs
@@ -291,7 +291,17 @@ public sealed class MongoReadinessMonitor
         public long StartedTimestamp { get; }
         public Task<ProbeExecutionResult> Task { get; }
 
-        public void Cancel() => _timeoutCancellation.Cancel();
+        public void Cancel()
+        {
+            try
+            {
+                _timeoutCancellation.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Probe completion already won ownership and disposed the timeout source.
+            }
+        }
 
         public void Dispose() => _timeoutCancellation.Dispose();
     }

--- a/BeanBot/Hosting/BeanBotServiceCollectionExtensions.cs
+++ b/BeanBot/Hosting/BeanBotServiceCollectionExtensions.cs
@@ -52,6 +52,8 @@ internal static class BeanBotServiceCollectionExtensions
             new MongoClient(provider.GetRequiredService<BeanBotOptions>().MongoConnectionString));
         services.AddSingleton<IMongoDatabase>(provider =>
             provider.GetRequiredService<MongoClient>().GetDatabase("BeanBotDB"));
+        services.AddSingleton<IMongoReadinessProbe, MongoReadinessProbe>();
+        services.AddSingleton<MongoReadinessMonitor>();
 
         services.AddSingleton<DiscordConnectionHealth>();
         services.AddSingleton<DiscordLifecycleCoordinator>();
@@ -144,6 +146,7 @@ internal static class BeanBotServiceCollectionExtensions
             provider.GetRequiredService<BeanBotOptions>().HealthCheck,
             provider.GetRequiredService<DiscordSocketClient>(),
             provider.GetRequiredService<DiscordConnectionHealth>(),
+            provider.GetRequiredService<MongoReadinessMonitor>(),
             provider.GetRequiredService<ILogger<HealthCheckServer>>()));
 
         services.AddSingleton<BeanBotRuntime>();

--- a/BeanBot/Logging/BeanBotHealthLog.cs
+++ b/BeanBot/Logging/BeanBotHealthLog.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.Logging;
+
+namespace BeanBot.Logging;
+
+internal static partial class BeanBotLog
+{
+    [LoggerMessage(Level = LogLevel.Warning, Message = "MongoDB readiness is unavailable. FailureKind={FailureKind}")]
+    internal static partial void MongoReadinessUnavailable(ILogger logger, string failureKind);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "MongoDB readiness recovered")]
+    internal static partial void MongoReadinessRecovered(ILogger logger);
+}

--- a/README.md
+++ b/README.md
@@ -39,13 +39,15 @@ BEANBOT_HEALTHCHECK_RATE_LIMIT_SECONDS=90
 
 When `BEANBOT_HEALTHCHECK_PORT` is set, the bot exposes a Kestrel-hosted `GET /healthz` and `HEAD /healthz` endpoint on that port:
 
-- `200 OK`: process is up and the Discord gateway session is ready.
+- `200 OK`: process is up, the Discord gateway session is ready, and MongoDB passed a recent readiness probe.
 - `401 Unauthorized`: the bearer token is missing or invalid.
-- `503 Service Unavailable`: process is up, but Discord is not currently connected or ready.
+- `503 Service Unavailable`: process is up, but Discord is not ready or MongoDB is unavailable/stale.
 - `429 Too Many Requests`: the same client polled again before the configured rate limit expired.
 - no response / connection failure: the bot process is down or unreachable.
 
-Successful and unhealthy JSON responses also include the non-secret release version and Git commit SHA so an operator can identify the running image.
+Successful and unhealthy JSON responses include the non-secret release version and Git commit SHA, the existing Discord lifecycle fields, and sanitized `mongoReachable` / `mongoLastCheckedAtUtc` fields so an operator can distinguish Gateway and persistence readiness without exposing MongoDB connection details.
+
+Mongo readiness uses a lightweight single-flight ping. A completed result is reused for at most 10 seconds, and a stale result triggers a fresh probe. Each probe has a 2-second application-owned deadline. If the underlying driver call does not settle by that deadline, `/healthz` reports MongoDB unavailable while BeanBot retains ownership of that single late probe until it completes; later polls do not fan out additional Mongo operations. Recovery is reflected by the next probe after the cached unhealthy result expires, without restarting BeanBot.
 
 If you bind the endpoint to anything other than `127.0.0.1`, set `BEANBOT_HEALTHCHECK_BEARER_TOKEN` and send `Authorization: Bearer <token>` from Home Assistant.
 
@@ -71,7 +73,7 @@ BeanBot remains a single application project, organized by responsibility:
 
 - `Configuration` binds and validates runtime settings.
 - `Discord` contains commands, event handlers, gateway lifecycle, messaging helpers, and reaction-role behavior.
-- `Health` owns gateway health snapshots and the authenticated `/healthz` endpoint.
+- `Health` owns Gateway and MongoDB readiness snapshots and the authenticated `/healthz` endpoint.
 - `Hosting` composes the Generic Host and coordinates startup and shutdown.
 - `Logging` contains structured log messages and Discord owner-alert delivery.
 - `Persistence` contains runtime directory setup, persisted models, outage state, and MongoDB repositories.


### PR DESCRIPTION
Closes #172

## Summary
- make `/healthz` return `200 OK` only when both Discord Gateway readiness and MongoDB readiness are healthy
- add sanitized `mongoReachable` and `mongoLastCheckedAtUtc` fields while preserving truthful Discord lifecycle fields
- probe MongoDB with a lightweight ping behind a 2-second application-owned deadline and a 10-second freshness window
- keep Mongo probing single-flight so repeated health polls cannot create overlapping or unbounded abandoned driver operations
- retain ownership of a timed-out underlying probe until it actually settles, observe late completion/failure, and never expose raw Mongo exception or connection details
- allow a later successful probe to restore readiness without restarting BeanBot
- document the combined readiness contract and bounded probe behavior

## Implementation
- added `IMongoReadinessProbe` / `MongoReadinessProbe` around the driver-supported `ping` command
- added `MongoReadinessMonitor` with a bounded 2-second probe deadline, 10-second completed-result freshness window, single-flight ownership, late-completion observation, and transition-only sanitized logging
- wired Mongo readiness into `HealthCheckServer` and dependency injection without changing the existing endpoint path, bearer authentication, rate limiting, GET/HEAD behavior, Kestrel limits, or shutdown bounds
- kept Discord state independent in the payload so Mongo failures cannot falsely report the Gateway as disconnected
- documented the tightened readiness semantics and maximum staleness behavior in `README.md`

## Review-found repair
The fresh review workflow found a deadline/completion race in `MongoReadinessMonitor`: a probe could complete and dispose its timeout `CancellationTokenSource` just before a timed-out waiter tried to cancel that source, allowing `ObjectDisposedException` to escape from `/healthz` instead of returning a bounded readiness result.

The existing PR branch was repaired in place by making the cancellation handoff tolerant of completion-owned disposal, and a deterministic `SequencedTimeProvider` regression test now forces that exact interleaving. The test also proves the timed-out waiter returns unhealthy without throwing while the already-completed probe result remains safely cached for the next request.

## Tests
- cache freshness and stale-success refresh behavior
- concurrent poll single-flight behavior
- probe timeout/cancellation and retained late-operation ownership
- late-fault observation and recovery after the late operation settles
- caller cancellation isolation for a shared probe
- completed failure followed by recovery
- deterministic timeout/completion/disposal race regression coverage
- combined Discord + Mongo HTTP status and sanitized payload behavior
- `HEAD /healthz` combined-readiness behavior
- existing health authentication, rate-limit, routing, lifecycle, and shutdown tests remain green under the full repository gate

## Verification
Fresh Verifier: **PASS** on exact head `9a6ecb683b9d6ce91b72976c928ef665402e57a8` after the review-found repair.

- Repository Verification #299: **PASS** — exact PR head checked out and `./scripts/verify.sh full` completed successfully
- CodeQL #133: **PASS**
- Dependency Review #110: **PASS**
- branch policy: based on current `develop` (`f896856f80a6269d5b3aebcae18fae78ba87c87a`), targets `develop`, 12 commits ahead / 0 behind
- diff scope: health monitor/server, DI registration, health logging, focused tests, README documentation, and the targeted timeout/completion race repair only
- review threads: none

Local focused / `verify.sh fast` / `verify.sh full` execution remains unavailable in the automation runtime because `github.com` DNS resolution fails, so no local PASS is claimed. Repository policy permits exact-head PR CI evidence for that infrastructure-only blocker; the full CI gate above supplied the deterministic verification evidence.

Fresh independent Reviewer: **CLEAN**. No consequential findings remain for health truthfulness, Mongo single-flight/timeout ownership, cancellation/disposal races, late faults, information disclosure, authentication/rate limiting, Docker/runtime compatibility, dependency/release behavior, test quality, or unrelated scope.

## Manual validation
After deployment, confirm `/healthz` remains `200` while both Discord and Mongo are healthy, becomes `503` within the documented probe freshness/deadline window during a Mongo outage while `discordConnected` stays truthful, and returns to `200` after Mongo recovers. No configuration, package, Docker, or release workflow changes are included.