### PR TITLE
Add dependency-free liveness endpoint

### DIFF
--- a/BeanBot.Tests/Health/HealthCheckLivenessTests.cs
+++ b/BeanBot.Tests/Health/HealthCheckLivenessTests.cs
@@ -1,0 +1,184 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using BeanBot.Configuration;
+using BeanBot.Health;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BeanBot.Tests.Health;
+
+public class HealthCheckLivenessTests
+{
+    private static readonly DiscordHealthSnapshot UnhealthySnapshot = new(
+        false,
+        "Discord gateway has not reached the Ready state yet.",
+        "LoggedOut",
+        "Disconnected",
+        null,
+        null,
+        null,
+        null);
+
+    [Fact]
+    public async Task Get_Liveness_ReturnsMinimalPayloadWithoutCreatingReadinessSnapshot()
+    {
+        await using var server = CreateServer(
+            () => throw new InvalidOperationException("Readiness must not run for liveness."));
+        await server.StartAsync(CancellationToken.None);
+        using var client = CreateClient(server);
+
+        using var response = await client.GetAsync("/livez?probe=1");
+        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+        Assert.Equal("alive", payload.RootElement.GetProperty("status").GetString());
+        Assert.Equal("0.0.0-local", payload.RootElement.GetProperty("version").GetString());
+        Assert.Equal("unknown", payload.RootElement.GetProperty("commitSha").GetString());
+        Assert.Equal(3, payload.RootElement.EnumerateObject().Count());
+    }
+
+    [Fact]
+    public async Task Head_Liveness_ReturnsHeadersWithoutBodyOrReadinessWork()
+    {
+        await using var server = CreateServer(
+            () => throw new InvalidOperationException("Readiness must not run for liveness."));
+        await server.StartAsync(CancellationToken.None);
+        using var client = CreateClient(server);
+        using var request = new HttpRequestMessage(HttpMethod.Head, "/livez");
+
+        using var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+        Assert.True(response.Content.Headers.ContentLength > 0);
+        Assert.Empty(await response.Content.ReadAsByteArrayAsync());
+    }
+
+    [Fact]
+    public async Task DiscordUnready_ReadinessIs503WhileLivenessRemains200()
+    {
+        var snapshotCalls = 0;
+        await using var server = CreateServer(() =>
+        {
+            Interlocked.Increment(ref snapshotCalls);
+            return UnhealthySnapshot;
+        });
+        await server.StartAsync(CancellationToken.None);
+        using var client = CreateClient(server);
+
+        using var liveness = await client.GetAsync("/livez");
+        Assert.Equal(0, Volatile.Read(ref snapshotCalls));
+        using var readiness = await client.GetAsync("/healthz");
+
+        Assert.Equal(HttpStatusCode.OK, liveness.StatusCode);
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, readiness.StatusCode);
+        Assert.Equal(1, Volatile.Read(ref snapshotCalls));
+    }
+
+    [Fact]
+    public async Task BearerAuthentication_AppliesToLivenessWithoutFailuresConsumingRateLimit()
+    {
+        await using var server = CreateServer(
+            () => UnhealthySnapshot,
+            bearerToken: "health-secret");
+        await server.StartAsync(CancellationToken.None);
+        using var client = CreateClient(server);
+
+        using var missing = await client.GetAsync("/livez");
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "wrong-secret");
+        using var invalid = await client.GetAsync("/livez");
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "health-secret");
+        using var valid = await client.GetAsync("/livez");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, missing.StatusCode);
+        Assert.Contains("Bearer", missing.Headers.WwwAuthenticate.Select(value => value.Scheme));
+        Assert.Equal(HttpStatusCode.Unauthorized, invalid.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, valid.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnsupportedMethod_LivenessUsesExistingSafe405Contract()
+    {
+        await using var server = CreateServer(() => UnhealthySnapshot);
+        await server.StartAsync(CancellationToken.None);
+        using var client = CreateClient(server);
+
+        using var response = await client.PostAsync("/livez", null);
+
+        Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+        Assert.Contains("GET", response.Content.Headers.Allow);
+        Assert.Contains("HEAD", response.Content.Headers.Allow);
+    }
+
+    [Fact]
+    public async Task ReadinessAndLiveness_ShareOneBoundedRateLimitStore()
+    {
+        var snapshotCalls = 0;
+        await using var server = CreateServer(
+            () =>
+            {
+                Interlocked.Increment(ref snapshotCalls);
+                return UnhealthySnapshot;
+            },
+            maximumTrackedRateLimitClients: 1);
+        await server.StartAsync(CancellationToken.None);
+        using var client = CreateClient(server);
+
+        using var readiness = await client.GetAsync("/healthz");
+        using var liveness = await client.GetAsync("/livez");
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, readiness.StatusCode);
+        Assert.Equal(HttpStatusCode.TooManyRequests, liveness.StatusCode);
+        Assert.NotNull(liveness.Headers.RetryAfter?.Delta);
+        Assert.Equal(1, Volatile.Read(ref snapshotCalls));
+    }
+
+    [Fact]
+    public async Task StopAfterServingBothRoutes_RemainsIdempotent()
+    {
+        var server = CreateServer(
+            () => UnhealthySnapshot,
+            maximumTrackedRateLimitClients: 2);
+        await server.StartAsync(CancellationToken.None);
+        using var client = CreateClient(server);
+
+        using var liveness = await client.GetAsync("/livez");
+        using var readiness = await client.GetAsync("/healthz");
+
+        Assert.Equal(HttpStatusCode.OK, liveness.StatusCode);
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, readiness.StatusCode);
+
+        await server.StopAsync(CancellationToken.None);
+        await server.StopAsync(CancellationToken.None);
+        await server.DisposeAsync();
+
+        Assert.Equal(0, server.BoundPort);
+    }
+
+    private static HealthCheckServer CreateServer(
+        Func<DiscordHealthSnapshot> createSnapshot,
+        string? bearerToken = null,
+        int maximumTrackedRateLimitClients = 10)
+    {
+        var options = new HealthCheckOptions(
+            true,
+            IPAddress.Loopback,
+            0,
+            bearerToken,
+            TimeSpan.FromSeconds(30));
+        return new HealthCheckServer(
+            options,
+            createSnapshot,
+            NullLogger<HealthCheckServer>.Instance,
+            maximumConcurrentClients: 2,
+            maximumTrackedRateLimitClients: maximumTrackedRateLimitClients);
+    }
+
+    private static HttpClient CreateClient(HealthCheckServer server)
+        => new(new SocketsHttpHandler { UseProxy = false })
+        {
+            BaseAddress = new Uri($"http://127.0.0.1:{server.BoundPort}")
+        };
+}

--- a/BeanBot.Tests/Health/HealthCheckMongoReadinessTests.cs
+++ b/BeanBot.Tests/Health/HealthCheckMongoReadinessTests.cs
@@ -69,6 +69,38 @@ public class HealthCheckMongoReadinessTests
     }
 
     [Fact]
+    public async Task MongoUnavailable_ReadinessIs503WhileLivenessDoesNotProbeDependencies()
+    {
+        var discordSnapshotCalls = 0;
+        var mongoProbeCalls = 0;
+        await using var server = CreateServer(
+            () =>
+            {
+                Interlocked.Increment(ref discordSnapshotCalls);
+                return HealthyDiscordSnapshot;
+            },
+            _ =>
+            {
+                Interlocked.Increment(ref mongoProbeCalls);
+                return Task.FromResult(new MongoReadinessSnapshot(false, DateTimeOffset.UtcNow));
+            });
+        await server.StartAsync(CancellationToken.None);
+        using var client = CreateClient(server);
+
+        using var liveness = await client.GetAsync("/livez");
+
+        Assert.Equal(HttpStatusCode.OK, liveness.StatusCode);
+        Assert.Equal(0, Volatile.Read(ref discordSnapshotCalls));
+        Assert.Equal(0, Volatile.Read(ref mongoProbeCalls));
+
+        using var readiness = await client.GetAsync("/healthz");
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, readiness.StatusCode);
+        Assert.Equal(1, Volatile.Read(ref discordSnapshotCalls));
+        Assert.Equal(1, Volatile.Read(ref mongoProbeCalls));
+    }
+
+    [Fact]
     public async Task Head_PreservesCombinedReadinessStatusWithoutBody()
     {
         await using var server = CreateServer(

--- a/BeanBot/Health/HealthCheckServer.cs
+++ b/BeanBot/Health/HealthCheckServer.cs
@@ -26,6 +26,7 @@ public sealed class HealthCheckServer : IAsyncDisposable
     internal const int MaxHeaderCharacters = 32 * 1024;
     internal const int DefaultMaximumConcurrentClients = 64;
     internal const int DefaultMaximumTrackedRateLimitClients = 4096;
+    internal const string LivenessPath = "/livez";
     private static readonly TimeSpan DefaultRequestHeadersTimeout = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan DefaultShutdownTimeout = TimeSpan.FromSeconds(1);
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -247,6 +248,12 @@ public sealed class HealthCheckServer : IAsyncDisposable
         });
 
         var application = builder.Build();
+        application.MapWhen(
+            context => string.Equals(
+                context.Request.Path.Value,
+                LivenessPath,
+                StringComparison.OrdinalIgnoreCase),
+            branch => branch.Run(HandleLivenessRequestAsync));
         application.Run(HandleRequestAsync);
         return application;
     }
@@ -273,6 +280,61 @@ public sealed class HealthCheckServer : IAsyncDisposable
             .Where(port => port > 0)
             .DefaultIfEmpty(0)
             .Min();
+    }
+
+    private async Task HandleLivenessRequestAsync(HttpContext context)
+    {
+        context.Response.Headers.Connection = "close";
+        var isHeadRequest = HttpMethods.IsHead(context.Request.Method);
+        if (!HttpMethods.IsGet(context.Request.Method) && !isHeadRequest)
+        {
+            context.Response.Headers.Allow = "GET, HEAD";
+            await WritePlainTextResponseAsync(
+                context,
+                StatusCodes.Status405MethodNotAllowed,
+                "Only GET and HEAD are supported.",
+                suppressBody: false);
+            return;
+        }
+
+        if (!IsAuthorized(context.Request))
+        {
+            context.Response.Headers.WWWAuthenticate = "Bearer";
+            await WritePlainTextResponseAsync(
+                context,
+                StatusCodes.Status401Unauthorized,
+                "Missing or invalid bearer token.",
+                isHeadRequest);
+            return;
+        }
+
+        var clientIdentifier = context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        if (_rateLimiter.IsRateLimited($"live|{clientIdentifier}", out var retryAfterSeconds))
+        {
+            context.Response.Headers.RetryAfter = retryAfterSeconds.ToString(CultureInfo.InvariantCulture);
+            await WriteJsonResponseAsync(
+                context,
+                StatusCodes.Status429TooManyRequests,
+                new
+                {
+                    status = "rate_limited",
+                    message = $"Wait {retryAfterSeconds} more seconds before polling {LivenessPath} again.",
+                    retryAfterSeconds
+                },
+                isHeadRequest);
+            return;
+        }
+
+        await WriteJsonResponseAsync(
+            context,
+            StatusCodes.Status200OK,
+            new
+            {
+                status = "alive",
+                version = BuildIdentity.Current.Version,
+                commitSha = BuildIdentity.Current.CommitSha
+            },
+            isHeadRequest);
     }
 
     private async Task HandleRequestAsync(HttpContext context)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Successful and unhealthy JSON responses also include the non-secret release vers
 
 If you bind the endpoint to anything other than `127.0.0.1`, set `BEANBOT_HEALTHCHECK_BEARER_TOKEN` and send `Authorization: Bearer <token>` from Home Assistant.
 
+The same listener also exposes dependency-free `GET /livez` and `HEAD /livez` liveness checks. `/livez` returns `200 OK` with only the non-secret build identity while the BeanBot process and Kestrel health surface can answer; it does not query Discord, MongoDB, external services, or persistence. It uses the same bearer-token policy, Kestrel limits, bounded client tracking, and poll interval as `/healthz` without opening another port.
+
+Use `/livez` for process/container liveness and restart decisions, and use `/healthz` for application readiness/availability monitoring. A recoverable required-dependency outage may therefore produce `/healthz = 503` while `/livez = 200`; that divergence is expected. A supervisor should not restart BeanBot solely because readiness is temporarily unavailable unless its operational policy deliberately chooses to do so.
+
 ## Local Development
 
 Install a stable .NET 10 SDK and Docker. The repository's `global.json` accepts SDK


### PR DESCRIPTION
Closes #174

## Summary
- add dependency-free `GET /livez` and `HEAD /livez` on the existing Kestrel health listener
- keep `/healthz` as the application-readiness route
- reuse the existing bearer authentication, Kestrel bounds, shutdown lifecycle, build identity, and bounded client-rate-limit store
- keep liveness and readiness in fixed separate rate-limit buckets per client while sharing the same globally bounded store
- document `/livez` for process/container restart decisions and `/healthz` for readiness/availability monitoring

## Implementation
- route exact `/livez` requests through an early `MapWhen` branch before the readiness handler; this structurally prevents liveness from invoking Discord readiness today and also bypasses the Mongo readiness call introduced by #172 / PR #173 when that work is integrated
- return only `status`, release `version`, and `commitSha` from liveness; no dependency status, configuration, exception, filesystem, connection, or persistence details are exposed
- preserve GET/HEAD-only behavior, bearer-token validation, connection-close behavior, response-size handling, request limits, and the existing bounded `BoundedClientRateLimiter`
- use a fixed `live|<client>` key inside the same limiter so ordinary liveness/readiness pollers do not cross-throttle while total tracked state remains capped

## Tests
- liveness GET returns the minimal sanitized payload and does not invoke the readiness snapshot factory
- liveness HEAD returns successful representation headers without a body or readiness work
- Discord-unready state demonstrates `/healthz = 503` while `/livez = 200`
- bearer authentication and 405 method behavior match the existing health contract
- a capacity-1 test proves liveness/readiness share the same bounded rate-limit store rather than creating a second client-state collection
- serving both routes preserves idempotent bounded shutdown
- the pending Mongo-readiness PR changes only the readiness handler path and preserves the internal constructor used by these tests, so `/livez` remains structurally isolated from its Mongo probe; direct combined runtime coverage becomes applicable once #173 is integrated

## Verification
Fresh Verifier: **PASS** on exact head `4b5ea8a363dc4feec014f08545e7a9a7287adfef` during the final review workflow.

- Repository Verification #300: **PASS** — GitHub Actions checked the exact PR head and the workflow's `Full repository verification` step ran `./scripts/verify.sh full`
- `verify.sh full` covers verification-orchestration self-tests, workflow validation, locked restore, formatting/analyzers, Release build/tests with coverage baseline, committed/staged/unstaged diff checks, master ancestry/branch integrity, vulnerable-package audit, Docker image build, hardened container smoke test, and shutdown smoke behavior
- CodeQL #134: **PASS** on the same head
- Dependency Review #111: **PASS** on the same head
- current `develop`: `f896856f80a6269d5b3aebcae18fae78ba87c87a`; PR targets `develop` and remains based on that current head
- complete PR diff remains limited to `HealthCheckServer`, focused liveness tests, and README documentation
- review threads: **0 open**

Local focused / `./scripts/verify.sh fast` / `./scripts/verify.sh full` execution remains unavailable in the automation runtime because a fresh clone attempt failed with `Could not resolve host: github.com`; no local PASS is claimed. Repository policy permits exact-head PR CI evidence for this infrastructure-only blocker, and the full exact-head CI gate above supplies the required deterministic verification evidence.

Fresh independent Reviewer: **CLEAN**. No consequential findings remain for health truthfulness, Discord lifecycle behavior, duplicate subscriptions/messages, unbounded waits/retries/tasks, cancellation, persistence, authentication/security, bounded rate-limit state, test quality, Docker/runtime compatibility, dependency/release behavior, or unrelated scope. No corrective code changes were required during this review run.

## Compatibility
No configuration, package, Dockerfile, persistence, Discord lifecycle, dependency, or release-workflow changes are included. The implementation is intentionally isolated from #172/#173: `/livez` branches before the readiness handler, so later Mongo readiness integration does not change liveness semantics.

## Manual validation
After deployment with the health listener enabled, point process/container liveness monitoring at `/livez` and readiness/availability monitoring at `/healthz`. Confirm a recoverable dependency outage can leave `/livez` at `200` while `/healthz` reports `503`, and keep probe cadence at or above `BEANBOT_HEALTHCHECK_RATE_LIMIT_SECONDS` to avoid intentional `429` responses.