### PR TITLE
Bound ordinary legacy command replies

### DIFF
--- a/BeanBot.Tests/Discord/Commands/LegacyCommandFeedbackSuppressionTests.cs
+++ b/BeanBot.Tests/Discord/Commands/LegacyCommandFeedbackSuppressionTests.cs
@@ -1,0 +1,39 @@
+using BeanBot.Discord.Commands;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.Commands;
+
+public class LegacyCommandFeedbackSuppressionTests
+{
+    [Fact]
+    public void ShouldSuppressFeedback_AmbiguousReplyTimeout_ReturnsTrue()
+    {
+        var exception = new LegacyCommandReplyTimeoutException(
+            "timed out",
+            new OperationCanceledException());
+
+        Assert.True(LegacyCommandFeedbackResponder.ShouldSuppressFeedback(exception));
+    }
+
+    [Fact]
+    public void ShouldSuppressFeedback_CapacityOrShutdownRejection_ReturnsTrue()
+    {
+        var exception = new LegacyCommandReplyRejectedException("rejected");
+
+        Assert.True(LegacyCommandFeedbackResponder.ShouldSuppressFeedback(exception));
+    }
+
+    [Fact]
+    public void ShouldSuppressFeedback_ShutdownCancellation_ReturnsTrue()
+    {
+        Assert.True(LegacyCommandFeedbackResponder.ShouldSuppressFeedback(
+            new OperationCanceledException()));
+    }
+
+    [Fact]
+    public void ShouldSuppressFeedback_UnrelatedCommandFailure_ReturnsFalse()
+    {
+        Assert.False(LegacyCommandFeedbackResponder.ShouldSuppressFeedback(
+            new InvalidOperationException("normal command failure")));
+    }
+}

--- a/BeanBot.Tests/Discord/Commands/LegacyCommandReplySenderTests.cs
+++ b/BeanBot.Tests/Discord/Commands/LegacyCommandReplySenderTests.cs
@@ -201,11 +201,11 @@ public class LegacyCommandReplySenderTests
         TimeSpan? sendTimeout = null,
         TimeSpan? drainTimeout = null)
         => new(
-            applicationStopping,
             logger,
             capacity,
             sendTimeout ?? TimeSpan.FromSeconds(1),
-            drainTimeout ?? TimeSpan.FromSeconds(1));
+            drainTimeout ?? TimeSpan.FromSeconds(1),
+            applicationStopping);
 
     private static async Task WaitUntilAsync(Func<bool> predicate)
     {

--- a/BeanBot.Tests/Discord/Commands/LegacyCommandReplySenderTests.cs
+++ b/BeanBot.Tests/Discord/Commands/LegacyCommandReplySenderTests.cs
@@ -108,8 +108,8 @@ public class LegacyCommandReplySenderTests
         var logger = new RecordingLogger<LegacyCommandReplySender>();
         var sender = CreateSender(
             logger,
-            applicationStopping.Token,
-            sendTimeout: TimeSpan.FromSeconds(1));
+            sendTimeout: TimeSpan.FromSeconds(1),
+            applicationStopping: applicationStopping.Token);
         var send = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
         CancellationToken requestToken = default;
 
@@ -196,10 +196,10 @@ public class LegacyCommandReplySenderTests
 
     private static LegacyCommandReplySender CreateSender(
         RecordingLogger<LegacyCommandReplySender> logger,
-        CancellationToken applicationStopping = default,
         int capacity = 4,
         TimeSpan? sendTimeout = null,
-        TimeSpan? drainTimeout = null)
+        TimeSpan? drainTimeout = null,
+        CancellationToken applicationStopping = default)
         => new(
             logger,
             capacity,

--- a/BeanBot.Tests/Discord/Commands/LegacyCommandReplySenderTests.cs
+++ b/BeanBot.Tests/Discord/Commands/LegacyCommandReplySenderTests.cs
@@ -1,0 +1,242 @@
+using BeanBot.Discord.Commands;
+using Discord;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.Commands;
+
+public class LegacyCommandReplySenderTests
+{
+    [Fact]
+    public async Task RunAsync_Success_StartsExactlyOnceAndUsesCancelableRequestToken()
+    {
+        var logger = new RecordingLogger<LegacyCommandReplySender>();
+        var sender = CreateSender(logger);
+        var attempts = 0;
+        CancellationToken requestToken = default;
+
+        var result = await sender.RunAsync(
+            options =>
+            {
+                attempts++;
+                requestToken = options.CancelToken;
+                return Task.FromResult("sent");
+            },
+            "text");
+
+        Assert.Equal("sent", result);
+        Assert.Equal(1, attempts);
+        Assert.True(requestToken.CanBeCanceled);
+        Assert.Equal(0, sender.OwnedOperationCount);
+    }
+
+    [Fact]
+    public async Task RunAsync_Timeout_DoesNotRetryAndRetainsOwnershipUntilUnderlyingTaskSettles()
+    {
+        var logger = new RecordingLogger<LegacyCommandReplySender>();
+        var sender = CreateSender(
+            logger,
+            capacity: 1,
+            sendTimeout: TimeSpan.FromMilliseconds(20));
+        var firstSend = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attempts = 0;
+        CancellationToken requestToken = default;
+
+        await Assert.ThrowsAsync<LegacyCommandReplyTimeoutException>(
+            () => sender.RunAsync(
+                options =>
+                {
+                    attempts++;
+                    requestToken = options.CancelToken;
+                    return firstSend.Task;
+                },
+                "text"));
+
+        Assert.Equal(1, attempts);
+        Assert.True(requestToken.IsCancellationRequested);
+        Assert.Equal(1, sender.OwnedOperationCount);
+
+        await Assert.ThrowsAsync<LegacyCommandReplyRejectedException>(
+            () => sender.RunAsync(
+                _ =>
+                {
+                    attempts++;
+                    return Task.FromResult("unexpected");
+                },
+                "embed"));
+        Assert.Equal(1, attempts);
+
+        firstSend.SetResult("late success");
+        await WaitUntilAsync(() => sender.OwnedOperationCount == 0);
+
+        var secondResult = await sender.RunAsync(
+            _ =>
+            {
+                attempts++;
+                return Task.FromResult("reused");
+            },
+            "file");
+
+        Assert.Equal("reused", secondResult);
+        Assert.Equal(2, attempts);
+    }
+
+    [Fact]
+    public async Task RunAsync_LateFault_IsObservedLoggedAndReleasesOwnershipOnce()
+    {
+        var logger = new RecordingLogger<LegacyCommandReplySender>();
+        var sender = CreateSender(logger, sendTimeout: TimeSpan.FromMilliseconds(20));
+        var send = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await Assert.ThrowsAsync<LegacyCommandReplyTimeoutException>(
+            () => sender.RunAsync(_ => send.Task, "text"));
+
+        var lateFailure = new InvalidOperationException("late Discord failure");
+        send.SetException(lateFailure);
+        await WaitUntilAsync(() => sender.OwnedOperationCount == 0);
+
+        var entry = Assert.Single(
+            logger.Entries,
+            candidate => candidate.Level == LogLevel.Error && candidate.Exception is AggregateException);
+        Assert.Contains(lateFailure, ((AggregateException)entry.Exception!).InnerExceptions);
+    }
+
+    [Fact]
+    public async Task RunAsync_HostCancellation_PropagatesCancellationInsteadOfTimeout()
+    {
+        using var applicationStopping = new CancellationTokenSource();
+        var logger = new RecordingLogger<LegacyCommandReplySender>();
+        var sender = CreateSender(
+            logger,
+            applicationStopping.Token,
+            sendTimeout: TimeSpan.FromSeconds(1));
+        var send = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        CancellationToken requestToken = default;
+
+        var operation = sender.RunAsync(
+            options =>
+            {
+                requestToken = options.CancelToken;
+                return send.Task;
+            },
+            "text");
+        applicationStopping.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => operation);
+        Assert.True(requestToken.IsCancellationRequested);
+        Assert.Equal(1, sender.OwnedOperationCount);
+
+        send.SetCanceled(requestToken);
+        await WaitUntilAsync(() => sender.OwnedOperationCount == 0);
+    }
+
+    [Fact]
+    public async Task StopAsync_RejectsNewRepliesAndKeepsSurvivingDiscordWorkOwnedAfterDrainBound()
+    {
+        var logger = new RecordingLogger<LegacyCommandReplySender>();
+        var sender = CreateSender(
+            logger,
+            sendTimeout: TimeSpan.FromSeconds(1),
+            drainTimeout: TimeSpan.FromMilliseconds(20));
+        var send = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        CancellationToken requestToken = default;
+
+        var operation = sender.RunAsync(
+            options =>
+            {
+                requestToken = options.CancelToken;
+                return send.Task;
+            },
+            "file");
+        await sender.StopAsync();
+
+        Assert.True(requestToken.IsCancellationRequested);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => operation);
+        Assert.True(sender.HasPendingOperations);
+        await Assert.ThrowsAsync<LegacyCommandReplyRejectedException>(
+            () => sender.RunAsync(_ => Task.FromResult("unexpected"), "text"));
+
+        send.SetResult("late success");
+        await WaitUntilAsync(() => !sender.HasPendingOperations);
+        await sender.StopAsync();
+    }
+
+    [Fact]
+    public async Task StopAsync_WhenUnderlyingSendHonorsCancellation_DrainsBeforeReturning()
+    {
+        var logger = new RecordingLogger<LegacyCommandReplySender>();
+        var sender = CreateSender(logger, drainTimeout: TimeSpan.FromSeconds(1));
+        CancellationToken requestToken = default;
+
+        var operation = sender.RunAsync<string>(
+            options =>
+            {
+                requestToken = options.CancelToken;
+                return Task.Delay(Timeout.InfiniteTimeSpan, requestToken)
+                    .ContinueWith(
+                        _ => "never",
+                        CancellationToken.None,
+                        TaskContinuationOptions.ExecuteSynchronously,
+                        TaskScheduler.Default);
+            },
+            "embed");
+
+        await sender.StopAsync();
+
+        Assert.True(requestToken.IsCancellationRequested);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => operation);
+        Assert.False(sender.HasPendingOperations);
+    }
+
+    [Fact]
+    public void Defaults_AreFiniteAndCapacityIsHardBounded()
+    {
+        Assert.InRange(LegacyCommandReplySender.DefaultCapacity, 1, 64);
+        Assert.True(LegacyCommandReplySender.DefaultSendTimeout > TimeSpan.Zero);
+        Assert.True(LegacyCommandReplySender.DefaultSendTimeout <= TimeSpan.FromSeconds(30));
+        Assert.True(LegacyCommandReplySender.DefaultDrainTimeout > TimeSpan.Zero);
+        Assert.True(LegacyCommandReplySender.DefaultDrainTimeout <= TimeSpan.FromSeconds(15));
+    }
+
+    private static LegacyCommandReplySender CreateSender(
+        RecordingLogger<LegacyCommandReplySender> logger,
+        CancellationToken applicationStopping = default,
+        int capacity = 4,
+        TimeSpan? sendTimeout = null,
+        TimeSpan? drainTimeout = null)
+        => new(
+            applicationStopping,
+            logger,
+            capacity,
+            sendTimeout ?? TimeSpan.FromSeconds(1),
+            drainTimeout ?? TimeSpan.FromSeconds(1));
+
+    private static async Task WaitUntilAsync(Func<bool> predicate)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(1);
+        while (!predicate())
+        {
+            Assert.True(DateTime.UtcNow < deadline, "Expected condition did not become true in time.");
+            await Task.Delay(5);
+        }
+    }
+
+    private sealed record LogEntry(LogLevel Level, Exception? Exception);
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => Entries.Add(new LogEntry(logLevel, exception));
+    }
+}

--- a/BeanBot.Tests/Discord/Commands/LegacyCommandReplySenderTests.cs
+++ b/BeanBot.Tests/Discord/Commands/LegacyCommandReplySenderTests.cs
@@ -168,16 +168,12 @@ public class LegacyCommandReplySenderTests
         var sender = CreateSender(logger, drainTimeout: TimeSpan.FromSeconds(1));
         CancellationToken requestToken = default;
 
-        var operation = sender.RunAsync<string>(
-            options =>
+        var operation = sender.RunAsync(
+            async options =>
             {
                 requestToken = options.CancelToken;
-                return Task.Delay(Timeout.InfiniteTimeSpan, requestToken)
-                    .ContinueWith(
-                        _ => "never",
-                        CancellationToken.None,
-                        TaskContinuationOptions.ExecuteSynchronously,
-                        TaskScheduler.Default);
+                await Task.Delay(Timeout.InfiniteTimeSpan, requestToken);
+                return "never";
             },
             "embed");
 

--- a/BeanBot.Tests/Hosting/BeanBotApplicationTests.cs
+++ b/BeanBot.Tests/Hosting/BeanBotApplicationTests.cs
@@ -45,6 +45,7 @@ public class BeanBotApplicationTests
                 "stop-new-member",
                 "stop-edited-message",
                 "stop-command",
+                "stop-command-replies",
                 "stop-message-waiter",
                 "stop-paginator",
                 "unsubscribe-discord-log",
@@ -75,6 +76,23 @@ public class BeanBotApplicationTests
         Assert.DoesNotContain("dispose-discord", runtime.Calls);
         Assert.Equal(2, runtime.Calls.Count(call => call == "flush-alerts"));
         Assert.Contains("unsubscribe-events", runtime.Calls);
+    }
+
+    [Fact]
+    public async Task StopAsync_CommandReplyWorkSurvivesDrain_SkipsDiscordShutdownAndDisposal()
+    {
+        var runtime = new RecordingRuntime
+        {
+            KeepDiscordLifecycleOwnedAfterCommandReplies = true
+        };
+        var application = new BeanBotApplication(runtime, NullLogger<BeanBotApplication>.Instance);
+
+        await application.StopAsync(CancellationToken.None);
+
+        Assert.Contains("stop-command-replies", runtime.Calls);
+        Assert.DoesNotContain("stop-discord", runtime.Calls);
+        Assert.DoesNotContain("dispose-discord", runtime.Calls);
+        Assert.Equal(2, runtime.Calls.Count(call => call == "flush-alerts"));
     }
 
     [Fact]
@@ -129,7 +147,8 @@ public class BeanBotApplicationTests
     [InlineData("stop-reaction", "stop-new-member")]
     [InlineData("stop-new-member", "stop-edited-message")]
     [InlineData("stop-edited-message", "stop-command")]
-    [InlineData("stop-command", "stop-message-waiter")]
+    [InlineData("stop-command", "stop-command-replies")]
+    [InlineData("stop-command-replies", "stop-message-waiter")]
     [InlineData("stop-message-waiter", "stop-paginator")]
     [InlineData("stop-paginator", "unsubscribe-discord-log")]
     [InlineData("unsubscribe-discord-log", "stop-recovery")]
@@ -265,6 +284,7 @@ public class BeanBotApplicationTests
         await application.StopAsync(CancellationToken.None);
 
         Assert.Contains("stop-reaction", runtime.Calls);
+        Assert.Contains("stop-command-replies", runtime.Calls);
         Assert.Contains("stop-recovery", runtime.Calls);
         Assert.Contains("unsubscribe-events", runtime.Calls);
         Assert.Contains("stop-pun", runtime.Calls);
@@ -280,6 +300,7 @@ public class BeanBotApplicationTests
         public string? IncompleteOperation { get; init; }
         public TaskCompletionSource? IncompleteCompletion { get; init; }
         public bool ActivateDiscordLifecycleOnIncompleteOperation { get; init; }
+        public bool KeepDiscordLifecycleOwnedAfterCommandReplies { get; init; }
         public string? BlockingOperation { get; init; }
         public ManualResetEventSlim? BlockingRelease { get; init; }
         public CancellationTokenSource? ShutdownCancellation { get; init; }
@@ -302,6 +323,15 @@ public class BeanBotApplicationTests
         public void StopNewMemberEvents() => Record("stop-new-member");
         public void StopEditedMessageEvents() => Record("stop-edited-message");
         public void StopCommandServices() => Record("stop-command");
+        public Task StopCommandRepliesAsync()
+        {
+            if (KeepDiscordLifecycleOwnedAfterCommandReplies)
+            {
+                HasActiveDiscordLifecycleOperation = true;
+            }
+
+            return RecordAsync("stop-command-replies");
+        }
         public void StopMessageWaiter() => Record("stop-message-waiter");
         public void StopPaginator() => Record("stop-paginator");
         public void UnsubscribeDiscordLog() => Record("unsubscribe-discord-log");

--- a/BeanBot.Tests/Hosting/BeanBotServiceRegistrationTests.cs
+++ b/BeanBot.Tests/Hosting/BeanBotServiceRegistrationTests.cs
@@ -37,6 +37,7 @@ public class BeanBotServiceRegistrationTests
         AssertSingleton<IPunProvider>(services);
         AssertSingleton<EditMessageEventServices>(services);
         AssertSingleton<LogHandler>(services);
+        AssertSingleton<LegacyCommandReplySender>(services);
 
         var clientDescriptor = Assert.Single(
             services,

--- a/BeanBot.Tests/Integration/BeanBotHostIntegrationTests.cs
+++ b/BeanBot.Tests/Integration/BeanBotHostIntegrationTests.cs
@@ -74,6 +74,7 @@ public class BeanBotHostIntegrationTests
                 "stop-new-member",
                 "stop-edited-message",
                 "stop-command",
+                "stop-command-replies",
                 "stop-message-waiter",
                 "stop-paginator",
                 "unsubscribe-discord-log",
@@ -316,6 +317,13 @@ public class BeanBotHostIntegrationTests
         public void StopNewMemberEvents() => Calls.Add("stop-new-member");
         public void StopEditedMessageEvents() => Calls.Add("stop-edited-message");
         public void StopCommandServices() => Calls.Add("stop-command");
+
+        public Task StopCommandRepliesAsync()
+        {
+            Calls.Add("stop-command-replies");
+            return Task.CompletedTask;
+        }
+
         public void StopMessageWaiter() => Calls.Add("stop-message-waiter");
         public void StopPaginator() => Calls.Add("stop-paginator");
         public void UnsubscribeDiscordLog() => Calls.Add("unsubscribe-discord-log");

--- a/BeanBot/Discord/Commands/AdministrativeModule.cs
+++ b/BeanBot/Discord/Commands/AdministrativeModule.cs
@@ -30,17 +30,20 @@ public class AdministrativeModule : ModuleBase<SocketCommandContext>
     private readonly RoleReactService _roleReactService;
     private readonly DiscordMessageCleanupService _messageCleanupService;
     private readonly DiscordMessageWaiter _messageWaiter;
+    private readonly LegacyCommandReplySender _replySender;
     private readonly ILogger<AdministrativeModule> _logger;
 
     public AdministrativeModule(
         RoleReactService roleReactService,
         DiscordMessageCleanupService messageCleanupService,
         DiscordMessageWaiter messageWaiter,
+        LegacyCommandReplySender replySender,
         ILogger<AdministrativeModule> logger)
     {
         _roleReactService = roleReactService ?? throw new ArgumentNullException(nameof(roleReactService));
         _messageCleanupService = messageCleanupService ?? throw new ArgumentNullException(nameof(messageCleanupService));
         _messageWaiter = messageWaiter ?? throw new ArgumentNullException(nameof(messageWaiter));
+        _replySender = replySender ?? throw new ArgumentNullException(nameof(replySender));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -63,12 +66,14 @@ public class AdministrativeModule : ModuleBase<SocketCommandContext>
             var sessionFailureMessage = GetInteractionSessionFailureMessage(sessionResult);
             if (sessionFailureMessage is not null)
             {
-                messagesInInteraction.Add(await ReplyAsync(sessionFailureMessage));
+                messagesInInteraction.Add(await _replySender.SendMessageAsync(Context, sessionFailureMessage));
                 return;
             }
 
             var roleEmotePairs = new List<RoleEmotePair>();
-            messagesInInteraction.Add(await ReplyAsync($"How many roles do you wish to configure? (1-{MaximumRolesPerGroup})"));
+            messagesInInteraction.Add(await _replySender.SendMessageAsync(
+                Context,
+                $"How many roles do you wish to configure? (1-{MaximumRolesPerGroup})"));
             var amountMessage = await _messageWaiter.WaitForNextMessageAsync(Context, InteractionTimeout);
             var roleCountResult = await GetRoleCountAsync(messagesInInteraction, amountMessage);
             if (!roleCountResult.Success)
@@ -78,7 +83,7 @@ public class AdministrativeModule : ModuleBase<SocketCommandContext>
 
             for (var index = 0; index < roleCountResult.RoleCount; index++)
             {
-                messagesInInteraction.Add(await ReplyAsync("Which role would you like to set up?"));
+                messagesInInteraction.Add(await _replySender.SendMessageAsync(Context, "Which role would you like to set up?"));
                 var roleMessage = await _messageWaiter.WaitForNextMessageAsync(Context, InteractionTimeout);
                 var role = await GetRoleAsync(messagesInInteraction, roleMessage);
                 if (role == null)
@@ -86,7 +91,9 @@ public class AdministrativeModule : ModuleBase<SocketCommandContext>
                     return;
                 }
 
-                messagesInInteraction.Add(await ReplyAsync($"Which emote would you like to set up with the role {role.Name}?"));
+                messagesInInteraction.Add(await _replySender.SendMessageAsync(
+                    Context,
+                    $"Which emote would you like to set up with the role {role.Name}?"));
                 var emoteMessage = await _messageWaiter.WaitForNextMessageAsync(Context, InteractionTimeout);
                 var emote = await GetEmoteAsync(messagesInInteraction, emoteMessage);
                 if (emote == null)
@@ -98,7 +105,9 @@ public class AdministrativeModule : ModuleBase<SocketCommandContext>
                     pair.RoleId == role.Id.ToString(CultureInfo.InvariantCulture)
                     || pair.EmojiId == emote.Id.ToString(CultureInfo.InvariantCulture)))
                 {
-                    messagesInInteraction.Add(await ReplyAsync("That role or emote is already being configured. Please start again."));
+                    messagesInInteraction.Add(await _replySender.SendMessageAsync(
+                        Context,
+                        "That role or emote is already being configured. Please start again."));
                     return;
                 }
 
@@ -107,11 +116,13 @@ public class AdministrativeModule : ModuleBase<SocketCommandContext>
                     emote.Id.ToString(CultureInfo.InvariantCulture)));
             }
 
-            messagesInInteraction.Add(await ReplyAsync("Please label this group of roles (i.e. Games, Position, NSFW, etc)."));
+            messagesInInteraction.Add(await _replySender.SendMessageAsync(
+                Context,
+                "Please label this group of roles (i.e. Games, Position, NSFW, etc)."));
             var labelMessage = await _messageWaiter.WaitForNextMessageAsync(Context, InteractionTimeout);
             if (labelMessage == null)
             {
-                messagesInInteraction.Add(await ReplyAsync("Time has expired, please try again."));
+                messagesInInteraction.Add(await _replySender.SendMessageAsync(Context, "Time has expired, please try again."));
                 return;
             }
 
@@ -158,7 +169,7 @@ public class AdministrativeModule : ModuleBase<SocketCommandContext>
         }
 
         roleEmbed.WithFooter(footer => footer.Text = $"Role Group: {roleGroupLabel}");
-        return await ReplyAsync(embed: roleEmbed.Build());
+        return await _replySender.SendMessageAsync(Context, embed: roleEmbed.Build());
     }
 
     private async Task AddRoleReactionsAsync(IUserMessage messageToListen, IEnumerable<RoleEmotePair> roleEmotePairs)
@@ -177,14 +188,16 @@ public class AdministrativeModule : ModuleBase<SocketCommandContext>
     {
         if (response == null)
         {
-            messages.Add(await ReplyAsync("Time has expired, please try again."));
+            messages.Add(await _replySender.SendMessageAsync(Context, "Time has expired, please try again."));
             return (false, 0);
         }
 
         messages.Add(response);
         if (!int.TryParse(response.Content, out var roleCount) || roleCount < 1 || roleCount > MaximumRolesPerGroup)
         {
-            messages.Add(await ReplyAsync($"Please enter a whole number from 1 to {MaximumRolesPerGroup}."));
+            messages.Add(await _replySender.SendMessageAsync(
+                Context,
+                $"Please enter a whole number from 1 to {MaximumRolesPerGroup}."));
             return (false, 0);
         }
 
@@ -195,7 +208,7 @@ public class AdministrativeModule : ModuleBase<SocketCommandContext>
     {
         if (response == null)
         {
-            messages.Add(await ReplyAsync("Time has expired, please try again."));
+            messages.Add(await _replySender.SendMessageAsync(Context, "Time has expired, please try again."));
             return null;
         }
 
@@ -208,19 +221,23 @@ public class AdministrativeModule : ModuleBase<SocketCommandContext>
 
         if (roleResolution.Status == RoleResolutionStatus.MultipleMentions)
         {
-            messages.Add(await ReplyAsync("Please mention only one role. Please start again."));
+            messages.Add(await _replySender.SendMessageAsync(Context, "Please mention only one role. Please start again."));
             return null;
         }
 
         if (roleResolution.Status == RoleResolutionStatus.AmbiguousName)
         {
-            messages.Add(await ReplyAsync("Multiple roles have that name. Please mention the role you want and start again."));
+            messages.Add(await _replySender.SendMessageAsync(
+                Context,
+                "Multiple roles have that name. Please mention the role you want and start again."));
             return null;
         }
 
         if (roleResolution.Status == RoleResolutionStatus.NotFound)
         {
-            messages.Add(await ReplyAsync($"The role {response.Content} does not exist. Please start again."));
+            messages.Add(await _replySender.SendMessageAsync(
+                Context,
+                $"The role {response.Content} does not exist. Please start again."));
             return null;
         }
 
@@ -273,7 +290,7 @@ public class AdministrativeModule : ModuleBase<SocketCommandContext>
     {
         if (response == null)
         {
-            messages.Add(await ReplyAsync("Time has expired, please try again."));
+            messages.Add(await _replySender.SendMessageAsync(Context, "Time has expired, please try again."));
             return null;
         }
 
@@ -282,7 +299,9 @@ public class AdministrativeModule : ModuleBase<SocketCommandContext>
             response.Content.Contains(candidate.Name, StringComparison.OrdinalIgnoreCase));
         if (emote == null)
         {
-            messages.Add(await ReplyAsync($"The emote {response.Content} does not exist. Please start again."));
+            messages.Add(await _replySender.SendMessageAsync(
+                Context,
+                $"The emote {response.Content} does not exist. Please start again."));
             return null;
         }
 

--- a/BeanBot/Discord/Commands/HelpModule.cs
+++ b/BeanBot/Discord/Commands/HelpModule.cs
@@ -8,10 +8,14 @@ namespace BeanBot.Discord.Commands;
 public class HelpModule : ModuleBase<SocketCommandContext>
 {
     private readonly CommandService _commandService;
+    private readonly LegacyCommandReplySender _replySender;
 
-    public HelpModule(CommandService commandService)
+    public HelpModule(
+        CommandService commandService,
+        LegacyCommandReplySender replySender)
     {
         _commandService = commandService ?? throw new ArgumentNullException(nameof(commandService));
+        _replySender = replySender ?? throw new ArgumentNullException(nameof(replySender));
     }
 
     [Command("help")]
@@ -58,6 +62,8 @@ public class HelpModule : ModuleBase<SocketCommandContext>
             }
         }
 
-        await ReplyAsync(string.Empty, false, helpBuilder.Build());
+        await _replySender.SendMessageAsync(
+            Context,
+            embed: helpBuilder.Build());
     }
 }

--- a/BeanBot/Discord/Commands/InfoModule.cs
+++ b/BeanBot/Discord/Commands/InfoModule.cs
@@ -6,6 +6,13 @@ namespace BeanBot.Discord.Commands;
 [Name("Bot Information")]
 public class InfoModule : ModuleBase<SocketCommandContext>
 {
+    private readonly LegacyCommandReplySender _replySender;
+
+    public InfoModule(LegacyCommandReplySender replySender)
+    {
+        _replySender = replySender ?? throw new ArgumentNullException(nameof(replySender));
+    }
+
     [Command("dev")]
     [Summary("Tags the lead developer on Discord")]
     [Remarks("succ dev")]
@@ -13,6 +20,8 @@ public class InfoModule : ModuleBase<SocketCommandContext>
     public async Task DeveloperCommand()
     {
         const long leadDeveloperDiscordUserId = 114559039731531781;
-        await ReplyAsync($"<@{leadDeveloperDiscordUserId}> is my lead developer");
+        await _replySender.SendMessageAsync(
+            Context,
+            $"<@{leadDeveloperDiscordUserId}> is my lead developer");
     }
 }

--- a/BeanBot/Discord/Commands/LegacyCommandFeedbackResponder.cs
+++ b/BeanBot/Discord/Commands/LegacyCommandFeedbackResponder.cs
@@ -75,7 +75,7 @@ internal sealed class LegacyCommandFeedbackResponder
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(result);
 
-        if (result.IsSuccess)
+        if (result.IsSuccess || ShouldSuppressFeedback(result))
         {
             return;
         }
@@ -93,6 +93,18 @@ internal sealed class LegacyCommandFeedbackResponder
                 exception);
         }
     }
+
+    internal static bool ShouldSuppressFeedback(IResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        return result is ExecuteResult executeResult &&
+            ShouldSuppressFeedback(executeResult.Exception);
+    }
+
+    internal static bool ShouldSuppressFeedback(Exception? exception)
+        => exception is LegacyCommandReplyTimeoutException
+            or LegacyCommandReplyRejectedException
+            or OperationCanceledException;
 
     internal static string CreateFeedback(Optional<CommandInfo> command, IResult result)
     {

--- a/BeanBot/Discord/Commands/LegacyCommandReplySender.cs
+++ b/BeanBot/Discord/Commands/LegacyCommandReplySender.cs
@@ -21,7 +21,7 @@ internal sealed class LegacyCommandReplyTimeoutException : TimeoutException
     }
 }
 
-public sealed partial class LegacyCommandReplySender
+public sealed partial class LegacyCommandReplySender : IDisposable
 {
     internal const int DefaultCapacity = 16;
     internal static readonly TimeSpan DefaultSendTimeout = TimeSpan.FromSeconds(10);
@@ -43,21 +43,21 @@ public sealed partial class LegacyCommandReplySender
         IHostApplicationLifetime applicationLifetime,
         ILogger<LegacyCommandReplySender> logger)
         : this(
-            applicationLifetime?.ApplicationStopping
-                ?? throw new ArgumentNullException(nameof(applicationLifetime)),
             logger,
             DefaultCapacity,
             DefaultSendTimeout,
-            DefaultDrainTimeout)
+            DefaultDrainTimeout,
+            applicationLifetime?.ApplicationStopping
+                ?? throw new ArgumentNullException(nameof(applicationLifetime)))
     {
     }
 
     internal LegacyCommandReplySender(
-        CancellationToken applicationStopping,
         ILogger<LegacyCommandReplySender> logger,
         int capacity,
         TimeSpan sendTimeout,
-        TimeSpan drainTimeout)
+        TimeSpan drainTimeout,
+        CancellationToken applicationStopping)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentOutOfRangeException.ThrowIfLessThan(capacity, 1);
@@ -190,6 +190,11 @@ public sealed partial class LegacyCommandReplySender
 
         _shutdown.Cancel();
         return stopTask;
+    }
+
+    public void Dispose()
+    {
+        _shutdown.Dispose();
     }
 
     private OwnedReplyOperation ReserveOperation(string replyKind)

--- a/BeanBot/Discord/Commands/LegacyCommandReplySender.cs
+++ b/BeanBot/Discord/Commands/LegacyCommandReplySender.cs
@@ -1,0 +1,319 @@
+using Discord;
+using Discord.Commands;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace BeanBot.Discord.Commands;
+
+internal sealed class LegacyCommandReplyRejectedException : InvalidOperationException
+{
+    public LegacyCommandReplyRejectedException(string message)
+        : base(message)
+    {
+    }
+}
+
+internal sealed class LegacyCommandReplyTimeoutException : TimeoutException
+{
+    public LegacyCommandReplyTimeoutException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}
+
+internal sealed partial class LegacyCommandReplySender
+{
+    internal const int DefaultCapacity = 16;
+    internal static readonly TimeSpan DefaultSendTimeout = TimeSpan.FromSeconds(10);
+    internal static readonly TimeSpan DefaultDrainTimeout = TimeSpan.FromSeconds(5);
+
+    private readonly object _gate = new();
+    private readonly Dictionary<long, OwnedReplyOperation> _ownedOperations = [];
+    private readonly CancellationToken _applicationStopping;
+    private readonly CancellationTokenSource _shutdown = new();
+    private readonly ILogger<LegacyCommandReplySender> _logger;
+    private readonly int _capacity;
+    private readonly TimeSpan _sendTimeout;
+    private readonly TimeSpan _drainTimeout;
+    private long _nextOperationId;
+    private bool _stopping;
+    private Task? _stopTask;
+
+    public LegacyCommandReplySender(
+        IHostApplicationLifetime applicationLifetime,
+        ILogger<LegacyCommandReplySender> logger)
+        : this(
+            applicationLifetime?.ApplicationStopping
+                ?? throw new ArgumentNullException(nameof(applicationLifetime)),
+            logger,
+            DefaultCapacity,
+            DefaultSendTimeout,
+            DefaultDrainTimeout)
+    {
+    }
+
+    internal LegacyCommandReplySender(
+        CancellationToken applicationStopping,
+        ILogger<LegacyCommandReplySender> logger,
+        int capacity,
+        TimeSpan sendTimeout,
+        TimeSpan drainTimeout)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentOutOfRangeException.ThrowIfLessThan(capacity, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(sendTimeout, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(drainTimeout, TimeSpan.Zero);
+
+        _applicationStopping = applicationStopping;
+        _logger = logger;
+        _capacity = capacity;
+        _sendTimeout = sendTimeout;
+        _drainTimeout = drainTimeout;
+    }
+
+    internal int OwnedOperationCount
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _ownedOperations.Count;
+            }
+        }
+    }
+
+    internal bool HasPendingOperations => OwnedOperationCount > 0;
+
+    public Task<IUserMessage> SendMessageAsync(
+        ICommandContext context,
+        string text = "",
+        bool isTts = false,
+        Embed? embed = null,
+        AllowedMentions? allowedMentions = null)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        var replyKind = embed is null ? "text" : "embed";
+        return RunAsync(
+            requestOptions => context.Channel.SendMessageAsync(
+                text,
+                isTTS: isTts,
+                embed: embed,
+                options: requestOptions,
+                allowedMentions: allowedMentions),
+            replyKind);
+    }
+
+    public Task<IUserMessage> SendFileAsync(
+        ICommandContext context,
+        string filePath,
+        string text = "",
+        AllowedMentions? allowedMentions = null)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        return RunAsync(
+            requestOptions => context.Channel.SendFileAsync(
+                filePath,
+                text,
+                options: requestOptions,
+                allowedMentions: allowedMentions),
+            "file");
+    }
+
+    internal async Task<T> RunAsync<T>(
+        Func<RequestOptions, Task<T>> beginSend,
+        string replyKind)
+    {
+        ArgumentNullException.ThrowIfNull(beginSend);
+        ArgumentException.ThrowIfNullOrWhiteSpace(replyKind);
+        _applicationStopping.ThrowIfCancellationRequested();
+
+        var operation = ReserveOperation(replyKind);
+        using var operationCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            _applicationStopping,
+            _shutdown.Token);
+        operationCancellation.CancelAfter(_sendTimeout);
+
+        Task<T> sendTask;
+        try
+        {
+            sendTask = beginSend(new RequestOptions
+            {
+                CancelToken = operationCancellation.Token
+            }) ?? throw new InvalidOperationException("The Discord reply operation returned no task.");
+        }
+        catch
+        {
+            CompleteOperation(operation, null);
+            throw;
+        }
+
+        ObserveAndOwnCompletion(operation, sendTask);
+
+        try
+        {
+            return await sendTask.WaitAsync(operationCancellation.Token);
+        }
+        catch (OperationCanceledException) when (
+            _applicationStopping.IsCancellationRequested || _shutdown.IsCancellationRequested)
+        {
+            Volatile.Write(ref operation.WaiterDetached, 1);
+            throw;
+        }
+        catch (OperationCanceledException exception) when (operationCancellation.IsCancellationRequested)
+        {
+            Volatile.Write(ref operation.WaiterDetached, 1);
+            ReplyTimedOut(_logger, replyKind, _sendTimeout);
+            throw new LegacyCommandReplyTimeoutException(
+                $"Legacy command {replyKind} reply timed out after {_sendTimeout}.",
+                exception);
+        }
+    }
+
+    public Task StopAsync()
+    {
+        Task stopTask;
+        lock (_gate)
+        {
+            if (_stopTask is not null)
+            {
+                return _stopTask;
+            }
+
+            _stopping = true;
+            var pending = _ownedOperations.Values
+                .Select(operation => operation.Completion.Task)
+                .ToArray();
+            _stopTask = DrainAsync(pending);
+            stopTask = _stopTask;
+        }
+
+        _shutdown.Cancel();
+        return stopTask;
+    }
+
+    private OwnedReplyOperation ReserveOperation(string replyKind)
+    {
+        lock (_gate)
+        {
+            if (_stopping)
+            {
+                ReplyRejectedDuringShutdown(_logger, replyKind);
+                throw new LegacyCommandReplyRejectedException(
+                    "BeanBot is shutting down and is no longer accepting command replies.");
+            }
+
+            if (_ownedOperations.Count >= _capacity)
+            {
+                ReplyCapacityReached(_logger, replyKind, _ownedOperations.Count, _capacity);
+                throw new LegacyCommandReplyRejectedException(
+                    $"Legacy command reply capacity {_capacity} is exhausted.");
+            }
+
+            var operation = new OwnedReplyOperation(++_nextOperationId, replyKind);
+            _ownedOperations.Add(operation.Id, operation);
+            return operation;
+        }
+    }
+
+    private void ObserveAndOwnCompletion(OwnedReplyOperation operation, Task sendTask)
+    {
+        _ = sendTask.ContinueWith(
+            completedTask => CompleteOperation(operation, completedTask),
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    private void CompleteOperation(OwnedReplyOperation operation, Task? sendTask)
+    {
+        if (sendTask?.IsFaulted == true)
+        {
+            var exception = sendTask.Exception;
+            if (Volatile.Read(ref operation.WaiterDetached) != 0 && exception is not null)
+            {
+                ReplyLateFailure(_logger, operation.ReplyKind, exception);
+            }
+        }
+
+        var removed = false;
+        lock (_gate)
+        {
+            removed = _ownedOperations.Remove(operation.Id);
+        }
+
+        if (removed)
+        {
+            operation.Completion.TrySetResult();
+        }
+    }
+
+    private async Task DrainAsync(Task[] pendingOperations)
+    {
+        if (pendingOperations.Length == 0)
+        {
+            return;
+        }
+
+        try
+        {
+            await Task.WhenAll(pendingOperations).WaitAsync(_drainTimeout);
+        }
+        catch (TimeoutException)
+        {
+            ReplyDrainTimedOut(_logger, OwnedOperationCount, _drainTimeout);
+        }
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Rejecting legacy command {ReplyKind} reply because BeanBot is shutting down")]
+    private static partial void ReplyRejectedDuringShutdown(ILogger logger, string replyKind);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Rejecting legacy command {ReplyKind} reply because {ActiveReplyOperations} operations occupy the hard limit {ReplyOperationCapacity}")]
+    private static partial void ReplyCapacityReached(
+        ILogger logger,
+        string replyKind,
+        int activeReplyOperations,
+        int replyOperationCapacity);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Legacy command {ReplyKind} reply exceeded its bounded wait {ReplyTimeout}; delivery outcome may be ambiguous and will not be retried")]
+    private static partial void ReplyTimedOut(
+        ILogger logger,
+        string replyKind,
+        TimeSpan replyTimeout);
+
+    [LoggerMessage(
+        Level = LogLevel.Error,
+        Message = "Legacy command {ReplyKind} reply failed after its caller stopped waiting")]
+    private static partial void ReplyLateFailure(
+        ILogger logger,
+        string replyKind,
+        Exception exception);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Timed out draining {ActiveReplyOperations} legacy command reply operation(s) after {DrainTimeout}; Discord client teardown must remain blocked while they are still owned")]
+    private static partial void ReplyDrainTimedOut(
+        ILogger logger,
+        int activeReplyOperations,
+        TimeSpan drainTimeout);
+
+    private sealed class OwnedReplyOperation
+    {
+        public OwnedReplyOperation(long id, string replyKind)
+        {
+            Id = id;
+            ReplyKind = replyKind;
+        }
+
+        public long Id { get; }
+        public string ReplyKind { get; }
+        public TaskCompletionSource Completion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int WaiterDetached;
+    }
+}

--- a/BeanBot/Discord/Commands/LegacyCommandReplySender.cs
+++ b/BeanBot/Discord/Commands/LegacyCommandReplySender.cs
@@ -21,7 +21,7 @@ internal sealed class LegacyCommandReplyTimeoutException : TimeoutException
     }
 }
 
-internal sealed partial class LegacyCommandReplySender
+public sealed partial class LegacyCommandReplySender
 {
     internal const int DefaultCapacity = 16;
     internal static readonly TimeSpan DefaultSendTimeout = TimeSpan.FromSeconds(10);

--- a/BeanBot/Discord/Commands/MemeModule.cs
+++ b/BeanBot/Discord/Commands/MemeModule.cs
@@ -20,6 +20,7 @@ public class MemeModule : ModuleBase<SocketCommandContext>
     private readonly IMemeProvider _memeProvider;
     private readonly ExternalMediaCommandOptions _mediaOptions;
     private readonly IHostApplicationLifetime _applicationLifetime;
+    private readonly LegacyCommandReplySender _replySender;
     private readonly ILogger<MemeModule> _logger;
 
     public MemeModule(
@@ -31,6 +32,7 @@ public class MemeModule : ModuleBase<SocketCommandContext>
         IMemeProvider memeProvider,
         ExternalMediaCommandOptions mediaOptions,
         IHostApplicationLifetime applicationLifetime,
+        LegacyCommandReplySender replySender,
         ILogger<MemeModule> logger)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
@@ -41,6 +43,7 @@ public class MemeModule : ModuleBase<SocketCommandContext>
         _memeProvider = memeProvider ?? throw new ArgumentNullException(nameof(memeProvider));
         _mediaOptions = mediaOptions ?? throw new ArgumentNullException(nameof(mediaOptions));
         _applicationLifetime = applicationLifetime ?? throw new ArgumentNullException(nameof(applicationLifetime));
+        _replySender = replySender ?? throw new ArgumentNullException(nameof(replySender));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -86,7 +89,7 @@ public class MemeModule : ModuleBase<SocketCommandContext>
     [RequireBotPermission(ChannelPermission.SendMessages)]
     public async Task McDonalds()
     {
-        await ReplyAsync("<:mcdonalds:661337575704887337>");
+        await _replySender.SendMessageAsync(Context, "<:mcdonalds:661337575704887337>");
     }
 
     [Command("fancy ocho ocho")]
@@ -104,7 +107,7 @@ public class MemeModule : ModuleBase<SocketCommandContext>
     [RequireBotPermission(ChannelPermission.SendMessages)]
     public async Task BlazeIt()
     {
-        await ReplyAsync("<:420stolfoit:675553715759087618>");
+        await _replySender.SendMessageAsync(Context, "<:420stolfoit:675553715759087618>");
     }
 
     [Command("toes")]
@@ -190,7 +193,7 @@ public class MemeModule : ModuleBase<SocketCommandContext>
 
         if (meme == null)
         {
-            await ReplyAsync("The meme machine is down, quick, call 911!");
+            await _replySender.SendMessageAsync(Context, "The meme machine is down, quick, call 911!");
         }
         else
         {
@@ -200,7 +203,7 @@ public class MemeModule : ModuleBase<SocketCommandContext>
                 Description = $"/r/{meme.SubReddit}",
                 ImageUrl = meme.ImageUrl
             };
-            await ReplyAsync(embed: memeBuilder.Build());
+            await _replySender.SendMessageAsync(Context, embed: memeBuilder.Build());
         }
     }
 
@@ -210,7 +213,7 @@ public class MemeModule : ModuleBase<SocketCommandContext>
     [RequireBotPermission(ChannelPermission.SendMessages)]
     public async Task NationalBird()
     {
-        await ReplyAsync("The Texas Offical National Bird is the AR-15");
+        await _replySender.SendMessageAsync(Context, "The Texas Offical National Bird is the AR-15");
     }
 
     [Command("texasnationalflower")]
@@ -218,7 +221,7 @@ public class MemeModule : ModuleBase<SocketCommandContext>
     [Remarks("texasnationalflower")]
     public async Task NationalFlower()
     {
-        await ReplyAsync("The Texas Official National Flower is the Jimmy Dean breakfast taco");
+        await _replySender.SendMessageAsync(Context, "The Texas Official National Flower is the Jimmy Dean breakfast taco");
     }
 
     [Command("texasfacts")]
@@ -227,18 +230,18 @@ public class MemeModule : ModuleBase<SocketCommandContext>
     public async Task TexasFacts()
     {
         var fact = TexasFactResponses[Random.Shared.Next(TexasFactResponses.Length)];
-        await ReplyAsync($"Did you know: {fact}");
+        await _replySender.SendMessageAsync(Context, $"Did you know: {fact}");
     }
 
     private async Task ChooseRandomPun()
     {
         if (!_punProvider.TryGetRandomPun(out var pun))
         {
-            await ReplyAsync("The PunMaster is temporarily out of material.");
+            await _replySender.SendMessageAsync(Context, "The PunMaster is temporarily out of material.");
             return;
         }
 
-        await ReplyAsync(pun);
+        await _replySender.SendMessageAsync(Context, pun);
     }
 
     private async Task ChooseRandomAnswer(string question)
@@ -289,10 +292,23 @@ public class MemeModule : ModuleBase<SocketCommandContext>
             var safeRejection = CreateMentionSafeReply(rejection);
             try
             {
-                await Context.Channel.SendFileAsync(
+                await _replySender.SendFileAsync(
+                    Context,
                     $"Resources/gordon{gordonGif}.gif",
                     safeRejection.Content,
-                    allowedMentions: safeRejection.AllowedMentions);
+                    safeRejection.AllowedMentions);
+            }
+            catch (LegacyCommandReplyTimeoutException)
+            {
+                throw;
+            }
+            catch (LegacyCommandReplyRejectedException)
+            {
+                throw;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
             }
             catch (Exception exception)
             {
@@ -383,7 +399,7 @@ public class MemeModule : ModuleBase<SocketCommandContext>
             stage,
             GetSafeMediaSource(url),
             exception.GetType().Name);
-        await ReplyAsync("I couldn't download that image right now.");
+        await _replySender.SendMessageAsync(Context, "I couldn't download that image right now.");
     }
 
     internal static string GetSafeMediaSource(Uri url)
@@ -422,7 +438,10 @@ public class MemeModule : ModuleBase<SocketCommandContext>
     private Task<IUserMessage> ReplyWithReflectedContentAsync(string content)
     {
         var reply = CreateMentionSafeReply(content);
-        return ReplyAsync(reply.Content, allowedMentions: reply.AllowedMentions);
+        return _replySender.SendMessageAsync(
+            Context,
+            reply.Content,
+            allowedMentions: reply.AllowedMentions);
     }
 
     private async Task ReplyWithOchoOcho()

--- a/BeanBot/Hosting/BeanBotApplication.cs
+++ b/BeanBot/Hosting/BeanBotApplication.cs
@@ -18,6 +18,7 @@ internal interface IBeanBotRuntime
     void StopNewMemberEvents();
     void StopEditedMessageEvents();
     void StopCommandServices();
+    Task StopCommandRepliesAsync();
     void StopMessageWaiter();
     void StopPaginator();
     void UnsubscribeDiscordLog();
@@ -135,6 +136,7 @@ internal sealed class BeanBotApplication : IBeanBotApplication
         await RunSynchronousStageAsync("new-member-events", _runtime.StopNewMemberEvents);
         await RunSynchronousStageAsync("edited-message-events", _runtime.StopEditedMessageEvents);
         await RunSynchronousStageAsync("command-services", _runtime.StopCommandServices);
+        await RunStageAsync("command-replies", _runtime.StopCommandRepliesAsync);
         await RunSynchronousStageAsync("message-waiter", _runtime.StopMessageWaiter);
         await RunSynchronousStageAsync("paginator", _runtime.StopPaginator);
         await RunSynchronousStageAsync("discord-log", _runtime.UnsubscribeDiscordLog);

--- a/BeanBot/Hosting/BeanBotRuntime.cs
+++ b/BeanBot/Hosting/BeanBotRuntime.cs
@@ -1,3 +1,4 @@
+using BeanBot.Discord.Commands;
 using BeanBot.Discord.Events;
 using BeanBot.Discord.Lifecycle;
 using BeanBot.Discord.Messaging;
@@ -19,6 +20,7 @@ internal sealed class BeanBotRuntime : IBeanBotRuntime
     private readonly DiscordOwnerErrorNotifier _ownerErrorNotifier;
     private readonly HealthCheckServer _healthCheckServer;
     private readonly CommandHandler _commandHandler;
+    private readonly LegacyCommandReplySender _commandReplySender;
     private readonly PunHandler _punHandler;
     private readonly EditMessageHandler _editMessageHandler;
     private readonly NewMemberHandler _newMemberHandler;
@@ -39,6 +41,7 @@ internal sealed class BeanBotRuntime : IBeanBotRuntime
         DiscordOwnerErrorNotifier ownerErrorNotifier,
         HealthCheckServer healthCheckServer,
         CommandHandler commandHandler,
+        LegacyCommandReplySender commandReplySender,
         PunHandler punHandler,
         EditMessageHandler editMessageHandler,
         NewMemberHandler newMemberHandler,
@@ -57,6 +60,7 @@ internal sealed class BeanBotRuntime : IBeanBotRuntime
         _ownerErrorNotifier = ownerErrorNotifier ?? throw new ArgumentNullException(nameof(ownerErrorNotifier));
         _healthCheckServer = healthCheckServer ?? throw new ArgumentNullException(nameof(healthCheckServer));
         _commandHandler = commandHandler ?? throw new ArgumentNullException(nameof(commandHandler));
+        _commandReplySender = commandReplySender ?? throw new ArgumentNullException(nameof(commandReplySender));
         _punHandler = punHandler ?? throw new ArgumentNullException(nameof(punHandler));
         _editMessageHandler = editMessageHandler ?? throw new ArgumentNullException(nameof(editMessageHandler));
         _newMemberHandler = newMemberHandler ?? throw new ArgumentNullException(nameof(newMemberHandler));
@@ -68,7 +72,7 @@ internal sealed class BeanBotRuntime : IBeanBotRuntime
     }
 
     public bool HasActiveDiscordLifecycleOperation
-        => _discordLifecycleCoordinator.HasActiveSequence;
+        => _discordLifecycleCoordinator.HasActiveSequence || _commandReplySender.HasPendingOperations;
 
     public bool CanDisposeDiscordClient => _canDisposeDiscordClient;
 
@@ -110,6 +114,8 @@ internal sealed class BeanBotRuntime : IBeanBotRuntime
     public void StopEditedMessageEvents() => _editMessageHandler.Dispose();
 
     public void StopCommandServices() => _commandHandler.Dispose();
+
+    public Task StopCommandRepliesAsync() => _commandReplySender.StopAsync();
 
     public void StopMessageWaiter() => _messageWaiter.Dispose();
 

--- a/BeanBot/Hosting/BeanBotServiceCollectionExtensions.cs
+++ b/BeanBot/Hosting/BeanBotServiceCollectionExtensions.cs
@@ -99,6 +99,7 @@ internal static class BeanBotServiceCollectionExtensions
             provider.GetRequiredService<DiscordOwnerErrorNotifier>());
         services.AddSingleton<DiscordOutageRecoveryNotifier>();
         services.AddSingleton<LogHandler>();
+        services.AddSingleton<LegacyCommandReplySender>();
         services.AddSingleton<DiscordLegacyCommandFeedbackDelivery>();
         services.AddSingleton<ILegacyCommandFeedbackDelivery>(provider =>
             provider.GetRequiredService<DiscordLegacyCommandFeedbackDelivery>());


### PR DESCRIPTION
Closes #184

## Summary
- add a singleton legacy-command reply owner with a finite 10-second application wait, Discord request cancellation, and a hard 16-operation capacity that includes timed-out-but-still-running sends
- retain ownership of ambiguous late Discord operations until the underlying task settles, observe late faults, reject new work at capacity/shutdown, and perform a bounded shutdown drain before Discord client teardown
- route ordinary legacy text/embed/local-file replies through the bounded sender while preserving specialized paginator, external-media upload, cleanup, and command-error feedback paths
- suppress secondary command-error feedback when the original reply timed out, was rejected, or was canceled so ambiguous sends are never automatically duplicated
- extend shutdown lifecycle and tests so surviving reply work prevents Discord client stop/disposal from racing known in-flight command replies

## Planner / implementation scope
The repository-owned Planner inspected the command modules, command feedback, external-media guards, hosting lifecycle, DI, tests, configuration, Docker/CI, verification scripts, documentation, and current issue/PR backlog. The approved smallest-change plan keeps the existing legacy command surface and specialized bounded operations intact while adding ownership only around ordinary successful replies. No material design decision remained unresolved.

## Implementation notes
- `LegacyCommandReplySender` uses one linked cancellation owner for Discord.Net `RequestOptions.CancelToken` and BeanBot's bounded waiter. Operational timeout, host/shutdown cancellation, and capacity/shutdown rejection remain distinguishable.
- A timed-out waiter never retries. Its reply-operation slot remains occupied until the underlying Discord task actually settles, so timeout handling cannot create an unbounded abandoned-task tail. Late faults are explicitly observed.
- Shutdown stops reply admission, cancels owned sends, waits through the bounded reply drain, and keeps surviving sends represented by `HasActiveDiscordLifecycleOperation`; normal Discord stop/disposal is skipped while such work remains.
- Administrative, help, info, and meme command modules route ordinary replies through the sender. Existing paginator and external-media owners remain specialized. Reflected user content continues to use `AllowedMentions.None`; intentional bot-authored mentions retain their existing behavior.

## Tests
Deterministic coverage includes normal bounded completion, timeout without retry, hard-cap rejection and capacity reuse, late-fault observation, host/shutdown cancellation, shared request-token propagation, bounded drain behavior, command-feedback suppression, DI registration, application shutdown ownership/order, and the existing mention-safety/legacy-command regression suite.

## Final verification and review
Final source head: `9d19ad9bbc8db6b44b6c9bf13bbb4ab1861f116e` against unchanged `develop` at `47e4ba8c1180d0777082309ac87665cece38d793` (19 commits ahead / 0 behind).

- Repository Verification #326: **PASS**. The pull-request run is associated with source head `9d19ad9bbc8db6b44b6c9bf13bbb4ab1861f116e`; GitHub checks out the PR merge result `cf9cecfdece106fcc1515bfd5c05f706784d3cb0`, while the repository workflow pins `BEANBOT_BRANCH_INTEGRITY_CANDIDATE` to the exact PR head. `./scripts/verify.sh full` passed locked restore, formatting/analyzers, Release build, **456/456 tests**, coverage (**66.21% lines / 54.68% branches**), branch/diff integrity, vulnerable-package audit, Docker build, hardened-container smoke, and SIGTERM shutdown smoke.
- CodeQL #161: **PASS** on head `9d19ad9bbc8db6b44b6c9bf13bbb4ab1861f116e`.
- Dependency Review #135: **PASS** on head `9d19ad9bbc8db6b44b6c9bf13bbb4ab1861f116e`.
- Fresh repository-owned Verifier: **PASS**. Every #184 acceptance criterion maps to the final diff and deterministic CI evidence; branch policy is correct and current `develop` has not moved.
- Fresh independent Reviewer: **CLEAN**. No consequential correctness, Discord lifecycle race, duplicate-send, unbounded wait/retry, cancellation, health, persistence, security, test-quality, Docker/runtime, dependency/release, or unrelated-scope finding remains.
- Review threads: **0 open**. Two Copilot nits were dispositioned without source changes: the pre-existing `Offical` wording is intentionally preserved because #184 explicitly requires response wording compatibility, and the explicit no-fallback rethrows are retained because they make the ambiguous-send duplicate-prevention boundary clear; the proposed filtered catch would be behaviorally equivalent style cleanup.

GitHub CI caught and the bounded implementation repair loop corrected four concrete integration/analyzer defects before the final green source head: the host-test runtime fake was updated for the new reply-stop lifecycle method; the DI-injected reply sender's accessibility was made compatible with public command modules; the sender was made disposable and its cancellation-token constructor ordering analyzer-compliant; and the test helper's cancellation-token parameter ordering was corrected. Each repair stayed within #184 and was reverified on a new head.

Local focused/fast/full execution was unavailable in this automation runtime because `github.com` could not be resolved, so no local PASS is claimed. Repository-authorized pull-request CI supplied the deterministic verification evidence instead.

## Compatibility / manual validation
- no command names, aliases, response wording, persistence schema, configuration surface, Docker contract, dependency versions, or release behavior are changed by #184
- reflected user content remains mention-safe; the intentional `%dev` mention remains enabled
- deployment smoke check: exercise representative ordinary text/embed/local-file legacy replies, then stop the bot once with no stalled send and confirm normal Discord shutdown; optionally simulate a stalled Discord reply in a non-production environment and confirm the process fails safe rather than disposing the client underneath known work