### PR TITLE
Harden legacy reaction-role role assignability

### DIFF
--- a/BeanBot.Tests/Discord/Commands/AdministrativeModuleRoleAssignabilityTests.cs
+++ b/BeanBot.Tests/Discord/Commands/AdministrativeModuleRoleAssignabilityTests.cs
@@ -3,12 +3,49 @@ using BeanBot.Discord.Commands;
 using BeanBot.Discord.ReactionRoles;
 using Discord;
 using Discord.Commands;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace BeanBot.Tests.Discord.Commands;
 
 public class AdministrativeModuleRoleAssignabilityTests
 {
+    [Fact]
+    public async Task SendRoleValidationMessageAsync_EveryoneRejectionDisablesAllMentions()
+    {
+        string? emittedText = null;
+        AllowedMentions? emittedMentions = null;
+        var sentMessage = DispatchProxy.Create<IUserMessage, DiscordProxy>();
+        var channel = DispatchProxy.Create<IMessageChannel, DiscordProxy>();
+        ((DiscordProxy)channel).InvokeMethod = (method, arguments) =>
+        {
+            Assert.Equal(nameof(IMessageChannel.SendMessageAsync), method.Name);
+            emittedText = Assert.IsType<string>(arguments[0]);
+            var mentionIndex = Array.FindIndex(method.GetParameters(), parameter => parameter.Name == "allowedMentions");
+            emittedMentions = Assert.IsType<AllowedMentions>(arguments[mentionIndex]);
+            return Task.FromResult(sentMessage);
+        };
+        var context = DispatchProxy.Create<ICommandContext, DiscordProxy>();
+        ((DiscordProxy)context).InvokeMethod = (method, _) => method.Name == "get_Channel"
+            ? channel
+            : throw new InvalidOperationException(method.Name);
+        using var sender = new LegacyCommandReplySender(
+            NullLogger<LegacyCommandReplySender>.Instance, 1, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), CancellationToken.None);
+        var text = AdministrativeModule.GetRoleValidationMessage(ReactionRoleAssignabilityStatus.EveryoneRole)!;
+
+        Assert.Same(sentMessage, await AdministrativeModule.SendRoleValidationMessageAsync(sender, context, text));
+
+        Assert.Contains("@everyone", emittedText);
+        Assert.Same(AllowedMentions.None, emittedMentions);
+    }
+
+    public class DiscordProxy : DispatchProxy
+    {
+        public Func<MethodInfo, object?[], object?>? InvokeMethod { get; set; }
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+            => InvokeMethod!(targetMethod!, args ?? []);
+    }
+
     [Fact]
     public void RoleSetting_RequiresBotManageRolesAndPanelReactionPermissions()
     {

--- a/BeanBot.Tests/Discord/Commands/AdministrativeModuleRoleAssignabilityTests.cs
+++ b/BeanBot.Tests/Discord/Commands/AdministrativeModuleRoleAssignabilityTests.cs
@@ -1,0 +1,49 @@
+using System.Reflection;
+using BeanBot.Discord.Commands;
+using BeanBot.Discord.ReactionRoles;
+using Discord;
+using Discord.Commands;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.Commands;
+
+public class AdministrativeModuleRoleAssignabilityTests
+{
+    [Fact]
+    public void RoleSetting_RequiresBotManageRolesAndPanelReactionPermissions()
+    {
+        var method = typeof(AdministrativeModule).GetMethod(nameof(AdministrativeModule.RoleSetting));
+        var attributes = Assert.IsAssignableFrom<IEnumerable<RequireBotPermissionAttribute>>(
+            method?.GetCustomAttributes<RequireBotPermissionAttribute>() ?? []);
+
+        Assert.Contains(attributes, attribute =>
+            attribute.GuildPermission == GuildPermission.ManageRoles);
+        Assert.Contains(attributes, attribute =>
+            attribute.ChannelPermission == (ChannelPermission.EmbedLinks | ChannelPermission.AddReactions));
+    }
+
+    [Fact]
+    public void GetRoleValidationMessage_Allowed_ReturnsNull()
+    {
+        Assert.Null(AdministrativeModule.GetRoleValidationMessage(ReactionRoleAssignabilityStatus.Allowed));
+    }
+
+    [Theory]
+    [InlineData(ReactionRoleAssignabilityStatus.EveryoneRole, "@everyone")]
+    [InlineData(ReactionRoleAssignabilityStatus.ManagedRole, "managed")]
+    [InlineData(ReactionRoleAssignabilityStatus.BotMissingManageRoles, "Manage Roles")]
+    [InlineData(ReactionRoleAssignabilityStatus.BotHierarchyTooLow, "highest role")]
+    [InlineData(ReactionRoleAssignabilityStatus.InvokerHierarchyTooLow, "below your highest role")]
+    [InlineData(ReactionRoleAssignabilityStatus.RoleMissing, "no longer available")]
+    public void GetRoleValidationMessage_Rejection_IsActionableAndSafe(
+        ReactionRoleAssignabilityStatus status,
+        string expectedText)
+    {
+        var message = AdministrativeModule.GetRoleValidationMessage(status);
+
+        Assert.NotNull(message);
+        Assert.Contains(expectedText, message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("permission bit", message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("position=", message, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/BeanBot.Tests/Discord/Commands/AdministrativeModuleRoleAssignabilityTests.cs
+++ b/BeanBot.Tests/Discord/Commands/AdministrativeModuleRoleAssignabilityTests.cs
@@ -29,16 +29,17 @@ public class AdministrativeModuleRoleAssignabilityTests
     }
 
     [Theory]
-    [InlineData(ReactionRoleAssignabilityStatus.EveryoneRole, "@everyone")]
-    [InlineData(ReactionRoleAssignabilityStatus.ManagedRole, "managed")]
-    [InlineData(ReactionRoleAssignabilityStatus.BotMissingManageRoles, "Manage Roles")]
-    [InlineData(ReactionRoleAssignabilityStatus.BotHierarchyTooLow, "highest role")]
-    [InlineData(ReactionRoleAssignabilityStatus.InvokerHierarchyTooLow, "below your highest role")]
-    [InlineData(ReactionRoleAssignabilityStatus.RoleMissing, "no longer available")]
+    [InlineData((int)ReactionRoleAssignabilityStatus.EveryoneRole, "@everyone")]
+    [InlineData((int)ReactionRoleAssignabilityStatus.ManagedRole, "managed")]
+    [InlineData((int)ReactionRoleAssignabilityStatus.BotMissingManageRoles, "Manage Roles")]
+    [InlineData((int)ReactionRoleAssignabilityStatus.BotHierarchyTooLow, "highest role")]
+    [InlineData((int)ReactionRoleAssignabilityStatus.InvokerHierarchyTooLow, "below your highest role")]
+    [InlineData((int)ReactionRoleAssignabilityStatus.RoleMissing, "no longer available")]
     public void GetRoleValidationMessage_Rejection_IsActionableAndSafe(
-        ReactionRoleAssignabilityStatus status,
+        int statusValue,
         string expectedText)
     {
+        var status = (ReactionRoleAssignabilityStatus)statusValue;
         var message = AdministrativeModule.GetRoleValidationMessage(status);
 
         Assert.NotNull(message);

--- a/BeanBot.Tests/Discord/ReactionRoles/ReactionRoleAssignabilityPolicyTests.cs
+++ b/BeanBot.Tests/Discord/ReactionRoles/ReactionRoleAssignabilityPolicyTests.cs
@@ -1,0 +1,121 @@
+using BeanBot.Discord.ReactionRoles;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.ReactionRoles;
+
+public class ReactionRoleAssignabilityPolicyTests
+{
+    [Fact]
+    public void EvaluateForSetup_RoleBelowInvokerAndBot_IsAllowed()
+    {
+        var status = ReactionRoleAssignabilityPolicy.EvaluateForSetup(
+            CreateFacts(targetPosition: 3, botHierarchy: 10),
+            invokerIsGuildOwner: false,
+            invokerHierarchy: 8);
+
+        Assert.Equal(ReactionRoleAssignabilityStatus.Allowed, status);
+    }
+
+    [Theory]
+    [InlineData(8)]
+    [InlineData(9)]
+    public void EvaluateForSetup_RoleAtOrAboveInvokerHierarchy_IsRejected(int targetPosition)
+    {
+        var status = ReactionRoleAssignabilityPolicy.EvaluateForSetup(
+            CreateFacts(targetPosition, botHierarchy: 10),
+            invokerIsGuildOwner: false,
+            invokerHierarchy: 8);
+
+        Assert.Equal(ReactionRoleAssignabilityStatus.InvokerHierarchyTooLow, status);
+    }
+
+    [Fact]
+    public void EvaluateForSetup_GuildOwner_BypassesInvokerHierarchyOnly()
+    {
+        var status = ReactionRoleAssignabilityPolicy.EvaluateForSetup(
+            CreateFacts(targetPosition: 9, botHierarchy: 10),
+            invokerIsGuildOwner: true,
+            invokerHierarchy: 1);
+
+        Assert.Equal(ReactionRoleAssignabilityStatus.Allowed, status);
+    }
+
+    [Fact]
+    public void EvaluateForSetup_EveryoneRole_IsRejected()
+    {
+        var status = ReactionRoleAssignabilityPolicy.EvaluateForSetup(
+            CreateFacts(isEveryoneRole: true),
+            invokerIsGuildOwner: true,
+            invokerHierarchy: 10);
+
+        Assert.Equal(ReactionRoleAssignabilityStatus.EveryoneRole, status);
+    }
+
+    [Fact]
+    public void EvaluateForSetup_ManagedRole_IsRejected()
+    {
+        var status = ReactionRoleAssignabilityPolicy.EvaluateForSetup(
+            CreateFacts(isManagedRole: true),
+            invokerIsGuildOwner: true,
+            invokerHierarchy: 10);
+
+        Assert.Equal(ReactionRoleAssignabilityStatus.ManagedRole, status);
+    }
+
+    [Theory]
+    [InlineData(10)]
+    [InlineData(11)]
+    public void EvaluateForSetup_RoleAtOrAboveBotHierarchy_IsRejected(int targetPosition)
+    {
+        var status = ReactionRoleAssignabilityPolicy.EvaluateForSetup(
+            CreateFacts(targetPosition, botHierarchy: 10),
+            invokerIsGuildOwner: true,
+            invokerHierarchy: 20);
+
+        Assert.Equal(ReactionRoleAssignabilityStatus.BotHierarchyTooLow, status);
+    }
+
+    [Fact]
+    public void EvaluateForSetup_MissingBotManageRoles_IsRejected()
+    {
+        var status = ReactionRoleAssignabilityPolicy.EvaluateForSetup(
+            CreateFacts(botCanManageRoles: false),
+            invokerIsGuildOwner: true,
+            invokerHierarchy: 10);
+
+        Assert.Equal(ReactionRoleAssignabilityStatus.BotMissingManageRoles, status);
+    }
+
+    [Fact]
+    public void EvaluateForRuntime_MissingPersistedRole_IsRejected()
+    {
+        var status = ReactionRoleAssignabilityPolicy.EvaluateForRuntime(
+            CreateFacts(roleExists: false));
+
+        Assert.Equal(ReactionRoleAssignabilityStatus.RoleMissing, status);
+    }
+
+    [Fact]
+    public void EvaluateForRuntime_DoesNotApplyHistoricalInvokerHierarchy()
+    {
+        var status = ReactionRoleAssignabilityPolicy.EvaluateForRuntime(
+            CreateFacts(targetPosition: 9, botHierarchy: 10));
+
+        Assert.Equal(ReactionRoleAssignabilityStatus.Allowed, status);
+    }
+
+    private static ReactionRoleAssignabilityFacts CreateFacts(
+        int targetPosition = 3,
+        int botHierarchy = 10,
+        bool roleExists = true,
+        bool isEveryoneRole = false,
+        bool isManagedRole = false,
+        bool botCanManageRoles = true)
+        => new(
+            roleExists,
+            isEveryoneRole,
+            isManagedRole,
+            botCanManageRoles,
+            targetPosition,
+            botHierarchy);
+}

--- a/BeanBot.Tests/Discord/ReactionRoles/ReactionRoleSetupTransactionTests.cs
+++ b/BeanBot.Tests/Discord/ReactionRoles/ReactionRoleSetupTransactionTests.cs
@@ -5,6 +5,66 @@ namespace BeanBot.Tests.Discord.ReactionRoles;
 
 public class ReactionRoleSetupTransactionTests
 {
+    [Theory]
+    [InlineData((int)ReactionRoleAssignabilityStatus.RoleMissing)]
+    [InlineData((int)ReactionRoleAssignabilityStatus.EveryoneRole)]
+    [InlineData((int)ReactionRoleAssignabilityStatus.ManagedRole)]
+    [InlineData((int)ReactionRoleAssignabilityStatus.BotMissingManageRoles)]
+    [InlineData((int)ReactionRoleAssignabilityStatus.BotHierarchyTooLow)]
+    [InlineData((int)ReactionRoleAssignabilityStatus.InvokerHierarchyTooLow)]
+    public async Task ExecuteIfAssignableAsync_RejectedTargetNeverPublishesOrPersists(int rejectedStatus)
+    {
+        var published = 0;
+        var persisted = 0;
+        var deleted = 0;
+        var status = await ReactionRoleSetupTransaction.ExecuteIfAssignableAsync(
+            () => (ReactionRoleAssignabilityStatus)rejectedStatus,
+            () =>
+            {
+                published++;
+                return Task.FromResult("panel");
+            },
+            _ =>
+            {
+                persisted++;
+                return Task.CompletedTask;
+            },
+            _ =>
+            {
+                deleted++;
+                return Task.CompletedTask;
+            },
+            _ => throw new InvalidOperationException("No compensation should be needed."));
+
+        Assert.Equal((ReactionRoleAssignabilityStatus)rejectedStatus, status);
+        Assert.Equal(0, published);
+        Assert.Equal(0, persisted);
+        Assert.Equal(0, deleted);
+    }
+
+    [Fact]
+    public async Task ExecuteIfAssignableAsync_AllowedTargetPublishesBeforePersisting()
+    {
+        var operations = new List<string>();
+        var status = await ReactionRoleSetupTransaction.ExecuteIfAssignableAsync(
+            () => ReactionRoleAssignabilityStatus.Allowed,
+            () =>
+            {
+                operations.Add("publish");
+                return Task.FromResult("panel");
+            },
+            _ =>
+            {
+                operations.Add("persist");
+                return Task.CompletedTask;
+            },
+            _ => throw new InvalidOperationException("No rollback should be needed."),
+            _ => throw new InvalidOperationException("No compensation should be needed."));
+
+        Assert.Equal(ReactionRoleAssignabilityStatus.Allowed, status);
+        Assert.Equal(new[] { "publish", "persist" }, operations);
+    }
+
     [Fact]
     public async Task ExecuteAsync_SuccessDoesNotDeleteMessage()
     {

--- a/BeanBot.Tests/Discord/ReactionRoles/RoleReactServiceAssignabilityTests.cs
+++ b/BeanBot.Tests/Discord/ReactionRoles/RoleReactServiceAssignabilityTests.cs
@@ -1,0 +1,92 @@
+using System.Reflection;
+using BeanBot.Discord.ReactionRoles;
+using Discord;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.ReactionRoles;
+
+public class RoleReactServiceAssignabilityTests
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ApplyRoleChangeAsync_EveryoneTargetNeverLooksUpMember(bool addRole)
+    {
+        var guild = DispatchProxy.Create<IGuild, DiscordCallRecorder>();
+        var role = DispatchProxy.Create<IRole, DiscordCallRecorder>();
+        var status = await RoleReactService.ApplyRoleChangeAsync(
+            new ReactionRoleAssignabilityFacts(true, true, false, true, 1, 2),
+            guild, role, 42, addRole, CancellationToken.None);
+
+        Assert.Equal(ReactionRoleAssignabilityStatus.EveryoneRole, status);
+        Assert.Empty(((DiscordCallRecorder)guild).Calls);
+    }
+
+    [Theory]
+    [InlineData(false, false, true, 1, 2, true)]
+    [InlineData(false, false, true, 1, 2, false)]
+    [InlineData(true, true, true, 1, 2, true)]
+    [InlineData(true, true, true, 1, 2, false)]
+    [InlineData(true, false, false, 1, 2, true)]
+    [InlineData(true, false, false, 1, 2, false)]
+    [InlineData(true, false, true, 2, 2, true)]
+    [InlineData(true, false, true, 2, 2, false)]
+    [InlineData(true, false, true, 3, 2, true)]
+    [InlineData(true, false, true, 3, 2, false)]
+    public async Task ApplyRoleChangeAsync_StaleTargetNeverLooksUpMemberOrMutatesRoles(
+        bool exists, bool managed, bool botCanManage, int rolePosition, int botHierarchy, bool addRole)
+    {
+        var guild = DispatchProxy.Create<IGuild, DiscordCallRecorder>();
+        var role = exists ? DispatchProxy.Create<IRole, DiscordCallRecorder>() : null;
+        var recorder = (DiscordCallRecorder)guild;
+        var facts = new ReactionRoleAssignabilityFacts(exists, false, managed, botCanManage, rolePosition, botHierarchy);
+
+        var status = await RoleReactService.ApplyRoleChangeAsync(
+            facts, guild, role, 42, addRole, CancellationToken.None);
+
+        Assert.NotEqual(ReactionRoleAssignabilityStatus.Allowed, status);
+        Assert.Empty(recorder.Calls);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ApplyRoleChangeAsync_AllowedTargetPerformsOnlyRequestedMutation(bool addRole)
+    {
+        var guild = DispatchProxy.Create<IGuild, DiscordCallRecorder>();
+        var user = DispatchProxy.Create<IGuildUser, DiscordCallRecorder>();
+        var role = DispatchProxy.Create<IRole, DiscordCallRecorder>();
+        ((DiscordCallRecorder)guild).User = user;
+        var userRecorder = (DiscordCallRecorder)user;
+        userRecorder.RoleIds = addRole ? [] : [7];
+        var facts = new ReactionRoleAssignabilityFacts(true, false, false, true, 1, 2);
+
+        var status = await RoleReactService.ApplyRoleChangeAsync(
+            facts, guild, role, 42, addRole, CancellationToken.None);
+
+        Assert.Equal(ReactionRoleAssignabilityStatus.Allowed, status);
+        Assert.Equal(new[] { "GetUserAsync" }, ((DiscordCallRecorder)guild).Calls);
+        Assert.Equal(new[] { addRole ? "AddRoleAsync" : "RemoveRoleAsync" }, userRecorder.Calls);
+    }
+
+    public class DiscordCallRecorder : DispatchProxy
+    {
+        public List<string> Calls { get; } = [];
+        public IGuildUser? User { get; set; }
+        public IReadOnlyCollection<ulong> RoleIds { get; set; } = [];
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            var name = targetMethod?.Name ?? throw new InvalidOperationException();
+            if (name == "get_Id") return 7UL;
+            if (name == "get_RoleIds") return RoleIds;
+            Calls.Add(name);
+            return name switch
+            {
+                "GetUserAsync" => Task.FromResult(User!),
+                "AddRoleAsync" or "RemoveRoleAsync" => Task.CompletedTask,
+                _ => throw new NotSupportedException(name)
+            };
+        }
+    }
+}

--- a/BeanBot/Discord/Commands/AdministrativeModule.cs
+++ b/BeanBot/Discord/Commands/AdministrativeModule.cs
@@ -141,7 +141,7 @@ public class AdministrativeModule : ModuleBase<SocketCommandContext>
             var setupFailure = GetRoleValidationMessage(setupStatus);
             if (setupFailure is not null)
             {
-                messagesInInteraction.Add(await _replySender.SendMessageAsync(Context, setupFailure));
+                messagesInInteraction.Add(await SendRoleValidationMessageAsync(_replySender, Context, setupFailure));
             }
         }
         finally
@@ -163,6 +163,10 @@ public class AdministrativeModule : ModuleBase<SocketCommandContext>
             _ => throw new ArgumentOutOfRangeException(nameof(result), result, null)
         };
     }
+
+    internal static Task<IUserMessage> SendRoleValidationMessageAsync(
+        LegacyCommandReplySender replySender, ICommandContext context, string message)
+        => replySender.SendMessageAsync(context, message, allowedMentions: AllowedMentions.None);
 
     internal static string? GetRoleValidationMessage(ReactionRoleAssignabilityStatus status)
     {
@@ -324,7 +328,7 @@ public class AdministrativeModule : ModuleBase<SocketCommandContext>
         var validationMessage = GetRoleValidationMessage(assignabilityStatus);
         if (validationMessage is not null)
         {
-            messages.Add(await _replySender.SendMessageAsync(Context, validationMessage));
+            messages.Add(await SendRoleValidationMessageAsync(_replySender, Context, validationMessage));
             return null;
         }
 

--- a/BeanBot/Discord/Commands/AdministrativeModule.cs
+++ b/BeanBot/Discord/Commands/AdministrativeModule.cs
@@ -50,7 +50,8 @@ public class AdministrativeModule : ModuleBase<SocketCommandContext>
     [Remarks("role setting")]
     [RequireGuild]
     [RequireUserPermission(GuildPermission.ManageRoles)]
-    [RequireBotPermission(GuildPermission.EmbedLinks)]
+    [RequireBotPermission(GuildPermission.ManageRoles)]
+    [RequireBotPermission(ChannelPermission.EmbedLinks | ChannelPermission.AddReactions)]
     public Task RoleSetting() => InvokeRoleSettingsAsync();
 
     internal async Task InvokeRoleSettingsAsync()
@@ -146,6 +147,27 @@ public class AdministrativeModule : ModuleBase<SocketCommandContext>
         };
     }
 
+    internal static string? GetRoleValidationMessage(ReactionRoleAssignabilityStatus status)
+    {
+        return status switch
+        {
+            ReactionRoleAssignabilityStatus.Allowed => null,
+            ReactionRoleAssignabilityStatus.EveryoneRole =>
+                "The @everyone role cannot be used for self-assignment. Please start again.",
+            ReactionRoleAssignabilityStatus.ManagedRole =>
+                "That role is managed by Discord or an integration and cannot be self-assigned. Please start again.",
+            ReactionRoleAssignabilityStatus.BotMissingManageRoles =>
+                "Bean Bot needs the Manage Roles permission before this role can be configured. Please start again after fixing its permissions.",
+            ReactionRoleAssignabilityStatus.BotHierarchyTooLow =>
+                "Bean Bot's highest role must be above the selected role. Please move Bean Bot higher in the role list and start again.",
+            ReactionRoleAssignabilityStatus.InvokerHierarchyTooLow =>
+                "You can only configure roles below your highest role. Please choose a lower role and start again.",
+            ReactionRoleAssignabilityStatus.RoleMissing =>
+                "That role is no longer available. Please choose another role and start again.",
+            _ => throw new ArgumentOutOfRangeException(nameof(status), status, null)
+        };
+    }
+
     private async Task<IUserMessage> CreateRoleMessageAsync(IEnumerable<RoleEmotePair> roleEmotePairs, string roleGroupLabel)
     {
         var pairs = roleEmotePairs.ToList();
@@ -224,7 +246,33 @@ public class AdministrativeModule : ModuleBase<SocketCommandContext>
             return null;
         }
 
-        return availableRoles.Single(role => role.Id == roleResolution.RoleId);
+        var role = availableRoles.Single(candidate => candidate.Id == roleResolution.RoleId);
+        var invokingUser = Context.User as SocketGuildUser ?? Context.Guild.GetUser(Context.User.Id);
+        if (invokingUser == null)
+        {
+            messages.Add(await ReplyAsync("Bean Bot could not verify your current role hierarchy. Please try again."));
+            return null;
+        }
+
+        var botUser = Context.Guild.CurrentUser;
+        var assignabilityStatus = ReactionRoleAssignabilityPolicy.EvaluateForSetup(
+            new ReactionRoleAssignabilityFacts(
+                RoleExists: true,
+                IsEveryoneRole: role.Id == Context.Guild.Id,
+                IsManagedRole: role.IsManaged,
+                BotCanManageRoles: botUser.GuildPermissions.ManageRoles,
+                TargetRolePosition: role.Position,
+                BotHierarchy: botUser.Hierarchy),
+            invokerIsGuildOwner: invokingUser.Id == Context.Guild.OwnerId,
+            invokerHierarchy: invokingUser.Hierarchy);
+        var validationMessage = GetRoleValidationMessage(assignabilityStatus);
+        if (validationMessage is not null)
+        {
+            messages.Add(await ReplyAsync(validationMessage));
+            return null;
+        }
+
+        return role;
     }
 
     internal static RoleResolution ResolveRole(

--- a/BeanBot/Discord/Commands/AdministrativeModule.cs
+++ b/BeanBot/Discord/Commands/AdministrativeModule.cs
@@ -267,7 +267,9 @@ public class AdministrativeModule : ModuleBase<SocketCommandContext>
         var invokingUser = Context.User as SocketGuildUser ?? Context.Guild.GetUser(Context.User.Id);
         if (invokingUser == null)
         {
-            messages.Add(await ReplyAsync("Bean Bot could not verify your current role hierarchy. Please try again."));
+            messages.Add(await _replySender.SendMessageAsync(
+                Context,
+                "Bean Bot could not verify your current role hierarchy. Please try again."));
             return null;
         }
 
@@ -285,7 +287,7 @@ public class AdministrativeModule : ModuleBase<SocketCommandContext>
         var validationMessage = GetRoleValidationMessage(assignabilityStatus);
         if (validationMessage is not null)
         {
-            messages.Add(await ReplyAsync(validationMessage));
+            messages.Add(await _replySender.SendMessageAsync(Context, validationMessage));
             return null;
         }
 

--- a/BeanBot/Discord/Commands/AdministrativeModule.cs
+++ b/BeanBot/Discord/Commands/AdministrativeModule.cs
@@ -128,7 +128,8 @@ public class AdministrativeModule : ModuleBase<SocketCommandContext>
             }
 
             messagesInInteraction.Add(labelMessage);
-            await ReactionRoleSetupTransaction.ExecuteAsync(
+            var setupStatus = await ReactionRoleSetupTransaction.ExecuteIfAssignableAsync(
+                () => ValidateSelectedRoles(roleEmotePairs),
                 () => CreateRoleMessageAsync(roleEmotePairs, labelMessage.Content),
                 async messageToListen =>
                 {
@@ -137,6 +138,11 @@ public class AdministrativeModule : ModuleBase<SocketCommandContext>
                 },
                 messageToListen => messageToListen.DeleteAsync(),
                 exception => BeanBotLog.IncompleteReactionRoleCleanupFailed(_logger, exception));
+            var setupFailure = GetRoleValidationMessage(setupStatus);
+            if (setupFailure is not null)
+            {
+                messagesInInteraction.Add(await _replySender.SendMessageAsync(Context, setupFailure));
+            }
         }
         finally
         {
@@ -177,6 +183,37 @@ public class AdministrativeModule : ModuleBase<SocketCommandContext>
                 "That role is no longer available. Please choose another role and start again.",
             _ => throw new ArgumentOutOfRangeException(nameof(status), status, null)
         };
+    }
+
+    private ReactionRoleAssignabilityStatus ValidateSelectedRoles(IEnumerable<RoleEmotePair> pairs)
+    {
+        var invokingUser = Context.Guild.GetUser(Context.User.Id);
+        if (invokingUser is null)
+        {
+            return ReactionRoleAssignabilityStatus.InvokerHierarchyTooLow;
+        }
+
+        var botUser = Context.Guild.CurrentUser;
+        foreach (var pair in pairs)
+        {
+            var role = ulong.TryParse(pair.RoleId, out var roleId) ? Context.Guild.GetRole(roleId) : null;
+            var status = ReactionRoleAssignabilityPolicy.EvaluateForSetup(
+                new ReactionRoleAssignabilityFacts(
+                    RoleExists: role is not null,
+                    IsEveryoneRole: role?.Id == Context.Guild.Id,
+                    IsManagedRole: role?.IsManaged ?? false,
+                    BotCanManageRoles: botUser.GuildPermissions.ManageRoles,
+                    TargetRolePosition: role?.Position ?? 0,
+                    BotHierarchy: botUser.Hierarchy),
+                invokerIsGuildOwner: invokingUser.Id == Context.Guild.OwnerId,
+                invokerHierarchy: invokingUser.Hierarchy);
+            if (status != ReactionRoleAssignabilityStatus.Allowed)
+            {
+                return status;
+            }
+        }
+
+        return ReactionRoleAssignabilityStatus.Allowed;
     }
 
     private async Task<IUserMessage> CreateRoleMessageAsync(IEnumerable<RoleEmotePair> roleEmotePairs, string roleGroupLabel)

--- a/BeanBot/Discord/ReactionRoles/ReactionRoleAssignabilityPolicy.cs
+++ b/BeanBot/Discord/ReactionRoles/ReactionRoleAssignabilityPolicy.cs
@@ -1,0 +1,67 @@
+namespace BeanBot.Discord.ReactionRoles;
+
+internal enum ReactionRoleAssignabilityStatus
+{
+    Allowed,
+    RoleMissing,
+    EveryoneRole,
+    ManagedRole,
+    BotMissingManageRoles,
+    BotHierarchyTooLow,
+    InvokerHierarchyTooLow
+}
+
+internal readonly record struct ReactionRoleAssignabilityFacts(
+    bool RoleExists,
+    bool IsEveryoneRole,
+    bool IsManagedRole,
+    bool BotCanManageRoles,
+    int TargetRolePosition,
+    int BotHierarchy);
+
+internal static class ReactionRoleAssignabilityPolicy
+{
+    internal static ReactionRoleAssignabilityStatus EvaluateForSetup(
+        ReactionRoleAssignabilityFacts facts,
+        bool invokerIsGuildOwner,
+        int invokerHierarchy)
+    {
+        var botStatus = EvaluateForRuntime(facts);
+        if (botStatus != ReactionRoleAssignabilityStatus.Allowed)
+        {
+            return botStatus;
+        }
+
+        return !invokerIsGuildOwner && facts.TargetRolePosition >= invokerHierarchy
+            ? ReactionRoleAssignabilityStatus.InvokerHierarchyTooLow
+            : ReactionRoleAssignabilityStatus.Allowed;
+    }
+
+    internal static ReactionRoleAssignabilityStatus EvaluateForRuntime(
+        ReactionRoleAssignabilityFacts facts)
+    {
+        if (!facts.RoleExists)
+        {
+            return ReactionRoleAssignabilityStatus.RoleMissing;
+        }
+
+        if (facts.IsEveryoneRole)
+        {
+            return ReactionRoleAssignabilityStatus.EveryoneRole;
+        }
+
+        if (facts.IsManagedRole)
+        {
+            return ReactionRoleAssignabilityStatus.ManagedRole;
+        }
+
+        if (!facts.BotCanManageRoles)
+        {
+            return ReactionRoleAssignabilityStatus.BotMissingManageRoles;
+        }
+
+        return facts.TargetRolePosition >= facts.BotHierarchy
+            ? ReactionRoleAssignabilityStatus.BotHierarchyTooLow
+            : ReactionRoleAssignabilityStatus.Allowed;
+    }
+}

--- a/BeanBot/Discord/ReactionRoles/ReactionRoleSetupTransaction.cs
+++ b/BeanBot/Discord/ReactionRoles/ReactionRoleSetupTransaction.cs
@@ -2,6 +2,23 @@ namespace BeanBot.Discord.ReactionRoles;
 
 internal static class ReactionRoleSetupTransaction
 {
+    internal static async Task<ReactionRoleAssignabilityStatus> ExecuteIfAssignableAsync<TMessage>(
+        Func<ReactionRoleAssignabilityStatus> validate,
+        Func<Task<TMessage>> createMessage,
+        Func<TMessage, Task> configureAndPersist,
+        Func<TMessage, Task> deleteMessage,
+        Action<Exception> onCompensationFailure)
+        where TMessage : class
+    {
+        var status = validate();
+        if (status == ReactionRoleAssignabilityStatus.Allowed)
+        {
+            await ExecuteAsync(createMessage, configureAndPersist, deleteMessage, onCompensationFailure);
+        }
+
+        return status;
+    }
+
     public static async Task<TMessage> ExecuteAsync<TMessage>(
         Func<Task<TMessage>> createMessage,
         Func<TMessage, Task> configureAndPersist,

--- a/BeanBot/Discord/ReactionRoles/RoleReactService.cs
+++ b/BeanBot/Discord/ReactionRoles/RoleReactService.cs
@@ -153,10 +153,36 @@ public class RoleReactService : IDisposable, IAsyncDisposable
                 return;
             }
 
-            var guild = (IGuild)textChannel.Guild;
+            var socketGuild = textChannel.Guild;
+            var role = socketGuild.GetRole(roleId);
+            var botUser = socketGuild.CurrentUser;
+            var assignabilityStatus = ReactionRoleAssignabilityPolicy.EvaluateForRuntime(
+                new ReactionRoleAssignabilityFacts(
+                    RoleExists: role is not null,
+                    IsEveryoneRole: role?.Id == socketGuild.Id,
+                    IsManagedRole: role?.IsManaged ?? false,
+                    BotCanManageRoles: botUser.GuildPermissions.ManageRoles,
+                    TargetRolePosition: role?.Position ?? 0,
+                    BotHierarchy: botUser.Hierarchy));
+            if (assignabilityStatus != ReactionRoleAssignabilityStatus.Allowed)
+            {
+                _logger.LogWarning(
+                    "Skipping reaction-role {Action} for message {MessageId} and role {RoleId} because the target is not assignable: {Reason}",
+                    addRole ? "add" : "remove",
+                    message.Id,
+                    roleId,
+                    assignabilityStatus);
+                return;
+            }
+
+            if (role == null)
+            {
+                return;
+            }
+
+            var guild = (IGuild)socketGuild;
             var user = await guild.GetUserAsync(reaction.UserId, CacheMode.AllowDownload);
-            var role = guild.Roles.FirstOrDefault(candidate => candidate.Id == roleId);
-            if (user == null || role == null)
+            if (user == null)
             {
                 return;
             }

--- a/BeanBot/Discord/ReactionRoles/RoleReactService.cs
+++ b/BeanBot/Discord/ReactionRoles/RoleReactService.cs
@@ -166,12 +166,12 @@ public class RoleReactService : IDisposable, IAsyncDisposable
                     BotHierarchy: botUser.Hierarchy));
             if (assignabilityStatus != ReactionRoleAssignabilityStatus.Allowed)
             {
-                _logger.LogWarning(
-                    "Skipping reaction-role {Action} for message {MessageId} and role {RoleId} because the target is not assignable: {Reason}",
+                BeanBotLog.ReactionRoleTargetUnassignable(
+                    _logger,
                     addRole ? "add" : "remove",
                     message.Id,
                     roleId,
-                    assignabilityStatus);
+                    assignabilityStatus.ToString());
                 return;
             }
 

--- a/BeanBot/Discord/ReactionRoles/RoleReactService.cs
+++ b/BeanBot/Discord/ReactionRoles/RoleReactService.cs
@@ -161,14 +161,19 @@ public class RoleReactService : IDisposable, IAsyncDisposable
             var socketGuild = textChannel.Guild;
             var role = socketGuild.GetRole(roleId);
             var botUser = socketGuild.CurrentUser;
-            var assignabilityStatus = ReactionRoleAssignabilityPolicy.EvaluateForRuntime(
+            var assignabilityStatus = await ApplyRoleChangeAsync(
                 new ReactionRoleAssignabilityFacts(
                     RoleExists: role is not null,
                     IsEveryoneRole: role?.Id == socketGuild.Id,
                     IsManagedRole: role?.IsManaged ?? false,
                     BotCanManageRoles: botUser.GuildPermissions.ManageRoles,
                     TargetRolePosition: role?.Position ?? 0,
-                    BotHierarchy: botUser.Hierarchy));
+                    BotHierarchy: botUser.Hierarchy),
+                socketGuild,
+                role,
+                reaction.UserId,
+                addRole,
+                cancellationToken);
             if (assignabilityStatus != ReactionRoleAssignabilityStatus.Allowed)
             {
                 BeanBotLog.ReactionRoleTargetUnassignable(
@@ -180,26 +185,6 @@ public class RoleReactService : IDisposable, IAsyncDisposable
                 return;
             }
 
-            if (role == null)
-            {
-                return;
-            }
-
-            var guild = (IGuild)socketGuild;
-            var user = await guild.GetUserAsync(reaction.UserId, CacheMode.AllowDownload);
-            if (user == null)
-            {
-                return;
-            }
-
-            if (addRole && !user.RoleIds.Contains(roleId))
-            {
-                await user.AddRoleAsync(role);
-            }
-            else if (!addRole && user.RoleIds.Contains(roleId))
-            {
-                await user.RemoveRoleAsync(role);
-            }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -213,6 +198,39 @@ public class RoleReactService : IDisposable, IAsyncDisposable
                 message.Id,
                 exception);
         }
+    }
+
+    internal static async Task<ReactionRoleAssignabilityStatus> ApplyRoleChangeAsync(
+        ReactionRoleAssignabilityFacts facts,
+        IGuild guild,
+        IRole? role,
+        ulong userId,
+        bool addRole,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var status = ReactionRoleAssignabilityPolicy.EvaluateForRuntime(facts);
+        if (status != ReactionRoleAssignabilityStatus.Allowed || role is null)
+        {
+            return role is null ? ReactionRoleAssignabilityStatus.RoleMissing : status;
+        }
+
+        var requestOptions = new RequestOptions { CancelToken = cancellationToken };
+        var user = await guild.GetUserAsync(userId, CacheMode.AllowDownload, requestOptions);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (user is not null)
+        {
+            if (addRole && !user.RoleIds.Contains(role.Id))
+            {
+                await user.AddRoleAsync(role, requestOptions);
+            }
+            else if (!addRole && user.RoleIds.Contains(role.Id))
+            {
+                await user.RemoveRoleAsync(role, requestOptions);
+            }
+        }
+
+        return status;
     }
 
     internal async Task<RoleSettings?> GetCachedRoleSettingAsync(

--- a/BeanBot/Logging/BeanBotLog.ReactionRoles.cs
+++ b/BeanBot/Logging/BeanBotLog.ReactionRoles.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.Logging;
+
+namespace BeanBot.Logging;
+
+internal static partial class BeanBotLog
+{
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Skipping reaction-role {Action} for message {MessageId} and role {RoleId} because the target is not assignable: {Reason}")]
+    internal static partial void ReactionRoleTargetUnassignable(
+        ILogger logger,
+        string action,
+        ulong messageId,
+        ulong roleId,
+        string reason);
+}


### PR DESCRIPTION
Closes #178

## Summary
- add a pure, testable legacy reaction-role assignability policy covering `@everyone`, managed roles, BeanBot `Manage Roles`, BeanBot hierarchy, and invoking-member hierarchy
- validate selected roles during `%role setting` before the role/emote pair is accepted, so invalid targets cannot reach panel creation or persistence
- require BeanBot `Manage Roles` plus channel-level `Embed Links` and `Add Reactions` before the legacy setup command starts
- revalidate BeanBot-side assignability for persisted panels immediately before a live add/remove mutation and skip stale/unassignable targets with structured warning diagnostics

## Plan
Implemented using the repository-owned Planner -> approved plan -> Implementer -> Verifier -> Reviewer workflow on a dedicated branch from `develop` (`f896856f80a6269d5b3aebcae18fae78ba87c87a`). The change intentionally leaves the wizard syntax and Mongo document shape unchanged. Runtime revalidation checks only BeanBot's current ability to mutate a persisted role; the original setup creator's hierarchy is not persisted or re-evaluated later.

## Tests
- pure policy coverage for normal roles, invoker equality/above-hierarchy rejection, guild-owner bypass, `@everyone`, managed roles, missing BeanBot `Manage Roles`, BeanBot hierarchy, missing persisted roles, and runtime behavior without historical invoker checks
- command metadata coverage proving the required BeanBot permissions are enforced before setup
- safe/actionable validation-message coverage
- existing role-resolution, setup-transaction, persistence/cache, shutdown, and reaction-role tests remain part of the full repository gate

## Verification
- final PR head: `5bf831fa176c6c43e5a3e3870449a33a33bb7a78`; current `develop` is still `f896856f80a6269d5b3aebcae18fae78ba87c87a`, so the branch is 4 commits ahead / 0 behind
- Repository Verification #309: **PASS** for the PR run associated with this head; the workflow runs `./scripts/verify.sh full` on the PR merge result and pins branch-integrity evidence to the exact PR head
- CodeQL #143: **PASS** for this head
- Dependency Review #120: **PASS** for this head
- fresh Verifier: **PASS** — original issue/acceptance criteria, accepted plan, branch policy, complete six-file diff, deterministic full-gate evidence, Docker/runtime implications, secrets/scope, and current CI were independently inspected
- fresh independent Reviewer: **CLEAN** — no consequential correctness, Discord lifecycle, duplicate-operation, cancellation, health, persistence, security, test-quality, Docker/runtime, dependency/release, or unrelated-scope finding remains
- review threads: **0 open**; the sole Copilot maintainability suggestion was reviewed and resolved without a code change because the defensive null guard fails safely and is preferable to replacing the guard with a null-forgiving assertion

A fresh local checkout/rerun is unavailable in this review environment: `git ls-remote https://github.com/EternalLiquet/BeanBot-DEPRACATED.git HEAD` fails with `Could not resolve host: github.com`. No local PASS is claimed. The repository-owned GitHub Actions full gate supplies the deterministic verification evidence.

## Compatibility / risk
- no dependency, Docker, configuration, release-workflow, command syntax, persistence-schema, or migration changes
- existing valid legacy reaction-role panels continue to use the same persistence model and add/remove flow
- invalid or stale targets now fail closed instead of attempting a role mutation BeanBot or the invoking administrator is not allowed to perform
- role hierarchy/permission can still change in the narrow interval after runtime revalidation and before Discord processes the mutation; that ordinary remote race is contained by the existing failure/logging path rather than being reported as success
- open PRs #161 and #171 also touch legacy reaction-role internals, so future merge ordering may require a small conflict resolution if those land first

## Manual validation
After deployment, verify one valid legacy panel still grants/removes a low role, then move the configured role above BeanBot (or remove BeanBot `Manage Roles`) and confirm reactions are ignored safely rather than attempting a doomed role mutation.