### PR TITLE
Bound and drain legacy command execution

### DIFF
--- a/BeanBot.Tests/Discord/Events/LegacyCommandExecutionCoordinatorTests.cs
+++ b/BeanBot.Tests/Discord/Events/LegacyCommandExecutionCoordinatorTests.cs
@@ -1,0 +1,190 @@
+using BeanBot.Discord.Events;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.Events;
+
+public class LegacyCommandExecutionCoordinatorTests
+{
+    [Fact]
+    public async Task TryExecuteAsync_NormalExecution_RunsOnceAndReleasesCapacity()
+    {
+        var coordinator = new LegacyCommandExecutionCoordinator(
+            maximumConcurrentExecutions: 2,
+            drainTimeout: TimeSpan.FromSeconds(1));
+        var executionCount = 0;
+
+        var result = await coordinator.TryExecuteAsync(() =>
+        {
+            Interlocked.Increment(ref executionCount);
+            return Task.CompletedTask;
+        });
+
+        Assert.Equal(LegacyCommandAdmissionResult.Executed, result);
+        Assert.Equal(1, executionCount);
+        Assert.Equal(0, coordinator.ActiveExecutionCount);
+    }
+
+    [Fact]
+    public async Task TryExecuteAsync_AtCapacity_RejectsWithoutQueueingAndKeepsBookkeepingBounded()
+    {
+        var coordinator = new LegacyCommandExecutionCoordinator(
+            maximumConcurrentExecutions: 2,
+            drainTimeout: TimeSpan.FromSeconds(1));
+        var bothStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var startedCount = 0;
+
+        Task<LegacyCommandAdmissionResult> StartExecution()
+            => coordinator.TryExecuteAsync(async () =>
+            {
+                if (Interlocked.Increment(ref startedCount) == 2)
+                {
+                    bothStarted.TrySetResult();
+                }
+
+                await release.Task;
+            });
+
+        var first = StartExecution();
+        var second = StartExecution();
+        await bothStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(2, coordinator.ActiveExecutionCount);
+        Assert.Equal(coordinator.MaximumConcurrentExecutions, coordinator.ActiveExecutionCount);
+
+        var rejectedExecutionCount = 0;
+        var rejected = await coordinator.TryExecuteAsync(() =>
+        {
+            Interlocked.Increment(ref rejectedExecutionCount);
+            return Task.CompletedTask;
+        });
+
+        Assert.Equal(LegacyCommandAdmissionResult.RejectedCapacity, rejected);
+        Assert.Equal(0, rejectedExecutionCount);
+        Assert.Equal(2, coordinator.ActiveExecutionCount);
+
+        release.TrySetResult();
+        var completed = await Task.WhenAll(first, second);
+        Assert.All(
+            completed,
+            result => Assert.Equal(LegacyCommandAdmissionResult.Executed, result));
+        Assert.Equal(0, coordinator.ActiveExecutionCount);
+    }
+
+    [Fact]
+    public async Task TryExecuteAsync_FailureAndCancellation_ReleaseCapacityExactlyOnce()
+    {
+        var coordinator = new LegacyCommandExecutionCoordinator(
+            maximumConcurrentExecutions: 1,
+            drainTimeout: TimeSpan.FromSeconds(1));
+        var expectedFailure = new InvalidOperationException("injected command failure");
+
+        var failure = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => coordinator.TryExecuteAsync(() => Task.FromException(expectedFailure)));
+        Assert.Same(expectedFailure, failure);
+        Assert.Equal(0, coordinator.ActiveExecutionCount);
+
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => coordinator.TryExecuteAsync(() => Task.FromCanceled(cancellation.Token)));
+        Assert.Equal(0, coordinator.ActiveExecutionCount);
+
+        var reused = await coordinator.TryExecuteAsync(() => Task.CompletedTask);
+        Assert.Equal(LegacyCommandAdmissionResult.Executed, reused);
+        Assert.Equal(0, coordinator.ActiveExecutionCount);
+    }
+
+    [Fact]
+    public async Task DrainAsync_StopsAdmissionAndWaitsForAlreadyAdmittedExecution()
+    {
+        var coordinator = new LegacyCommandExecutionCoordinator(
+            maximumConcurrentExecutions: 2,
+            drainTimeout: TimeSpan.FromSeconds(1));
+        var started = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var admitted = coordinator.TryExecuteAsync(async () =>
+        {
+            started.TrySetResult();
+            await release.Task;
+        });
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        coordinator.StopAdmission();
+        var rejected = await coordinator.TryExecuteAsync(() => Task.CompletedTask);
+        Assert.Equal(LegacyCommandAdmissionResult.RejectedStopping, rejected);
+
+        var drain = coordinator.DrainAsync(_ => { });
+        Assert.False(drain.IsCompleted);
+
+        release.TrySetResult();
+        var drainResult = await drain.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.True(drainResult.IsDrained);
+        Assert.Equal(0, drainResult.SurvivingExecutionCount);
+        Assert.Equal(LegacyCommandAdmissionResult.Executed, await admitted);
+        Assert.Equal(0, coordinator.ActiveExecutionCount);
+    }
+
+    [Fact]
+    public async Task DrainAsync_TimeoutReturnsSurvivorAndObservesLateFault()
+    {
+        var coordinator = new LegacyCommandExecutionCoordinator(
+            maximumConcurrentExecutions: 1,
+            drainTimeout: TimeSpan.FromMilliseconds(50));
+        var started = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var commandCompletion = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var lateFailure = new TaskCompletionSource<Exception>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var admitted = coordinator.TryExecuteAsync(async () =>
+        {
+            started.TrySetResult();
+            await commandCompletion.Task;
+        });
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        coordinator.StopAdmission();
+        var drainResult = await coordinator.DrainAsync(
+            exception => lateFailure.TrySetResult(exception));
+
+        Assert.False(drainResult.IsDrained);
+        Assert.Equal(1, drainResult.SurvivingExecutionCount);
+        Assert.Equal(1, coordinator.ActiveExecutionCount);
+
+        var expectedFailure = new InvalidOperationException("late command failure");
+        commandCompletion.TrySetException(expectedFailure);
+
+        var observedFailure = await lateFailure.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.Same(expectedFailure, observedFailure);
+        var commandFailure = await Assert.ThrowsAsync<InvalidOperationException>(() => admitted);
+        Assert.Same(expectedFailure, commandFailure);
+        Assert.Equal(0, coordinator.ActiveExecutionCount);
+    }
+
+    [Fact]
+    public async Task StopAdmission_IsIdempotentAndPreventsFutureExecution()
+    {
+        var coordinator = new LegacyCommandExecutionCoordinator(
+            maximumConcurrentExecutions: 1,
+            drainTimeout: TimeSpan.FromSeconds(1));
+
+        coordinator.StopAdmission();
+        coordinator.StopAdmission();
+
+        var rejected = await coordinator.TryExecuteAsync(() => Task.CompletedTask);
+        var firstDrain = await coordinator.DrainAsync(_ => { });
+        var secondDrain = await coordinator.DrainAsync(_ => { });
+
+        Assert.Equal(LegacyCommandAdmissionResult.RejectedStopping, rejected);
+        Assert.True(firstDrain.IsDrained);
+        Assert.True(secondDrain.IsDrained);
+        Assert.Equal(0, coordinator.ActiveExecutionCount);
+    }
+}

--- a/BeanBot.Tests/Discord/Events/LegacyCommandExecutionCoordinatorTests.cs
+++ b/BeanBot.Tests/Discord/Events/LegacyCommandExecutionCoordinatorTests.cs
@@ -1,4 +1,14 @@
+using System.Reflection;
+using BeanBot.Discord.Commands;
 using BeanBot.Discord.Events;
+using BeanBot.Discord.Messaging;
+using BeanBot.Hosting;
+using Discord;
+using Discord.Commands;
+using Discord.WebSocket;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Xunit;
 
 namespace BeanBot.Tests.Discord.Events;
@@ -6,185 +16,209 @@ namespace BeanBot.Tests.Discord.Events;
 public class LegacyCommandExecutionCoordinatorTests
 {
     [Fact]
-    public async Task TryExecuteAsync_NormalExecution_RunsOnceAndReleasesCapacity()
+    public async Task TryStart_NormalExecution_RunsOnceAndReleasesCapacity()
     {
-        var coordinator = new LegacyCommandExecutionCoordinator(
-            maximumConcurrentExecutions: 2,
-            drainTimeout: TimeSpan.FromSeconds(1));
-        var executionCount = 0;
-
-        var result = await coordinator.TryExecuteAsync(() =>
-        {
-            Interlocked.Increment(ref executionCount);
-            return Task.CompletedTask;
-        });
-
-        Assert.Equal(LegacyCommandAdmissionResult.Executed, result);
-        Assert.Equal(1, executionCount);
+        var coordinator = new LegacyCommandExecutionCoordinator();
+        var calls = 0;
+        var result = coordinator.TryStart(() => { calls++; return Task.CompletedTask; }, _ => { }, out var completion);
+        await completion;
+        Assert.True((await coordinator.DrainAsync()).IsDrained);
+        Assert.Equal(LegacyCommandAdmissionResult.Admitted, result);
+        Assert.Equal(1, calls);
         Assert.Equal(0, coordinator.ActiveExecutionCount);
     }
 
     [Fact]
-    public async Task TryExecuteAsync_AtCapacity_RejectsWithoutQueueingAndKeepsBookkeepingBounded()
+    public async Task TryStart_AtCapacity_RejectsWithoutQueueing()
     {
-        var coordinator = new LegacyCommandExecutionCoordinator(
-            maximumConcurrentExecutions: 2,
-            drainTimeout: TimeSpan.FromSeconds(1));
-        var bothStarted = new TaskCompletionSource(
-            TaskCreationOptions.RunContinuationsAsynchronously);
-        var release = new TaskCompletionSource(
-            TaskCreationOptions.RunContinuationsAsynchronously);
-        var startedCount = 0;
-
-        Task<LegacyCommandAdmissionResult> StartExecution()
-            => coordinator.TryExecuteAsync(async () =>
-            {
-                if (Interlocked.Increment(ref startedCount) == 2)
-                {
-                    bothStarted.TrySetResult();
-                }
-
-                await release.Task;
-            });
-
-        var first = StartExecution();
-        var second = StartExecution();
-        await bothStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
-
-        Assert.Equal(2, coordinator.ActiveExecutionCount);
-        Assert.Equal(coordinator.MaximumConcurrentExecutions, coordinator.ActiveExecutionCount);
-
-        var rejectedExecutionCount = 0;
-        var rejected = await coordinator.TryExecuteAsync(() =>
-        {
-            Interlocked.Increment(ref rejectedExecutionCount);
-            return Task.CompletedTask;
-        });
-
+        var coordinator = new LegacyCommandExecutionCoordinator(maximumConcurrentExecutions: 2);
+        var release = NewCompletion();
+        Assert.Equal(LegacyCommandAdmissionResult.Admitted, coordinator.TryStart(() => release.Task, _ => { }, out var first));
+        Assert.Equal(LegacyCommandAdmissionResult.Admitted, coordinator.TryStart(() => release.Task, _ => { }, out var second));
+        var rejectedCalls = 0;
+        var rejected = coordinator.TryStart(() => { rejectedCalls++; return Task.CompletedTask; }, _ => { }, out _);
         Assert.Equal(LegacyCommandAdmissionResult.RejectedCapacity, rejected);
-        Assert.Equal(0, rejectedExecutionCount);
         Assert.Equal(2, coordinator.ActiveExecutionCount);
+        Assert.Equal(0, rejectedCalls);
+        release.SetResult();
+        await Task.WhenAll(first, second);
+        Assert.True((await coordinator.DrainAsync()).IsDrained);
+        Assert.Equal(0, coordinator.ActiveExecutionCount);
+    }
 
-        release.TrySetResult();
-        var completed = await Task.WhenAll(first, second);
-        Assert.All(
-            completed,
-            result => Assert.Equal(LegacyCommandAdmissionResult.Executed, result));
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task TryStart_FailureIsObservedOnceEvenWhenNoCallerAwaitsIt(bool throwSynchronously)
+    {
+        var coordinator = new LegacyCommandExecutionCoordinator(maximumConcurrentExecutions: 1);
+        var expected = new InvalidOperationException("injected failure");
+        var observed = NewCompletion();
+        var reports = 0;
+        coordinator.TryStart(
+            () => throwSynchronously ? throw expected : Task.FromException(expected),
+            exception => { Assert.Same(expected, exception); Interlocked.Increment(ref reports); observed.SetResult(); },
+            out var completion);
+        await observed.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.Same(expected, await Assert.ThrowsAsync<InvalidOperationException>(() => completion));
+        Assert.True((await coordinator.DrainAsync()).IsDrained);
+        Assert.Equal(1, reports);
         Assert.Equal(0, coordinator.ActiveExecutionCount);
     }
 
     [Fact]
-    public async Task TryExecuteAsync_FailureAndCancellation_ReleaseCapacityExactlyOnce()
+    public async Task TryStart_CancellationRemainsCancellationAndReleasesCapacity()
     {
-        var coordinator = new LegacyCommandExecutionCoordinator(
-            maximumConcurrentExecutions: 1,
-            drainTimeout: TimeSpan.FromSeconds(1));
-        var expectedFailure = new InvalidOperationException("injected command failure");
-
-        var failure = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => coordinator.TryExecuteAsync(() => Task.FromException(expectedFailure)));
-        Assert.Same(expectedFailure, failure);
-        Assert.Equal(0, coordinator.ActiveExecutionCount);
-
+        var coordinator = new LegacyCommandExecutionCoordinator();
         using var cancellation = new CancellationTokenSource();
         cancellation.Cancel();
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => coordinator.TryExecuteAsync(() => Task.FromCanceled(cancellation.Token)));
-        Assert.Equal(0, coordinator.ActiveExecutionCount);
-
-        var reused = await coordinator.TryExecuteAsync(() => Task.CompletedTask);
-        Assert.Equal(LegacyCommandAdmissionResult.Executed, reused);
-        Assert.Equal(0, coordinator.ActiveExecutionCount);
-    }
-
-    [Fact]
-    public async Task DrainAsync_StopsAdmissionAndWaitsForAlreadyAdmittedExecution()
-    {
-        var coordinator = new LegacyCommandExecutionCoordinator(
-            maximumConcurrentExecutions: 2,
-            drainTimeout: TimeSpan.FromSeconds(1));
-        var started = new TaskCompletionSource(
-            TaskCreationOptions.RunContinuationsAsynchronously);
-        var release = new TaskCompletionSource(
-            TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var admitted = coordinator.TryExecuteAsync(async () =>
-        {
-            started.TrySetResult();
-            await release.Task;
-        });
-        await started.Task.WaitAsync(TimeSpan.FromSeconds(1));
-
-        coordinator.StopAdmission();
-        var rejected = await coordinator.TryExecuteAsync(() => Task.CompletedTask);
-        Assert.Equal(LegacyCommandAdmissionResult.RejectedStopping, rejected);
-
-        var drain = coordinator.DrainAsync(_ => { });
-        Assert.False(drain.IsCompleted);
-
-        release.TrySetResult();
-        var drainResult = await drain.WaitAsync(TimeSpan.FromSeconds(1));
-        Assert.True(drainResult.IsDrained);
-        Assert.Equal(0, drainResult.SurvivingExecutionCount);
-        Assert.Equal(LegacyCommandAdmissionResult.Executed, await admitted);
+        var reports = 0;
+        coordinator.TryStart(() => Task.FromCanceled(cancellation.Token), _ => reports++, out var completion);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => completion);
+        Assert.True((await coordinator.DrainAsync()).IsDrained);
+        Assert.True(completion.IsCanceled);
+        Assert.Equal(0, reports);
         Assert.Equal(0, coordinator.ActiveExecutionCount);
     }
 
     [Fact]
-    public async Task DrainAsync_TimeoutReturnsSurvivorAndObservesLateFault()
+    public async Task DrainAsync_TimeoutRetainsSurvivorUntilLateFailureActuallyCompletes()
     {
-        var coordinator = new LegacyCommandExecutionCoordinator(
-            maximumConcurrentExecutions: 1,
-            drainTimeout: TimeSpan.FromMilliseconds(50));
-        var started = new TaskCompletionSource(
-            TaskCreationOptions.RunContinuationsAsynchronously);
-        var commandCompletion = new TaskCompletionSource(
-            TaskCreationOptions.RunContinuationsAsynchronously);
-        var lateFailure = new TaskCompletionSource<Exception>(
-            TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var admitted = coordinator.TryExecuteAsync(async () =>
-        {
-            started.TrySetResult();
-            await commandCompletion.Task;
-        });
-        await started.Task.WaitAsync(TimeSpan.FromSeconds(1));
-
-        coordinator.StopAdmission();
-        var drainResult = await coordinator.DrainAsync(
-            exception => lateFailure.TrySetResult(exception));
-
-        Assert.False(drainResult.IsDrained);
-        Assert.Equal(1, drainResult.SurvivingExecutionCount);
+        var coordinator = new LegacyCommandExecutionCoordinator(drainTimeout: TimeSpan.FromMilliseconds(20));
+        var release = NewCompletion();
+        var reports = 0;
+        coordinator.TryStart(() => release.Task, _ => Interlocked.Increment(ref reports), out var completion);
+        var result = await coordinator.DrainAsync();
+        Assert.False(result.IsDrained);
+        Assert.Equal(1, result.SurvivingExecutionCount);
         Assert.Equal(1, coordinator.ActiveExecutionCount);
-
-        var expectedFailure = new InvalidOperationException("late command failure");
-        commandCompletion.TrySetException(expectedFailure);
-
-        var observedFailure = await lateFailure.Task.WaitAsync(TimeSpan.FromSeconds(1));
-        Assert.Same(expectedFailure, observedFailure);
-        var commandFailure = await Assert.ThrowsAsync<InvalidOperationException>(() => admitted);
-        Assert.Same(expectedFailure, commandFailure);
+        Assert.False(coordinator.WhenDrained.IsCompleted);
+        Assert.Equal(LegacyCommandAdmissionResult.RejectedStopping, coordinator.TryStart(() => Task.CompletedTask, _ => { }, out _));
+        release.SetException(new InvalidOperationException("late failure"));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => completion);
+        await coordinator.WhenDrained.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.Equal(1, reports);
         Assert.Equal(0, coordinator.ActiveExecutionCount);
     }
 
     [Fact]
     public async Task StopAdmission_IsIdempotentAndPreventsFutureExecution()
     {
-        var coordinator = new LegacyCommandExecutionCoordinator(
-            maximumConcurrentExecutions: 1,
-            drainTimeout: TimeSpan.FromSeconds(1));
-
+        var coordinator = new LegacyCommandExecutionCoordinator();
         coordinator.StopAdmission();
         coordinator.StopAdmission();
-
-        var rejected = await coordinator.TryExecuteAsync(() => Task.CompletedTask);
-        var firstDrain = await coordinator.DrainAsync(_ => { });
-        var secondDrain = await coordinator.DrainAsync(_ => { });
-
-        Assert.Equal(LegacyCommandAdmissionResult.RejectedStopping, rejected);
-        Assert.True(firstDrain.IsDrained);
-        Assert.True(secondDrain.IsDrained);
+        Assert.Equal(LegacyCommandAdmissionResult.RejectedStopping, coordinator.TryStart(() => Task.CompletedTask, _ => { }, out _));
+        Assert.True((await coordinator.DrainAsync()).IsDrained);
+        Assert.True((await coordinator.DrainAsync()).IsDrained);
         Assert.Equal(0, coordinator.ActiveExecutionCount);
+    }
+
+    [Fact]
+    public async Task RealCommandPipeline_ReturnsAfterAdmissionAndOwnsBodyAndCompletionFeedback()
+    {
+        using var waiter = new BoundedMessageWaiter<string>(1);
+        var state = new BlockingCommandState(waiter);
+        using var services = new ServiceCollection().AddSingleton(state).BuildServiceProvider();
+        using var commands = new CommandService(new CommandServiceConfig { DefaultRunMode = RunMode.Sync });
+        await commands.AddModuleAsync<BlockingModule>(services);
+        Assert.Contains(commands.Commands, command => command.Aliases.Contains("blocking"));
+        var context = DispatchProxy.Create<ICommandContext, CommandContextProxy>();
+        var feedbackStarted = NewCompletion();
+        var releaseFeedback = NewCompletion();
+        IResult? commandResult = null;
+        commands.CommandExecuted += async (_, _, result) => { commandResult = result; feedbackStarted.TrySetResult(); await releaseFeedback.Task; };
+        var executionFailure = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var coordinator = new LegacyCommandExecutionCoordinator(maximumConcurrentExecutions: 1, drainTimeout: TimeSpan.FromMilliseconds(20));
+
+        Task<IResult>? executeResult = null;
+        var admission = coordinator.TryStart(() => executeResult = commands.ExecuteAsync(context, "blocking", services), exception => executionFailure.TrySetResult(exception), out var completion);
+        Assert.Equal(LegacyCommandAdmissionResult.Admitted, admission);
+        await Task.WhenAny(state.Started.Task, feedbackStarted.Task, executionFailure.Task, completion).WaitAsync(TimeSpan.FromSeconds(1));
+        if (completion.IsCompleted)
+        {
+            await completion;
+            var result = await executeResult!;
+            Assert.True(result.IsSuccess, result.ErrorReason);
+        }
+        if (executionFailure.Task.IsCompleted) throw new Xunit.Sdk.XunitException((await executionFailure.Task).ToString());
+        Assert.True(commandResult is null || commandResult.IsSuccess, commandResult?.ErrorReason);
+        await state.Started.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.False(completion.IsCompleted);
+        Assert.Equal(1, coordinator.ActiveExecutionCount);
+        Assert.Equal(LegacyCommandAdmissionResult.RejectedCapacity,
+            coordinator.TryStart(() => commands.ExecuteAsync(context, "blocking", services), _ => { }, out _));
+
+        Assert.True(waiter.TryPublish(10, 20, false, "answer"));
+        await feedbackStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.Equal("answer", state.Answer);
+        Assert.Equal(1, coordinator.ActiveExecutionCount);
+        Assert.False((await coordinator.DrainAsync()).IsDrained);
+        releaseFeedback.SetResult();
+        await completion.WaitAsync(TimeSpan.FromSeconds(1));
+        await coordinator.WhenDrained.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.Equal(0, coordinator.ActiveExecutionCount);
+    }
+
+    [Fact]
+    public async Task ProductionCommands_AllRunSynchronouslyInsideBeanBotOwnership()
+    {
+        var builder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings { DisableDefaults = true });
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["BeanBot:BotToken"] = "test-token",
+            ["BeanBot:MongoConnectionString"] = "mongodb://127.0.0.1:27017",
+            ["BeanBot:GeneralChannelId"] = "1",
+            ["BeanBot:HatoeteUrl"] = "https://example.com/a.png",
+            ["BeanBot:YoshimaruUrl"] = "https://example.com/b.png"
+        });
+        builder.Services.AddBeanBot(builder.Configuration);
+        using var host = builder.Build();
+        using var client = host.Services.GetRequiredService<DiscordSocketClient>();
+        var commands = host.Services.GetRequiredService<CommandService>();
+        await commands.AddModulesAsync(typeof(AdministrativeModule).Assembly, host.Services);
+        Assert.NotEmpty(commands.Commands);
+        Assert.All(commands.Commands, command => Assert.Equal(RunMode.Sync, command.RunMode));
+        Assert.Contains(commands.Commands, command => command.Aliases.Contains("role setting"));
+    }
+
+    private static TaskCompletionSource NewCompletion() => new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public sealed class BlockingCommandState
+    {
+        private readonly BoundedMessageWaiter<string> _waiter;
+        internal BlockingCommandState(BoundedMessageWaiter<string> waiter) => _waiter = waiter;
+        public TaskCompletionSource Started { get; } = NewCompletion();
+        public string? Answer { get; private set; }
+        public async Task RunAsync()
+        {
+            var answer = _waiter.WaitAsync(10, 20, TimeSpan.FromSeconds(2));
+            Started.SetResult();
+            Answer = await answer;
+        }
+    }
+
+    public class BlockingModule(BlockingCommandState state) : ModuleBase<ICommandContext>
+    {
+        [Command("blocking", RunMode = RunMode.Sync)]
+        public Task BlockingAsync() => state.RunAsync();
+    }
+
+    public class CommandContextProxy : DispatchProxy
+    {
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+            => targetMethod?.Name switch
+            {
+                "get_Guild" => null,
+                "get_User" => DispatchProxy.Create<IUser, CommandContextProxy>(),
+                "get_Channel" => DispatchProxy.Create<IMessageChannel, CommandContextProxy>(),
+                "get_Message" => DispatchProxy.Create<IUserMessage, CommandContextProxy>(),
+                "get_Client" => DispatchProxy.Create<IDiscordClient, CommandContextProxy>(),
+                "get_CurrentUser" => DispatchProxy.Create<ISelfUser, CommandContextProxy>(),
+                "get_Id" => 1UL,
+                "get_Username" => "test-user",
+                "get_Content" => "blocking",
+                "get_IsBot" => false,
+                _ => throw new NotSupportedException(targetMethod?.Name)
+            };
     }
 }

--- a/BeanBot.Tests/Hosting/BeanBotApplicationTests.cs
+++ b/BeanBot.Tests/Hosting/BeanBotApplicationTests.cs
@@ -61,6 +61,64 @@ public class BeanBotApplicationTests
     }
 
     [Fact]
+    public async Task StopAsync_WaitsForCommandDrainBeforeContinuingShutdown()
+    {
+        var commandDrain = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var commandStopStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var runtime = new RecordingRuntime
+        {
+            IncompleteOperation = "stop-command",
+            IncompleteCompletion = commandDrain,
+            OperationRecorded = operation =>
+            {
+                if (operation == "stop-command")
+                {
+                    commandStopStarted.TrySetResult();
+                }
+            }
+        };
+        var application = new BeanBotApplication(
+            runtime,
+            NullLogger<BeanBotApplication>.Instance,
+            TimeSpan.FromSeconds(1));
+
+        var stopTask = application.StopAsync(CancellationToken.None);
+        await commandStopStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.DoesNotContain("stop-message-waiter", runtime.Calls);
+        Assert.DoesNotContain("stop-discord", runtime.Calls);
+        Assert.DoesNotContain("dispose-discord", runtime.Calls);
+
+        commandDrain.TrySetResult();
+        await stopTask.WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.Contains("stop-message-waiter", runtime.Calls);
+        Assert.Contains("stop-discord", runtime.Calls);
+        Assert.Contains("dispose-discord", runtime.Calls);
+    }
+
+    [Fact]
+    public async Task StopAsync_CommandDrainTimeout_SkipsDiscordShutdownAndDisposal()
+    {
+        var runtime = new RecordingRuntime
+        {
+            CommandServicesDrained = false
+        };
+        var application = new BeanBotApplication(runtime, NullLogger<BeanBotApplication>.Instance);
+
+        await Assert.ThrowsAsync<TimeoutException>(
+            () => application.StopAsync(CancellationToken.None));
+
+        Assert.Contains("stop-message-waiter", runtime.Calls);
+        Assert.Contains("stop-health", runtime.Calls);
+        Assert.DoesNotContain("stop-discord", runtime.Calls);
+        Assert.DoesNotContain("dispose-discord", runtime.Calls);
+        Assert.Equal(2, runtime.Calls.Count(call => call == "flush-alerts"));
+    }
+
+    [Fact]
     public async Task StopAsync_UnfinishedDiscordStartup_SkipsDiscordShutdownAndDisposal()
     {
         var runtime = new RecordingRuntime
@@ -288,6 +346,7 @@ public class BeanBotApplicationTests
         public bool HasActiveDiscordLifecycleOperation { get; set; }
         public bool CanDisposeDiscordClient { get; private set; }
         public bool HealthStopTokenWasAlreadyCanceled { get; private set; }
+        public bool CommandServicesDrained { get; init; } = true;
         private bool _failureThrown;
 
         public void SubscribeApplicationEvents() => Record("subscribe-events");
@@ -301,7 +360,11 @@ public class BeanBotApplicationTests
         public void StopReactionServices() => Record("stop-reaction");
         public void StopNewMemberEvents() => Record("stop-new-member");
         public void StopEditedMessageEvents() => Record("stop-edited-message");
-        public void StopCommandServices() => Record("stop-command");
+        public async Task<bool> StopCommandServicesAsync()
+        {
+            await RecordAsync("stop-command");
+            return CommandServicesDrained;
+        }
         public void StopMessageWaiter() => Record("stop-message-waiter");
         public void StopPaginator() => Record("stop-paginator");
         public void UnsubscribeDiscordLog() => Record("unsubscribe-discord-log");
@@ -348,6 +411,7 @@ public class BeanBotApplicationTests
             if (IncompleteOperation == operation)
             {
                 Calls.Add(operation);
+                OperationRecorded?.Invoke(operation);
                 if (ActivateDiscordLifecycleOnIncompleteOperation)
                 {
                     HasActiveDiscordLifecycleOperation = true;

--- a/BeanBot.Tests/Integration/BeanBotHostIntegrationTests.cs
+++ b/BeanBot.Tests/Integration/BeanBotHostIntegrationTests.cs
@@ -315,7 +315,11 @@ public class BeanBotHostIntegrationTests
         public void StopReactionServices() => Calls.Add("stop-reaction");
         public void StopNewMemberEvents() => Calls.Add("stop-new-member");
         public void StopEditedMessageEvents() => Calls.Add("stop-edited-message");
-        public void StopCommandServices() => Calls.Add("stop-command");
+        public Task<bool> StopCommandServicesAsync()
+        {
+            Calls.Add("stop-command");
+            return Task.FromResult(true);
+        }
         public void StopMessageWaiter() => Calls.Add("stop-message-waiter");
         public void StopPaginator() => Calls.Add("stop-paginator");
         public void UnsubscribeDiscordLog() => Calls.Add("unsubscribe-discord-log");

--- a/BeanBot/Discord/Commands/AdministrativeModule.cs
+++ b/BeanBot/Discord/Commands/AdministrativeModule.cs
@@ -47,7 +47,7 @@ public class AdministrativeModule : ModuleBase<SocketCommandContext>
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    [Command("role setting", RunMode = RunMode.Async)]
+    [Command("role setting", RunMode = RunMode.Sync)]
     [Summary("Will create a message for auto-role based on reactions")]
     [Alias("rolesetting", "role settings", "rolesettings")]
     [Remarks("role setting")]

--- a/BeanBot/Discord/Events/CommandHandler.cs
+++ b/BeanBot/Discord/Events/CommandHandler.cs
@@ -36,6 +36,9 @@ public sealed class CommandHandler : IDisposable
     private readonly LogHandler _logHandler;
     private readonly LegacyCommandFeedbackResponder _feedbackResponder;
     private readonly ILogger<CommandHandler> _logger;
+    private readonly object _lifecycleGate = new();
+    private readonly LegacyCommandExecutionCoordinator _executionCoordinator = new();
+    private Task<LegacyCommandDrainResult>? _stopTask;
     private bool _initialized;
 
     public CommandHandler(
@@ -58,28 +61,54 @@ public sealed class CommandHandler : IDisposable
 
     public async Task InitializeCommandsAsync()
     {
-        if (_initialized)
+        lock (_lifecycleGate)
         {
-            return;
+            if (_initialized || _executionCoordinator.IsStopping)
+            {
+                return;
+            }
         }
 
         BeanBotLog.CommandsInstalling(_logger);
         await _commandService.AddModulesAsync(assembly: Assembly.GetEntryAssembly() ?? typeof(CommandHandler).Assembly,
                                               services: _services);
-        _discordClient.MessageReceived += HandleCommandAsync;
-        _commandService.CommandExecuted += _logHandler.LogCommands;
-        _commandService.CommandExecuted += _feedbackResponder.RespondAsync;
-        _initialized = true;
+
+        lock (_lifecycleGate)
+        {
+            if (_initialized || _executionCoordinator.IsStopping)
+            {
+                return;
+            }
+
+            _discordClient.MessageReceived += HandleCommandAsync;
+            _commandService.CommandExecuted += _logHandler.LogCommands;
+            _commandService.CommandExecuted += _feedbackResponder.RespondAsync;
+            _initialized = true;
+        }
+    }
+
+    public Task<LegacyCommandDrainResult> StopAsync()
+    {
+        lock (_lifecycleGate)
+        {
+            if (_stopTask is not null)
+            {
+                return _stopTask;
+            }
+
+            _executionCoordinator.StopAdmission();
+            UnsubscribeCore();
+            _stopTask = DrainCommandsAsync();
+            return _stopTask;
+        }
     }
 
     public void Dispose()
     {
-        if (_initialized)
+        lock (_lifecycleGate)
         {
-            _discordClient.MessageReceived -= HandleCommandAsync;
-            _commandService.CommandExecuted -= _feedbackResponder.RespondAsync;
-            _commandService.CommandExecuted -= _logHandler.LogCommands;
-            _initialized = false;
+            _executionCoordinator.StopAdmission();
+            UnsubscribeCore();
         }
     }
 
@@ -117,11 +146,26 @@ public sealed class CommandHandler : IDisposable
             return;
         }
 
-        var context = new SocketCommandContext(_discordClient, discordMessage);
-        await _commandService.ExecuteAsync(
-            context: context,
-            argPos: argPos,
-            services: _services);
+        var admissionResult = await _executionCoordinator.TryExecuteAsync(() =>
+        {
+            var context = new SocketCommandContext(_discordClient, discordMessage);
+            return _commandService.ExecuteAsync(
+                context: context,
+                argPos: argPos,
+                services: _services);
+        });
+
+        if (admissionResult == LegacyCommandAdmissionResult.RejectedCapacity)
+        {
+            LegacyCommandLog.CapacityRejected(
+                _logger,
+                _executionCoordinator.ActiveExecutionCount,
+                _executionCoordinator.MaximumConcurrentExecutions);
+        }
+        else if (admissionResult == LegacyCommandAdmissionResult.RejectedStopping)
+        {
+            LegacyCommandLog.ShutdownRejected(_logger);
+        }
     }
 
     internal CommandPrefixKind GetCommandPrefix(SocketUserMessage discordMessage, ref int argPos)
@@ -158,4 +202,32 @@ public sealed class CommandHandler : IDisposable
 
     internal static bool MessageIsSystemMessage([NotNullWhen(false)] SocketUserMessage? discordMessage)
         => discordMessage == null;
+
+    private async Task<LegacyCommandDrainResult> DrainCommandsAsync()
+    {
+        var result = await _executionCoordinator.DrainAsync(
+            exception => LegacyCommandLog.LateFailure(_logger, exception));
+        if (!result.IsDrained)
+        {
+            LegacyCommandLog.DrainTimedOut(
+                _logger,
+                result.SurvivingExecutionCount,
+                LegacyCommandExecutionCoordinator.DefaultDrainTimeout);
+        }
+
+        return result;
+    }
+
+    private void UnsubscribeCore()
+    {
+        if (!_initialized)
+        {
+            return;
+        }
+
+        _discordClient.MessageReceived -= HandleCommandAsync;
+        _commandService.CommandExecuted -= _feedbackResponder.RespondAsync;
+        _commandService.CommandExecuted -= _logHandler.LogCommands;
+        _initialized = false;
+    }
 }

--- a/BeanBot/Discord/Events/CommandHandler.cs
+++ b/BeanBot/Discord/Events/CommandHandler.cs
@@ -87,7 +87,7 @@ public sealed class CommandHandler : IDisposable
         }
     }
 
-    public Task<LegacyCommandDrainResult> StopAsync()
+    internal Task<LegacyCommandDrainResult> StopAsync()
     {
         lock (_lifecycleGate)
         {

--- a/BeanBot/Discord/Events/CommandHandler.cs
+++ b/BeanBot/Discord/Events/CommandHandler.cs
@@ -39,6 +39,8 @@ public sealed class CommandHandler : IDisposable
     private readonly object _lifecycleGate = new();
     private readonly LegacyCommandExecutionCoordinator _executionCoordinator = new();
     private Task<LegacyCommandDrainResult>? _stopTask;
+    private Task? _completionUnsubscribeTask;
+    private bool _completionSubscribed;
     private bool _initialized;
 
     public CommandHandler(
@@ -83,6 +85,7 @@ public sealed class CommandHandler : IDisposable
             _discordClient.MessageReceived += HandleCommandAsync;
             _commandService.CommandExecuted += _logHandler.LogCommands;
             _commandService.CommandExecuted += _feedbackResponder.RespondAsync;
+            _completionSubscribed = true;
             _initialized = true;
         }
     }
@@ -97,7 +100,7 @@ public sealed class CommandHandler : IDisposable
             }
 
             _executionCoordinator.StopAdmission();
-            UnsubscribeCore();
+            StopSubscriptionsCore();
             _stopTask = DrainCommandsAsync();
             return _stopTask;
         }
@@ -108,16 +111,16 @@ public sealed class CommandHandler : IDisposable
         lock (_lifecycleGate)
         {
             _executionCoordinator.StopAdmission();
-            UnsubscribeCore();
+            StopSubscriptionsCore();
         }
     }
 
-    internal async Task HandleCommandAsync(SocketMessage messageEvent)
+    internal Task HandleCommandAsync(SocketMessage messageEvent)
     {
         var discordMessage = messageEvent as SocketUserMessage;
         if (MessageIsSystemMessage(discordMessage))
         {
-            return; // Return and ignore if the message is a Discord system message.
+            return Task.CompletedTask;
         }
 
         var argPos = 0;
@@ -138,22 +141,22 @@ public sealed class CommandHandler : IDisposable
         if (route == CommandMessageRoute.PublishToMessageWaiter)
         {
             _messageWaiter.TryPublish(messageEvent);
-            return;
+            return Task.CompletedTask;
         }
 
         if (route == CommandMessageRoute.Ignore)
         {
-            return;
+            return Task.CompletedTask;
         }
 
-        var admissionResult = await _executionCoordinator.TryExecuteAsync(() =>
+        var admissionResult = _executionCoordinator.TryStart(() =>
         {
             var context = new SocketCommandContext(_discordClient, discordMessage);
             return _commandService.ExecuteAsync(
                 context: context,
                 argPos: argPos,
                 services: _services);
-        });
+        }, exception => LegacyCommandLog.LateFailure(_logger, exception), out _);
 
         if (admissionResult == LegacyCommandAdmissionResult.RejectedCapacity)
         {
@@ -166,6 +169,8 @@ public sealed class CommandHandler : IDisposable
         {
             LegacyCommandLog.ShutdownRejected(_logger);
         }
+
+        return Task.CompletedTask;
     }
 
     internal CommandPrefixKind GetCommandPrefix(SocketUserMessage discordMessage, ref int argPos)
@@ -205,8 +210,7 @@ public sealed class CommandHandler : IDisposable
 
     private async Task<LegacyCommandDrainResult> DrainCommandsAsync()
     {
-        var result = await _executionCoordinator.DrainAsync(
-            exception => LegacyCommandLog.LateFailure(_logger, exception));
+        var result = await _executionCoordinator.DrainAsync();
         if (!result.IsDrained)
         {
             LegacyCommandLog.DrainTimedOut(
@@ -218,16 +222,26 @@ public sealed class CommandHandler : IDisposable
         return result;
     }
 
-    private void UnsubscribeCore()
+    private void StopSubscriptionsCore()
     {
-        if (!_initialized)
+        if (_initialized)
         {
-            return;
+            _discordClient.MessageReceived -= HandleCommandAsync;
+            _initialized = false;
         }
 
-        _discordClient.MessageReceived -= HandleCommandAsync;
-        _commandService.CommandExecuted -= _feedbackResponder.RespondAsync;
-        _commandService.CommandExecuted -= _logHandler.LogCommands;
-        _initialized = false;
+        _completionUnsubscribeTask ??= UnsubscribeCompletionWhenDrainedAsync();
+    }
+
+    private async Task UnsubscribeCompletionWhenDrainedAsync()
+    {
+        await _executionCoordinator.WhenDrained.ConfigureAwait(false);
+        lock (_lifecycleGate)
+        {
+            if (!_completionSubscribed) return;
+            _commandService.CommandExecuted -= _feedbackResponder.RespondAsync;
+            _commandService.CommandExecuted -= _logHandler.LogCommands;
+            _completionSubscribed = false;
+        }
     }
 }

--- a/BeanBot/Discord/Events/LegacyCommandExecutionCoordinator.cs
+++ b/BeanBot/Discord/Events/LegacyCommandExecutionCoordinator.cs
@@ -177,9 +177,9 @@ internal sealed class LegacyCommandExecutionCoordinator
         }
     }
 
-    private static Task ObserveCompletionAsync(Task executionTask)
+    private static Task<AggregateException?> ObserveCompletionAsync(Task executionTask)
         => executionTask.ContinueWith(
-            static completedTask => _ = completedTask.Exception,
+            static completedTask => completedTask.Exception,
             CancellationToken.None,
             TaskContinuationOptions.ExecuteSynchronously,
             TaskScheduler.Default);

--- a/BeanBot/Discord/Events/LegacyCommandExecutionCoordinator.cs
+++ b/BeanBot/Discord/Events/LegacyCommandExecutionCoordinator.cs
@@ -1,0 +1,195 @@
+namespace BeanBot.Discord.Events;
+
+internal enum LegacyCommandAdmissionResult
+{
+    Executed,
+    RejectedStopping,
+    RejectedCapacity
+}
+
+internal readonly record struct LegacyCommandDrainResult(
+    bool IsDrained,
+    int SurvivingExecutionCount);
+
+internal sealed class LegacyCommandExecutionCoordinator
+{
+    internal const int DefaultMaximumConcurrentExecutions = 16;
+    internal static readonly TimeSpan DefaultDrainTimeout = TimeSpan.FromSeconds(5);
+
+    private readonly object _gate = new();
+    private readonly HashSet<TrackedExecution> _activeExecutions = [];
+    private readonly int _maximumConcurrentExecutions;
+    private readonly TimeSpan _drainTimeout;
+    private bool _stopping;
+
+    internal LegacyCommandExecutionCoordinator(
+        int maximumConcurrentExecutions = DefaultMaximumConcurrentExecutions,
+        TimeSpan? drainTimeout = null)
+    {
+        if (maximumConcurrentExecutions <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maximumConcurrentExecutions));
+        }
+
+        _maximumConcurrentExecutions = maximumConcurrentExecutions;
+        _drainTimeout = drainTimeout ?? DefaultDrainTimeout;
+        if (_drainTimeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(drainTimeout));
+        }
+    }
+
+    internal int MaximumConcurrentExecutions => _maximumConcurrentExecutions;
+
+    internal int ActiveExecutionCount
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _activeExecutions.Count;
+            }
+        }
+    }
+
+    internal bool IsStopping
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _stopping;
+            }
+        }
+    }
+
+    internal async Task<LegacyCommandAdmissionResult> TryExecuteAsync(Func<Task> execute)
+    {
+        ArgumentNullException.ThrowIfNull(execute);
+
+        TrackedExecution trackedExecution;
+        TaskCompletionSource<Func<Task>> startSource;
+        lock (_gate)
+        {
+            if (_stopping)
+            {
+                return LegacyCommandAdmissionResult.RejectedStopping;
+            }
+
+            if (_activeExecutions.Count >= _maximumConcurrentExecutions)
+            {
+                return LegacyCommandAdmissionResult.RejectedCapacity;
+            }
+
+            trackedExecution = new TrackedExecution();
+            startSource = new TaskCompletionSource<Func<Task>>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            trackedExecution.ExecutionTask = RunTrackedExecutionAsync(
+                trackedExecution,
+                startSource.Task);
+            _activeExecutions.Add(trackedExecution);
+        }
+
+        startSource.TrySetResult(execute);
+        await trackedExecution.ExecutionTask.ConfigureAwait(false);
+        return LegacyCommandAdmissionResult.Executed;
+    }
+
+    internal void StopAdmission()
+    {
+        lock (_gate)
+        {
+            _stopping = true;
+        }
+    }
+
+    internal async Task<LegacyCommandDrainResult> DrainAsync(Action<Exception> lateFailureObserver)
+    {
+        ArgumentNullException.ThrowIfNull(lateFailureObserver);
+
+        TrackedExecution[] snapshot;
+        lock (_gate)
+        {
+            _stopping = true;
+            snapshot = [.. _activeExecutions];
+        }
+
+        if (snapshot.Length == 0)
+        {
+            return new LegacyCommandDrainResult(true, 0);
+        }
+
+        var completionTasks = snapshot
+            .Select(static execution => ObserveCompletionAsync(execution.ExecutionTask))
+            .ToArray();
+
+        try
+        {
+            await Task.WhenAll(completionTasks)
+                .WaitAsync(_drainTimeout)
+                .ConfigureAwait(false);
+            return new LegacyCommandDrainResult(true, 0);
+        }
+        catch (TimeoutException)
+        {
+            TrackedExecution[] survivors;
+            lock (_gate)
+            {
+                survivors = [.. _activeExecutions];
+            }
+
+            foreach (var survivor in survivors)
+            {
+                _ = survivor.ExecutionTask.ContinueWith(
+                    static (completedTask, state) =>
+                    {
+                        var observer = (Action<Exception>)state!;
+                        observer(completedTask.Exception!.GetBaseException());
+                    },
+                    lateFailureObserver,
+                    CancellationToken.None,
+                    TaskContinuationOptions.OnlyOnFaulted |
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+            }
+
+            return new LegacyCommandDrainResult(false, survivors.Length);
+        }
+    }
+
+    private async Task RunTrackedExecutionAsync(
+        TrackedExecution trackedExecution,
+        Task<Func<Task>> startTask)
+    {
+        try
+        {
+            var execute = await startTask.ConfigureAwait(false);
+            await execute().ConfigureAwait(false);
+        }
+        finally
+        {
+            lock (_gate)
+            {
+                _activeExecutions.Remove(trackedExecution);
+            }
+        }
+    }
+
+    private static async Task ObserveCompletionAsync(Task executionTask)
+    {
+        try
+        {
+            await executionTask.ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // The command event caller receives the original fault. Draining only needs
+            // to observe completion so command failures do not become shutdown failures.
+        }
+    }
+
+    private sealed class TrackedExecution
+    {
+        public Task ExecutionTask { get; set; } = Task.CompletedTask;
+    }
+}

--- a/BeanBot/Discord/Events/LegacyCommandExecutionCoordinator.cs
+++ b/BeanBot/Discord/Events/LegacyCommandExecutionCoordinator.cs
@@ -135,6 +135,11 @@ internal sealed class LegacyCommandExecutionCoordinator
                 survivors = [.. _activeExecutions];
             }
 
+            if (survivors.Length == 0)
+            {
+                return new LegacyCommandDrainResult(true, 0);
+            }
+
             foreach (var survivor in survivors)
             {
                 _ = survivor.ExecutionTask.ContinueWith(
@@ -172,18 +177,12 @@ internal sealed class LegacyCommandExecutionCoordinator
         }
     }
 
-    private static async Task ObserveCompletionAsync(Task executionTask)
-    {
-        try
-        {
-            await executionTask.ConfigureAwait(false);
-        }
-        catch (Exception)
-        {
-            // The command event caller receives the original fault. Draining only needs
-            // to observe completion so command failures do not become shutdown failures.
-        }
-    }
+    private static Task ObserveCompletionAsync(Task executionTask)
+        => executionTask.ContinueWith(
+            static completedTask => _ = completedTask.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
 
     private sealed class TrackedExecution
     {

--- a/BeanBot/Discord/Events/LegacyCommandExecutionCoordinator.cs
+++ b/BeanBot/Discord/Events/LegacyCommandExecutionCoordinator.cs
@@ -26,10 +26,7 @@ internal sealed class LegacyCommandExecutionCoordinator
         int maximumConcurrentExecutions = DefaultMaximumConcurrentExecutions,
         TimeSpan? drainTimeout = null)
     {
-        if (maximumConcurrentExecutions <= 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(maximumConcurrentExecutions));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumConcurrentExecutions);
 
         _maximumConcurrentExecutions = maximumConcurrentExecutions;
         _drainTimeout = drainTimeout ?? DefaultDrainTimeout;

--- a/BeanBot/Discord/Events/LegacyCommandExecutionCoordinator.cs
+++ b/BeanBot/Discord/Events/LegacyCommandExecutionCoordinator.cs
@@ -2,22 +2,20 @@ namespace BeanBot.Discord.Events;
 
 internal enum LegacyCommandAdmissionResult
 {
-    Executed,
+    Admitted,
     RejectedStopping,
     RejectedCapacity
 }
 
-internal readonly record struct LegacyCommandDrainResult(
-    bool IsDrained,
-    int SurvivingExecutionCount);
+internal readonly record struct LegacyCommandDrainResult(bool IsDrained, int SurvivingExecutionCount);
 
 internal sealed class LegacyCommandExecutionCoordinator
 {
     internal const int DefaultMaximumConcurrentExecutions = 16;
     internal static readonly TimeSpan DefaultDrainTimeout = TimeSpan.FromSeconds(5);
-
     private readonly object _gate = new();
-    private readonly HashSet<TrackedExecution> _activeExecutions = [];
+    private readonly HashSet<Task> _activeExecutions = [];
+    private readonly TaskCompletionSource _drained = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly int _maximumConcurrentExecutions;
     private readonly TimeSpan _drainTimeout;
     private bool _stopping;
@@ -27,25 +25,18 @@ internal sealed class LegacyCommandExecutionCoordinator
         TimeSpan? drainTimeout = null)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumConcurrentExecutions);
-
         _maximumConcurrentExecutions = maximumConcurrentExecutions;
         _drainTimeout = drainTimeout ?? DefaultDrainTimeout;
-        if (_drainTimeout <= TimeSpan.Zero)
-        {
-            throw new ArgumentOutOfRangeException(nameof(drainTimeout));
-        }
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(_drainTimeout, TimeSpan.Zero);
     }
 
     internal int MaximumConcurrentExecutions => _maximumConcurrentExecutions;
-
+    internal Task WhenDrained => _drained.Task;
     internal int ActiveExecutionCount
     {
         get
         {
-            lock (_gate)
-            {
-                return _activeExecutions.Count;
-            }
+            lock (_gate) { return _activeExecutions.Count; }
         }
     }
 
@@ -53,43 +44,39 @@ internal sealed class LegacyCommandExecutionCoordinator
     {
         get
         {
-            lock (_gate)
-            {
-                return _stopping;
-            }
+            lock (_gate) { return _stopping; }
         }
     }
 
-    internal async Task<LegacyCommandAdmissionResult> TryExecuteAsync(Func<Task> execute)
+    internal LegacyCommandAdmissionResult TryStart(
+        Func<Task> execute,
+        Action<Exception> reportFailure,
+        out Task completion)
     {
         ArgumentNullException.ThrowIfNull(execute);
-
-        TrackedExecution trackedExecution;
-        TaskCompletionSource<Func<Task>> startSource;
+        ArgumentNullException.ThrowIfNull(reportFailure);
+        TaskCompletionSource start;
         lock (_gate)
         {
+            completion = Task.CompletedTask;
             if (_stopping)
             {
                 return LegacyCommandAdmissionResult.RejectedStopping;
             }
-
             if (_activeExecutions.Count >= _maximumConcurrentExecutions)
             {
                 return LegacyCommandAdmissionResult.RejectedCapacity;
             }
 
-            trackedExecution = new TrackedExecution();
-            startSource = new TaskCompletionSource<Func<Task>>(
-                TaskCreationOptions.RunContinuationsAsynchronously);
-            trackedExecution.ExecutionTask = RunTrackedExecutionAsync(
-                trackedExecution,
-                startSource.Task);
-            _activeExecutions.Add(trackedExecution);
+            start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            completion = RunAsync(start.Task, execute, reportFailure);
+            _activeExecutions.Add(completion);
+            _ = completion.ContinueWith(CompleteExecution, CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
         }
 
-        startSource.TrySetResult(execute);
-        await trackedExecution.ExecutionTask.ConfigureAwait(false);
-        return LegacyCommandAdmissionResult.Executed;
+        start.SetResult();
+        return LegacyCommandAdmissionResult.Admitted;
     }
 
     internal void StopAdmission()
@@ -97,95 +84,65 @@ internal sealed class LegacyCommandExecutionCoordinator
         lock (_gate)
         {
             _stopping = true;
+            if (_activeExecutions.Count == 0)
+            {
+                _drained.TrySetResult();
+            }
         }
     }
 
-    internal async Task<LegacyCommandDrainResult> DrainAsync(Action<Exception> lateFailureObserver)
+    internal async Task<LegacyCommandDrainResult> DrainAsync()
     {
-        ArgumentNullException.ThrowIfNull(lateFailureObserver);
-
-        TrackedExecution[] snapshot;
-        lock (_gate)
-        {
-            _stopping = true;
-            snapshot = [.. _activeExecutions];
-        }
-
-        if (snapshot.Length == 0)
-        {
-            return new LegacyCommandDrainResult(true, 0);
-        }
-
-        var completionTasks = snapshot
-            .Select(static execution => ObserveCompletionAsync(execution.ExecutionTask))
-            .ToArray();
-
+        StopAdmission();
         try
         {
-            await Task.WhenAll(completionTasks)
-                .WaitAsync(_drainTimeout)
-                .ConfigureAwait(false);
+            await WhenDrained.WaitAsync(_drainTimeout).ConfigureAwait(false);
             return new LegacyCommandDrainResult(true, 0);
         }
         catch (TimeoutException)
         {
-            TrackedExecution[] survivors;
             lock (_gate)
             {
-                survivors = [.. _activeExecutions];
+                return new LegacyCommandDrainResult(_activeExecutions.Count == 0, _activeExecutions.Count);
             }
-
-            if (survivors.Length == 0)
-            {
-                return new LegacyCommandDrainResult(true, 0);
-            }
-
-            foreach (var survivor in survivors)
-            {
-                _ = survivor.ExecutionTask.ContinueWith(
-                    static (completedTask, state) =>
-                    {
-                        var observer = (Action<Exception>)state!;
-                        observer(completedTask.Exception!.GetBaseException());
-                    },
-                    lateFailureObserver,
-                    CancellationToken.None,
-                    TaskContinuationOptions.OnlyOnFaulted |
-                    TaskContinuationOptions.ExecuteSynchronously,
-                    TaskScheduler.Default);
-            }
-
-            return new LegacyCommandDrainResult(false, survivors.Length);
         }
     }
 
-    private async Task RunTrackedExecutionAsync(
-        TrackedExecution trackedExecution,
-        Task<Func<Task>> startTask)
+    private static async Task RunAsync(Task start, Func<Task> execute, Action<Exception> reportFailure)
     {
+        await start.ConfigureAwait(false);
         try
         {
-            var execute = await startTask.ConfigureAwait(false);
             await execute().ConfigureAwait(false);
         }
-        finally
+        catch (OperationCanceledException)
         {
-            lock (_gate)
+            throw;
+        }
+        catch (Exception exception)
+        {
+            try
             {
-                _activeExecutions.Remove(trackedExecution);
+                reportFailure(exception);
             }
+            catch (Exception)
+            {
+                // Reporting must not replace the original failure or create an unowned fault.
+            }
+            throw;
         }
     }
 
-    private static Task<AggregateException?> ObserveCompletionAsync(Task executionTask)
-        => executionTask.ContinueWith(
-            static completedTask => completedTask.Exception,
-            CancellationToken.None,
-            TaskContinuationOptions.ExecuteSynchronously,
-            TaskScheduler.Default);
-
-    private sealed class TrackedExecution
+    private void CompleteExecution(Task completion)
     {
-        public Task ExecutionTask { get; set; } = Task.CompletedTask;
+        _ = completion.Exception;
+        lock (_gate)
+        {
+            _activeExecutions.Remove(completion);
+            if (_stopping && _activeExecutions.Count == 0)
+            {
+                _drained.TrySetResult();
+            }
+        }
     }
 }

--- a/BeanBot/Discord/Events/LegacyCommandLog.cs
+++ b/BeanBot/Discord/Events/LegacyCommandLog.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Logging;
+
+namespace BeanBot.Discord.Events;
+
+internal static partial class LegacyCommandLog
+{
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Rejected a legacy command because {ActiveExecutionCount} execution(s) already occupy the configured limit {MaximumConcurrentExecutions}")]
+    internal static partial void CapacityRejected(
+        ILogger logger,
+        int activeExecutionCount,
+        int maximumConcurrentExecutions);
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Rejected a legacy command because command execution is stopping")]
+    internal static partial void ShutdownRejected(ILogger logger);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Timed out draining {SurvivingExecutionCount} legacy command execution(s) after {DrainTimeout}; Discord teardown will be skipped while known command work survives")]
+    internal static partial void DrainTimedOut(
+        ILogger logger,
+        int survivingExecutionCount,
+        TimeSpan drainTimeout);
+
+    [LoggerMessage(
+        Level = LogLevel.Error,
+        Message = "A legacy command failed after the bounded command-drain wait ended")]
+    internal static partial void LateFailure(ILogger logger, Exception exception);
+}

--- a/BeanBot/Discord/Events/LegacyCommandLog.cs
+++ b/BeanBot/Discord/Events/LegacyCommandLog.cs
@@ -6,7 +6,7 @@ internal static partial class LegacyCommandLog
 {
     [LoggerMessage(
         Level = LogLevel.Debug,
-        Message = "Rejected a legacy command because {ActiveExecutionCount} execution(s) already occupy the configured limit {MaximumConcurrentExecutions}")]
+        Message = "Rejected a legacy command because the configured concurrent execution limit {MaximumConcurrentExecutions} was full at admission; {ActiveExecutionCount} execution(s) remain active when logged")]
     internal static partial void CapacityRejected(
         ILogger logger,
         int activeExecutionCount,

--- a/BeanBot/Discord/Events/LegacyCommandLog.cs
+++ b/BeanBot/Discord/Events/LegacyCommandLog.cs
@@ -27,6 +27,6 @@ internal static partial class LegacyCommandLog
 
     [LoggerMessage(
         Level = LogLevel.Error,
-        Message = "A legacy command failed after the bounded command-drain wait ended")]
+        Message = "An owned legacy command execution failed")]
     internal static partial void LateFailure(ILogger logger, Exception exception);
 }

--- a/BeanBot/Hosting/BeanBotApplication.cs
+++ b/BeanBot/Hosting/BeanBotApplication.cs
@@ -17,7 +17,7 @@ internal interface IBeanBotRuntime
     void StopReactionServices();
     void StopNewMemberEvents();
     void StopEditedMessageEvents();
-    void StopCommandServices();
+    Task<bool> StopCommandServicesAsync();
     void StopMessageWaiter();
     void StopPaginator();
     void UnsubscribeDiscordLog();
@@ -82,6 +82,7 @@ internal sealed class BeanBotApplication : IBeanBotApplication
         }
 
         Exception? firstFailure = null;
+        var commandServicesDrained = false;
 
         async Task RunStageAsync(
             string stageName,
@@ -134,7 +135,17 @@ internal sealed class BeanBotApplication : IBeanBotApplication
         await RunSynchronousStageAsync("reaction-services", _runtime.StopReactionServices);
         await RunSynchronousStageAsync("new-member-events", _runtime.StopNewMemberEvents);
         await RunSynchronousStageAsync("edited-message-events", _runtime.StopEditedMessageEvents);
-        await RunSynchronousStageAsync("command-services", _runtime.StopCommandServices);
+        await RunStageAsync(
+            "command-services",
+            async () =>
+            {
+                commandServicesDrained = await _runtime.StopCommandServicesAsync();
+                if (!commandServicesDrained)
+                {
+                    throw new TimeoutException(
+                        "Legacy command execution did not drain before the command-services shutdown bound.");
+                }
+            });
         await RunSynchronousStageAsync("message-waiter", _runtime.StopMessageWaiter);
         await RunSynchronousStageAsync("paginator", _runtime.StopPaginator);
         await RunSynchronousStageAsync("discord-log", _runtime.UnsubscribeDiscordLog);
@@ -147,7 +158,8 @@ internal sealed class BeanBotApplication : IBeanBotApplication
         var canStopDiscord = false;
         await RunSynchronousStageAsync(
             "discord-startup-state",
-            () => canStopDiscord = !_runtime.HasActiveDiscordLifecycleOperation);
+            () => canStopDiscord = commandServicesDrained &&
+                !_runtime.HasActiveDiscordLifecycleOperation);
         if (!canStopDiscord)
         {
             BeanBotLog.DiscordStopSkipped(_logger);

--- a/BeanBot/Hosting/BeanBotRuntime.cs
+++ b/BeanBot/Hosting/BeanBotRuntime.cs
@@ -109,7 +109,11 @@ internal sealed class BeanBotRuntime : IBeanBotRuntime
 
     public void StopEditedMessageEvents() => _editMessageHandler.Dispose();
 
-    public void StopCommandServices() => _commandHandler.Dispose();
+    public async Task<bool> StopCommandServicesAsync()
+    {
+        var result = await _commandHandler.StopAsync();
+        return result.IsDrained;
+    }
 
     public void StopMessageWaiter() => _messageWaiter.Dispose();
 

--- a/BeanBot/Hosting/BeanBotServiceCollectionExtensions.cs
+++ b/BeanBot/Hosting/BeanBotServiceCollectionExtensions.cs
@@ -45,6 +45,7 @@ internal static class BeanBotServiceCollectionExtensions
         services.AddSingleton(_ => new CommandService(new CommandServiceConfig
         {
             LogLevel = LogSeverity.Verbose,
+            DefaultRunMode = RunMode.Sync,
             CaseSensitiveCommands = false
         }));
 


### PR DESCRIPTION
Closes #176

## Summary

- add a hard 16-command concurrent admission ceiling around legacy `%`, `succ `, and mention-prefix execution without introducing a queue
- keep bot/system messages and ordinary non-command traffic outside command capacity; existing message-waiter routing remains unchanged
- explicitly track admitted command work, stop admission before handler unsubscription, and boundedly drain in-flight commands during shutdown
- if command work survives the 5-second drain bound, continue safe non-Discord cleanup but skip normal Discord stop/logout/client disposal so the shared client is not torn down underneath known command work
- observe and log late command failures after a timed-out drain without logging message content or other sensitive data
- keep capacity-rejection diagnostics race-truthful by distinguishing the admission-time full condition from the active count observed later when logging

## Tests

- deterministic coordinator coverage for normal execution, concurrent admission/capacity rejection with no queue, bounded bookkeeping, failure/cancellation slot reuse, successful drain, drain timeout, late faults, and idempotent admission shutdown
- application shutdown coverage proving later teardown waits for command drain and Discord teardown is suppressed after a failed drain
- existing host integration runtime updated for the asynchronous command-stop contract; existing `%`, `succ `, mention-prefix, bot/system, and message-waiter routing tests remain green under the repository full gate

## Verification

- Final exact head: `9b2b513c7339f206dbf05d92c07907083dc7bcba`.
- Local focused/fast/full execution was unavailable because this automation runtime could not resolve `github.com`; no local PASS is claimed. Repository policy allows exact-head GitHub CI evidence when local infrastructure is the blocker.
- Repository Verification #305: **PASS** on the exact final head. The workflow checked out that exact SHA and completed repository-owned `./scripts/verify.sh full`, covering workflow/orchestration checks, locked restore, formatting/analyzers, Release build/tests with coverage baseline, diff/branch-integrity checks, vulnerable-package audit, Docker build, and hardened container smoke.
- CodeQL #139: **PASS** on the exact final head.
- Dependency Review #116: **PASS** on the exact final head.
- Fresh Verifier after the review repair: **PASS** against issue #176, current `develop`, the complete eight-file diff, final exact head, and current CI evidence.
- Fresh independent Reviewer after that PASS: **CLEAN**. No consequential correctness, Discord lifecycle, duplicate-subscription/message, unbounded-wait/queue, cancellation, persistence, health, security, test-quality, Docker/runtime, dependency/release, or scope-creep finding remains.
- Review-found repairs retained in the final diff: the drain timeout path rechecks live tracked work after the deadline so a timeout/completion race with zero survivors does not spuriously suppress Discord shutdown; completion observation uses a concrete task result type; and this review corrected the capacity-rejection log wording so a command finishing between rejection and logging cannot make the diagnostic misleading.
- Review threads: **0 open**; the capacity-diagnostic thread was fixed, replied to with exact-head evidence, and resolved.
- Branch policy: `fix/bound-legacy-command-execution` is **13 commits ahead / 0 behind** current `develop`; PR target remains `develop`.

## Manual validation

After deployment, smoke a normal prefix command and mention-prefix command. During a controlled graceful restart, optionally exercise shutdown while a representative command is active and confirm the expected drain/timeout diagnostics. No configuration, persistence, dependency, Docker, or release migration is required.