### PR TITLE
Make daily pun schedule configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@ BEANBOT_GENERAL_CHANNEL_ID=
 BEANBOT_HATOETE_URL=
 BEANBOT_YOSHIMARU_URL=
 
+# Optional daily pun schedule
+# Values are local wall-clock time (24-hour HH:mm) plus an IANA or Windows timezone ID.
+BEANBOT_DAILY_PUN_TIME=16:20
+BEANBOT_DAILY_PUN_TIMEZONE=America/Chicago
+
 # Optional health check endpoint
 # Leave BEANBOT_HEALTHCHECK_PORT empty to disable the endpoint entirely.
 BEANBOT_HEALTHCHECK_PORT=

--- a/BeanBot.Tests/Configuration/DailyPunScheduleConfigurationTests.cs
+++ b/BeanBot.Tests/Configuration/DailyPunScheduleConfigurationTests.cs
@@ -1,0 +1,116 @@
+using BeanBot.Configuration;
+using BeanBot.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace BeanBot.Tests.Configuration;
+
+public class DailyPunScheduleConfigurationTests
+{
+    [Fact]
+    public void Options_OmittedDailyPunSettingsPreserveExistingSchedule()
+    {
+        using var provider = CreateProvider(RequiredSettings());
+        var options = provider.GetRequiredService<BeanBotOptions>();
+
+        Assert.Equal(new TimeSpan(16, 20, 0), options.DailyPun.LocalTime);
+        Assert.Equal("America/Chicago", options.DailyPun.TimeZoneId);
+        Assert.NotNull(options.DailyPun.TimeZone);
+    }
+
+    [Fact]
+    public void Options_ParsesCanonicalDailyPunSchedule()
+    {
+        var values = RequiredSettings();
+        values[BeanBotConfiguration.DailyPunTimeVariable] = "09:05";
+        values[BeanBotConfiguration.DailyPunTimeZoneVariable] = "Europe/London";
+
+        using var provider = CreateProvider(values);
+        var options = provider.GetRequiredService<BeanBotOptions>();
+
+        Assert.Equal(new TimeSpan(9, 5, 0), options.DailyPun.LocalTime);
+        Assert.Equal("Europe/London", options.DailyPun.TimeZoneId);
+    }
+
+    [Theory]
+    [InlineData("BEANBOT_DAILY_PUN_TIME", "9:05")]
+    [InlineData("BEANBOT_DAILY_PUN_TIME", "24:00")]
+    [InlineData("BEANBOT_DAILY_PUN_TIMEZONE", "Mars/Olympus")]
+    [InlineData("BEANBOT_DAILY_PUN_TIMEZONE", " ")]
+    public void Options_RejectsMalformedDailyPunScheduleWithoutEchoingValue(string key, string value)
+    {
+        var values = RequiredSettings();
+        values[key] = value;
+
+        using var provider = CreateProvider(values);
+        var exception = Assert.Throws<OptionsValidationException>(
+            () => provider.GetRequiredService<BeanBotOptions>());
+
+        Assert.Contains(key, exception.Message);
+        Assert.DoesNotContain(value, exception.Message);
+    }
+
+    [Theory]
+    [InlineData("America/Chicago")]
+    [InlineData("Central Standard Time")]
+    public void Options_ResolvesIanaAndWindowsTimeZoneIds(string timeZoneId)
+    {
+        var values = RequiredSettings();
+        values[BeanBotConfiguration.DailyPunTimeZoneVariable] = timeZoneId;
+
+        using var provider = CreateProvider(values);
+        var options = provider.GetRequiredService<BeanBotOptions>();
+
+        Assert.Equal(timeZoneId, options.DailyPun.TimeZoneId);
+        Assert.NotNull(options.DailyPun.TimeZone);
+    }
+
+    [Fact]
+    public void Options_BindsHierarchicalDailyPunSchedule()
+    {
+        var configuration = new ConfigurationManager();
+        configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["BeanBot:BotToken"] = "section-token",
+            ["BeanBot:MongoConnectionString"] = "mongodb://section:27017",
+            ["BeanBot:GeneralChannelId"] = "321",
+            ["BeanBot:HatoeteUrl"] = "https://section.example/hatoete.png",
+            ["BeanBot:YoshimaruUrl"] = "https://section.example/yoshimaru.png",
+            ["BeanBot:DailyPun:Time"] = "07:45",
+            ["BeanBot:DailyPun:TimeZone"] = "UTC"
+        });
+        configuration.AddBeanBotConfiguration(Array.Empty<string>());
+
+        using var provider = CreateProvider(configuration);
+        var options = provider.GetRequiredService<BeanBotOptions>();
+
+        Assert.Equal(new TimeSpan(7, 45, 0), options.DailyPun.LocalTime);
+        Assert.Equal("UTC", options.DailyPun.TimeZoneId);
+    }
+
+    private static ServiceProvider CreateProvider(IReadOnlyDictionary<string, string?> values)
+    {
+        var configuration = new ConfigurationManager();
+        configuration.AddInMemoryCollection(values);
+        configuration.AddBeanBotConfiguration(Array.Empty<string>());
+        return CreateProvider(configuration);
+    }
+
+    private static ServiceProvider CreateProvider(IConfiguration configuration)
+    {
+        var services = new ServiceCollection();
+        services.AddBeanBot(configuration);
+        return services.BuildServiceProvider();
+    }
+
+    private static Dictionary<string, string?> RequiredSettings() => new()
+    {
+        [BeanBotConfiguration.BotTokenVariable] = "token",
+        [BeanBotConfiguration.MongoConnectionVariable] = "mongodb://localhost:27017",
+        [BeanBotConfiguration.GeneralChannelVariable] = "123",
+        [BeanBotConfiguration.HatoeteUrlVariable] = "https://example.com/hatoete.png",
+        [BeanBotConfiguration.YoshimaruUrlVariable] = "https://example.com/yoshimaru.png"
+    };
+}

--- a/BeanBot.Tests/Configuration/DailyPunScheduleConfigurationTests.cs
+++ b/BeanBot.Tests/Configuration/DailyPunScheduleConfigurationTests.cs
@@ -38,7 +38,6 @@ public class DailyPunScheduleConfigurationTests
     [InlineData("BEANBOT_DAILY_PUN_TIME", "9:05")]
     [InlineData("BEANBOT_DAILY_PUN_TIME", "24:00")]
     [InlineData("BEANBOT_DAILY_PUN_TIMEZONE", "Mars/Olympus")]
-    [InlineData("BEANBOT_DAILY_PUN_TIMEZONE", " ")]
     public void Options_RejectsMalformedDailyPunScheduleWithoutEchoingValue(string key, string value)
     {
         var values = RequiredSettings();

--- a/BeanBot.Tests/Discord/Events/DailyPunScheduleTests.cs
+++ b/BeanBot.Tests/Discord/Events/DailyPunScheduleTests.cs
@@ -1,0 +1,91 @@
+using System.Diagnostics.CodeAnalysis;
+using BeanBot.Configuration;
+using BeanBot.Discord.Commands;
+using BeanBot.Discord.Events;
+using Discord.WebSocket;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.Events;
+
+public class DailyPunScheduleTests
+{
+    [Fact]
+    public void ComputeNextOccurrenceUtc_UsesConfiguredLocalTimeAndTimeZone()
+    {
+        var schedule = CreateSchedule("09:00", "Asia/Tokyo");
+        var nowUtc = new DateTimeOffset(2026, 1, 15, 1, 0, 0, TimeSpan.Zero);
+
+        var nextUtc = PunHandler.ComputeNextOccurrenceUtc(schedule, nowUtc);
+
+        Assert.Equal(new DateTimeOffset(2026, 1, 16, 0, 0, 0, TimeSpan.Zero), nextUtc);
+    }
+
+    [Fact]
+    public void ComputeNextOccurrenceUtc_SpringForwardMovesInvalidWallTimeForwardOnce()
+    {
+        var schedule = CreateSchedule("02:30", "America/Chicago");
+        var nowUtc = new DateTimeOffset(2026, 3, 8, 7, 0, 0, TimeSpan.Zero);
+
+        var nextUtc = PunHandler.ComputeNextOccurrenceUtc(schedule, nowUtc);
+
+        Assert.Equal(new DateTimeOffset(2026, 3, 8, 8, 30, 0, TimeSpan.Zero), nextUtc);
+    }
+
+    [Fact]
+    public void ComputeNextOccurrenceUtc_FallBackChoosesOneStandardTimeOccurrence()
+    {
+        var schedule = CreateSchedule("01:30", "America/Chicago");
+        var nowUtc = new DateTimeOffset(2026, 11, 1, 5, 0, 0, TimeSpan.Zero);
+
+        var nextUtc = PunHandler.ComputeNextOccurrenceUtc(schedule, nowUtc);
+
+        Assert.Equal(new DateTimeOffset(2026, 11, 1, 7, 30, 0, TimeSpan.Zero), nextUtc);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_CancelsScheduledDelayWithInjectedClock()
+    {
+        using var client = new DiscordSocketClient();
+        var schedule = CreateSchedule("16:20", "America/Chicago");
+        var options = new BeanBotOptions(
+            "token",
+            "mongodb://localhost",
+            1,
+            new Uri("https://example.com/hatoete"),
+            new Uri("https://example.com/yoshimaru"),
+            schedule,
+            HealthCheckOptions.Disabled);
+        var handler = new PunHandler(
+            client,
+            options,
+            new UnavailablePunProvider(),
+            NullLogger<PunHandler>.Instance,
+            new FrozenTimeProvider(new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero)));
+
+        handler.Start();
+
+        await handler.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(1));
+    }
+
+    private static DailyPunSchedule CreateSchedule(string localTime, string timeZoneId)
+    {
+        Assert.True(DailyPunSchedule.TryParseLocalTime(localTime, out var parsedTime));
+        Assert.True(DailyPunSchedule.TryResolveTimeZone(timeZoneId, out var timeZone));
+        return new DailyPunSchedule(parsedTime, timeZoneId, timeZone!);
+    }
+
+    private sealed class FrozenTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+
+    private sealed class UnavailablePunProvider : IPunProvider
+    {
+        public bool TryGetRandomPun([NotNullWhen(true)] out string? pun)
+        {
+            pun = null;
+            return false;
+        }
+    }
+}

--- a/BeanBot.Tests/Discord/Events/DailyPunScheduleTests.cs
+++ b/BeanBot.Tests/Discord/Events/DailyPunScheduleTests.cs
@@ -33,10 +33,32 @@ public class DailyPunScheduleTests
     }
 
     [Fact]
+    public void ComputeNextOccurrenceUtc_SpringForwardKeepsAdjustedOccurrenceUntilItPasses()
+    {
+        var schedule = CreateSchedule("02:30", "America/Chicago");
+        var nowUtc = new DateTimeOffset(2026, 3, 8, 8, 15, 0, TimeSpan.Zero);
+
+        var nextUtc = PunHandler.ComputeNextOccurrenceUtc(schedule, nowUtc);
+
+        Assert.Equal(new DateTimeOffset(2026, 3, 8, 8, 30, 0, TimeSpan.Zero), nextUtc);
+    }
+
+    [Fact]
     public void ComputeNextOccurrenceUtc_FallBackChoosesOneStandardTimeOccurrence()
     {
         var schedule = CreateSchedule("01:30", "America/Chicago");
         var nowUtc = new DateTimeOffset(2026, 11, 1, 5, 0, 0, TimeSpan.Zero);
+
+        var nextUtc = PunHandler.ComputeNextOccurrenceUtc(schedule, nowUtc);
+
+        Assert.Equal(new DateTimeOffset(2026, 11, 1, 7, 30, 0, TimeSpan.Zero), nextUtc);
+    }
+
+    [Fact]
+    public void ComputeNextOccurrenceUtc_FallBackKeepsChosenOccurrenceDuringFirstRepeatedHour()
+    {
+        var schedule = CreateSchedule("01:30", "America/Chicago");
+        var nowUtc = new DateTimeOffset(2026, 11, 1, 6, 45, 0, TimeSpan.Zero);
 
         var nextUtc = PunHandler.ComputeNextOccurrenceUtc(schedule, nowUtc);
 

--- a/BeanBot/Configuration/BeanBotConfiguration.cs
+++ b/BeanBot/Configuration/BeanBotConfiguration.cs
@@ -10,6 +10,8 @@ internal static class BeanBotConfiguration
     internal const string GeneralChannelVariable = "BEANBOT_GENERAL_CHANNEL_ID";
     internal const string HatoeteUrlVariable = "BEANBOT_HATOETE_URL";
     internal const string YoshimaruUrlVariable = "BEANBOT_YOSHIMARU_URL";
+    internal const string DailyPunTimeVariable = "BEANBOT_DAILY_PUN_TIME";
+    internal const string DailyPunTimeZoneVariable = "BEANBOT_DAILY_PUN_TIMEZONE";
     internal const string HealthCheckPortVariable = "BEANBOT_HEALTHCHECK_PORT";
     internal const string HealthCheckBindAddressVariable = "BEANBOT_HEALTHCHECK_BIND_ADDRESS";
     internal const string HealthCheckBearerTokenVariable = "BEANBOT_HEALTHCHECK_BEARER_TOKEN";
@@ -22,6 +24,12 @@ internal static class BeanBotConfiguration
         new(GeneralChannelVariable, "generalChannelId", "GeneralChannelId"),
         new(HatoeteUrlVariable, "hatoeteUrl", "HatoeteUrl"),
         new(YoshimaruUrlVariable, "yoshimaruUrl", "YoshimaruUrl")
+    ];
+
+    private static readonly ConfigurationKey[] DailyPunKeys =
+    [
+        new(DailyPunTimeVariable, "dailyPunTime", "DailyPun:Time"),
+        new(DailyPunTimeZoneVariable, "dailyPunTimezone", "DailyPun:TimeZone")
     ];
 
     private static readonly ConfigurationKey HealthCheckPort =
@@ -44,6 +52,11 @@ internal static class BeanBotConfiguration
 
         var normalizedValues = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
         foreach (var key in RequiredKeys)
+        {
+            AddNormalizedValue(configuration, normalizedValues, key);
+        }
+
+        foreach (var key in DailyPunKeys)
         {
             AddNormalizedValue(configuration, normalizedValues, key);
         }

--- a/BeanBot/Configuration/BeanBotOptions.cs
+++ b/BeanBot/Configuration/BeanBotOptions.cs
@@ -11,12 +11,32 @@ public sealed class BeanBotOptions
         Uri hatoeteImageUrl,
         Uri yoshimaruImageUrl,
         HealthCheckOptions healthCheck)
+        : this(
+            botToken,
+            mongoConnectionString,
+            generalChannelId,
+            hatoeteImageUrl,
+            yoshimaruImageUrl,
+            DailyPunSchedule.CreateDefault(),
+            healthCheck)
+    {
+    }
+
+    public BeanBotOptions(
+        string botToken,
+        string mongoConnectionString,
+        ulong generalChannelId,
+        Uri hatoeteImageUrl,
+        Uri yoshimaruImageUrl,
+        DailyPunSchedule dailyPun,
+        HealthCheckOptions healthCheck)
     {
         BotToken = botToken;
         MongoConnectionString = mongoConnectionString;
         GeneralChannelId = generalChannelId;
         HatoeteImageUrl = hatoeteImageUrl;
         YoshimaruImageUrl = yoshimaruImageUrl;
+        DailyPun = dailyPun ?? throw new ArgumentNullException(nameof(dailyPun));
         HealthCheck = healthCheck;
     }
 
@@ -25,6 +45,7 @@ public sealed class BeanBotOptions
     public ulong GeneralChannelId { get; }
     public Uri HatoeteImageUrl { get; }
     public Uri YoshimaruImageUrl { get; }
+    public DailyPunSchedule DailyPun { get; }
     public HealthCheckOptions HealthCheck { get; }
 }
 

--- a/BeanBot/Configuration/BeanBotOptionsFactory.cs
+++ b/BeanBot/Configuration/BeanBotOptionsFactory.cs
@@ -15,6 +15,7 @@ internal static class BeanBotOptionsFactory
             ulong.Parse(settings.GeneralChannelId!, NumberStyles.None, CultureInfo.InvariantCulture),
             new Uri(settings.HatoeteUrl!, UriKind.Absolute),
             new Uri(settings.YoshimaruUrl!, UriKind.Absolute),
+            DailyPunSchedule.Create(settings.DailyPun),
             CreateHealthCheckOptions(settings.HealthCheck));
     }
 

--- a/BeanBot/Configuration/BeanBotSettings.cs
+++ b/BeanBot/Configuration/BeanBotSettings.cs
@@ -9,7 +9,14 @@ internal sealed class BeanBotSettings
     public string? GeneralChannelId { get; set; }
     public string? HatoeteUrl { get; set; }
     public string? YoshimaruUrl { get; set; }
+    public BeanBotDailyPunSettings DailyPun { get; set; } = new BeanBotDailyPunSettings();
     public BeanBotHealthCheckSettings HealthCheck { get; set; } = new BeanBotHealthCheckSettings();
+}
+
+internal sealed class BeanBotDailyPunSettings
+{
+    public string? Time { get; set; } = DailyPunSchedule.DefaultTime;
+    public string? TimeZone { get; set; } = DailyPunSchedule.DefaultTimeZoneId;
 }
 
 internal sealed class BeanBotHealthCheckSettings

--- a/BeanBot/Configuration/BeanBotSettingsValidator.cs
+++ b/BeanBot/Configuration/BeanBotSettingsValidator.cs
@@ -44,11 +44,31 @@ internal sealed class BeanBotSettingsValidator : IValidateOptions<BeanBotSetting
             "yoshimaruUrl",
             failures);
 
+        ValidateDailyPun(settings.DailyPun, failures);
         ValidateHealthCheck(settings.HealthCheck, failures);
 
         return failures.Count == 0
             ? ValidateOptionsResult.Success
             : ValidateOptionsResult.Fail(failures);
+    }
+
+    private static void ValidateDailyPun(
+        BeanBotDailyPunSettings settings,
+        List<string> failures)
+    {
+        if (!DailyPunSchedule.TryParseLocalTime(settings.Time, out _))
+        {
+            failures.Add(
+                $"Invalid value for {BeanBotConfiguration.DailyPunTimeVariable}. " +
+                "Expected a 24-hour local time in HH:mm format.");
+        }
+
+        if (!DailyPunSchedule.TryResolveTimeZone(settings.TimeZone, out _))
+        {
+            failures.Add(
+                $"Invalid value for {BeanBotConfiguration.DailyPunTimeZoneVariable}. " +
+                "Expected a recognized IANA or Windows timezone ID.");
+        }
     }
 
     private static void ValidateHealthCheck(

--- a/BeanBot/Configuration/DailyPunSchedule.cs
+++ b/BeanBot/Configuration/DailyPunSchedule.cs
@@ -1,0 +1,102 @@
+using System.Globalization;
+
+namespace BeanBot.Configuration;
+
+public sealed class DailyPunSchedule
+{
+    public const string DefaultTime = "16:20";
+    public const string DefaultTimeZoneId = "America/Chicago";
+
+    internal DailyPunSchedule(TimeSpan localTime, string timeZoneId, TimeZoneInfo timeZone)
+    {
+        LocalTime = localTime;
+        TimeZoneId = timeZoneId;
+        TimeZone = timeZone;
+    }
+
+    public TimeSpan LocalTime { get; }
+    public string TimeZoneId { get; }
+    public TimeZoneInfo TimeZone { get; }
+
+    internal static DailyPunSchedule Create(BeanBotDailyPunSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        if (!TryParseLocalTime(settings.Time, out var localTime) ||
+            !TryResolveTimeZone(settings.TimeZone, out var timeZone))
+        {
+            throw new InvalidOperationException(
+                "Daily pun settings must be validated before creating BeanBot options.");
+        }
+
+        return new DailyPunSchedule(localTime, settings.TimeZone!, timeZone!);
+    }
+
+    internal static DailyPunSchedule CreateDefault()
+        => Create(new BeanBotDailyPunSettings());
+
+    internal static bool TryParseLocalTime(string? value, out TimeSpan localTime)
+    {
+        if (TimeOnly.TryParseExact(
+            value,
+            "HH:mm",
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out var parsed))
+        {
+            localTime = parsed.ToTimeSpan();
+            return true;
+        }
+
+        localTime = default;
+        return false;
+    }
+
+    internal static bool TryResolveTimeZone(string? timeZoneId, out TimeZoneInfo? timeZone)
+    {
+        if (string.IsNullOrWhiteSpace(timeZoneId))
+        {
+            timeZone = null;
+            return false;
+        }
+
+        if (TryFindTimeZone(timeZoneId, out timeZone))
+        {
+            return true;
+        }
+
+        if (TimeZoneInfo.TryConvertIanaIdToWindowsId(timeZoneId, out var windowsId) &&
+            TryFindTimeZone(windowsId, out timeZone))
+        {
+            return true;
+        }
+
+        if (TimeZoneInfo.TryConvertWindowsIdToIanaId(timeZoneId, out var ianaId) &&
+            TryFindTimeZone(ianaId, out timeZone))
+        {
+            return true;
+        }
+
+        timeZone = null;
+        return false;
+    }
+
+    private static bool TryFindTimeZone(string timeZoneId, out TimeZoneInfo? timeZone)
+    {
+        try
+        {
+            timeZone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+            return true;
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            timeZone = null;
+            return false;
+        }
+        catch (InvalidTimeZoneException)
+        {
+            timeZone = null;
+            return false;
+        }
+    }
+}

--- a/BeanBot/Discord/Events/PunHandler.cs
+++ b/BeanBot/Discord/Events/PunHandler.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using BeanBot.Configuration;
 using BeanBot.Discord.Commands;
 using BeanBot.Logging;
@@ -90,9 +90,9 @@ public sealed class PunHandler : IAsyncDisposable
                     PunScheduleLog.Scheduled(
                         _logger,
                         nextLocal,
+                        _schedule.TimeZoneId,
                         nextUtc,
-                        nowLocal,
-                        _schedule.TimeZoneId);
+                        nowLocal);
                 }
 
                 await Task.Delay(delay, _timeProvider, token);
@@ -241,25 +241,35 @@ public sealed class PunHandler : IAsyncDisposable
             schedule.LocalTime.Seconds,
             DateTimeKind.Unspecified);
 
-        if (currentLocalTime.TimeOfDay >= schedule.LocalTime)
+        var nextOccurrenceUtc = ResolveOccurrenceUtc(schedule.TimeZone, tentativeNextPostTime);
+        if (nextOccurrenceUtc <= nowUtc)
         {
-            tentativeNextPostTime = tentativeNextPostTime.AddDays(1);
+            nextOccurrenceUtc = ResolveOccurrenceUtc(
+                schedule.TimeZone,
+                tentativeNextPostTime.AddDays(1));
         }
 
-        if (schedule.TimeZone.IsInvalidTime(tentativeNextPostTime))
+        return nextOccurrenceUtc;
+    }
+
+    private static DateTimeOffset ResolveOccurrenceUtc(
+        TimeZoneInfo timeZone,
+        DateTime localOccurrence)
+    {
+        if (timeZone.IsInvalidTime(localOccurrence))
         {
-            tentativeNextPostTime = tentativeNextPostTime.AddHours(1);
+            localOccurrence = localOccurrence.AddHours(1);
         }
-        else if (schedule.TimeZone.IsAmbiguousTime(tentativeNextPostTime))
+        else if (timeZone.IsAmbiguousTime(localOccurrence))
         {
-            var offsets = schedule.TimeZone.GetAmbiguousTimeOffsets(tentativeNextPostTime);
-            var preferredOffset = offsets.Contains(schedule.TimeZone.BaseUtcOffset)
-                ? schedule.TimeZone.BaseUtcOffset
+            var offsets = timeZone.GetAmbiguousTimeOffsets(localOccurrence);
+            var preferredOffset = offsets.Contains(timeZone.BaseUtcOffset)
+                ? timeZone.BaseUtcOffset
                 : offsets.Min();
-            return new DateTimeOffset(tentativeNextPostTime, preferredOffset).ToUniversalTime();
+            return new DateTimeOffset(localOccurrence, preferredOffset).ToUniversalTime();
         }
 
-        var utc = TimeZoneInfo.ConvertTimeToUtc(tentativeNextPostTime, schedule.TimeZone);
+        var utc = TimeZoneInfo.ConvertTimeToUtc(localOccurrence, timeZone);
         return new DateTimeOffset(utc, TimeSpan.Zero);
     }
 

--- a/BeanBot/Discord/Events/PunHandler.cs
+++ b/BeanBot/Discord/Events/PunHandler.cs
@@ -12,13 +12,14 @@ public sealed class PunHandler : IAsyncDisposable
 {
     private readonly DiscordSocketClient _discordClient;
     private readonly ulong _generalChannelId;
+    private readonly DailyPunSchedule _schedule;
     private readonly IPunProvider _punProvider;
     private readonly ILogger<PunHandler> _logger;
+    private readonly TimeProvider _timeProvider;
     private readonly CancellationTokenSource _tokenSource = new();
     private Task? _runner;
     private int _disposed;
 
-    private static readonly TimeSpan PostTimeLocal = new(16, 20, 0);
     internal static readonly TimeSpan MessageSendTimeout = TimeSpan.FromSeconds(10);
 
     public PunHandler(
@@ -26,11 +27,29 @@ public sealed class PunHandler : IAsyncDisposable
         BeanBotOptions options,
         IPunProvider punProvider,
         ILogger<PunHandler> logger)
+        : this(
+            discordSocketClient,
+            options,
+            punProvider,
+            logger,
+            TimeProvider.System)
+    {
+    }
+
+    internal PunHandler(
+        DiscordSocketClient discordSocketClient,
+        BeanBotOptions options,
+        IPunProvider punProvider,
+        ILogger<PunHandler> logger,
+        TimeProvider timeProvider)
     {
         _discordClient = discordSocketClient ?? throw new ArgumentNullException(nameof(discordSocketClient));
-        _generalChannelId = (options ?? throw new ArgumentNullException(nameof(options))).GeneralChannelId;
+        var configuredOptions = options ?? throw new ArgumentNullException(nameof(options));
+        _generalChannelId = configuredOptions.GeneralChannelId;
+        _schedule = configuredOptions.DailyPun;
         _punProvider = punProvider ?? throw new ArgumentNullException(nameof(punProvider));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
         BeanBotLog.PunServiceInitializing(_logger);
     }
 
@@ -48,54 +67,54 @@ public sealed class PunHandler : IAsyncDisposable
 
     private async Task RunAsync(CancellationToken token)
     {
-        var timezone = GetChicagoTimeZone();
-
         while (!token.IsCancellationRequested)
         {
             try
             {
-                var nextRunUtc = ComputeNextOccurenceUtc(timezone, PostTimeLocal);
-                var delay = nextRunUtc - DateTimeOffset.UtcNow;
+                var nowUtc = _timeProvider.GetUtcNow();
+                var nextRunUtc = ComputeNextOccurrenceUtc(_schedule, nowUtc);
+                var delay = nextRunUtc - nowUtc;
                 if (delay < TimeSpan.Zero)
                 {
                     delay = TimeSpan.Zero;
                 }
 
-                var chicagoNow = GetChicagoNow(timezone);
                 if (_logger.IsEnabled(LogLevel.Information))
                 {
-                    var nextLocal = TimeZoneInfo.ConvertTime(nextRunUtc, timezone)
+                    var nextLocal = TimeZoneInfo.ConvertTime(nextRunUtc, _schedule.TimeZone)
                         .ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
                     var nextUtc = nextRunUtc.UtcDateTime
                         .ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
-                    var nowLocal = chicagoNow.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
-                    BeanBotLog.PunScheduled(
+                    var nowLocal = TimeZoneInfo.ConvertTime(nowUtc, _schedule.TimeZone)
+                        .ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+                    PunScheduleLog.Scheduled(
                         _logger,
                         nextLocal,
                         nextUtc,
-                        nowLocal);
+                        nowLocal,
+                        _schedule.TimeZoneId);
                 }
 
-                await Task.Delay(delay, token);
+                await Task.Delay(delay, _timeProvider, token);
 
-                await PostDailyAsync(timezone, token);
+                await PostDailyAsync(token);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (token.IsCancellationRequested)
             {
                 BeanBotLog.PunServiceShuttingDown(_logger);
             }
             catch (Exception ex)
             {
                 BeanBotLog.PunLoopFailed(_logger, ex);
-                await Task.Delay(TimeSpan.FromSeconds(30), token);
+                await Task.Delay(TimeSpan.FromSeconds(30), _timeProvider, token);
             }
         }
     }
 
-    private async Task PostDailyAsync(TimeZoneInfo timezone, CancellationToken token)
+    private async Task PostDailyAsync(CancellationToken token)
     {
-        var chicagoNow = GetChicagoNow(timezone);
-        BeanBotLog.PunPosting(_logger, chicagoNow);
+        var localNow = TimeZoneInfo.ConvertTime(_timeProvider.GetUtcNow(), _schedule.TimeZone);
+        PunScheduleLog.Posting(_logger, localNow, _schedule.TimeZoneId);
 
         var channel = _discordClient.GetChannel(_generalChannelId) as SocketTextChannel;
         if (channel is null)
@@ -206,56 +225,43 @@ public sealed class PunHandler : IAsyncDisposable
             TaskScheduler.Default);
     }
 
-    private static TimeZoneInfo GetChicagoTimeZone()
+    internal static DateTimeOffset ComputeNextOccurrenceUtc(
+        DailyPunSchedule schedule,
+        DateTimeOffset nowUtc)
     {
-        try
-        {
-            // If on Linux or MacOS
-            return TimeZoneInfo.FindSystemTimeZoneById("America/Chicago");
-        }
-        catch (TimeZoneNotFoundException)
-        {
-            // If on Windows
-            return TimeZoneInfo.FindSystemTimeZoneById("Central Standard Time");
-        }
-    }
+        ArgumentNullException.ThrowIfNull(schedule);
 
-    private static DateTimeOffset GetChicagoNow(TimeZoneInfo timezone)
-        => TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, timezone);
-
-
-    private static DateTimeOffset ComputeNextOccurenceUtc(TimeZoneInfo timezone, TimeSpan localTime)
-    {
-        var currentChicagoTime = GetChicagoNow(timezone);
+        var currentLocalTime = TimeZoneInfo.ConvertTime(nowUtc, schedule.TimeZone);
         var tentativeNextPostTime = new DateTime(
-            currentChicagoTime.Year,
-            currentChicagoTime.Month,
-            currentChicagoTime.Day,
-            localTime.Hours,
-            localTime.Minutes,
-            localTime.Seconds,
-            DateTimeKind.Unspecified
-        );
+            currentLocalTime.Year,
+            currentLocalTime.Month,
+            currentLocalTime.Day,
+            schedule.LocalTime.Hours,
+            schedule.LocalTime.Minutes,
+            schedule.LocalTime.Seconds,
+            DateTimeKind.Unspecified);
 
-        if (currentChicagoTime.TimeOfDay >= localTime)
+        if (currentLocalTime.TimeOfDay >= schedule.LocalTime)
         {
             tentativeNextPostTime = tentativeNextPostTime.AddDays(1);
         }
 
-        if (timezone.IsInvalidTime(tentativeNextPostTime))
+        if (schedule.TimeZone.IsInvalidTime(tentativeNextPostTime))
         {
             tentativeNextPostTime = tentativeNextPostTime.AddHours(1);
         }
-        else if (timezone.IsAmbiguousTime(tentativeNextPostTime))
+        else if (schedule.TimeZone.IsAmbiguousTime(tentativeNextPostTime))
         {
-            return new DateTimeOffset(tentativeNextPostTime, timezone.GetAmbiguousTimeOffsets(tentativeNextPostTime)[0]);
+            var offsets = schedule.TimeZone.GetAmbiguousTimeOffsets(tentativeNextPostTime);
+            var preferredOffset = offsets.Contains(schedule.TimeZone.BaseUtcOffset)
+                ? schedule.TimeZone.BaseUtcOffset
+                : offsets.Min();
+            return new DateTimeOffset(tentativeNextPostTime, preferredOffset).ToUniversalTime();
         }
 
-        var utc = TimeZoneInfo.ConvertTimeToUtc(tentativeNextPostTime, timezone);
-
+        var utc = TimeZoneInfo.ConvertTimeToUtc(tentativeNextPostTime, schedule.TimeZone);
         return new DateTimeOffset(utc, TimeSpan.Zero);
     }
-
 
     public async ValueTask DisposeAsync()
     {

--- a/BeanBot/Logging/PunScheduleLog.cs
+++ b/BeanBot/Logging/PunScheduleLog.cs
@@ -10,9 +10,9 @@ internal static partial class PunScheduleLog
     internal static partial void Scheduled(
         ILogger logger,
         string nextLocal,
+        string timeZoneId,
         string nextUtc,
-        string nowLocal,
-        string timeZoneId);
+        string nowLocal);
 
     [LoggerMessage(
         Level = LogLevel.Information,

--- a/BeanBot/Logging/PunScheduleLog.cs
+++ b/BeanBot/Logging/PunScheduleLog.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Logging;
+
+namespace BeanBot.Logging;
+
+internal static partial class PunScheduleLog
+{
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Next pun scheduled for {NextLocal} in {TimeZoneId} ({NextUtc} UTC). Now: {NowLocal}")]
+    internal static partial void Scheduled(
+        ILogger logger,
+        string nextLocal,
+        string nextUtc,
+        string nowLocal,
+        string timeZoneId);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Posting daily pun at {LocalTime} in {TimeZoneId}")]
+    internal static partial void Posting(
+        ILogger logger,
+        DateTimeOffset localTime,
+        string timeZoneId);
+}

--- a/docs/daily-pun-schedule.md
+++ b/docs/daily-pun-schedule.md
@@ -1,0 +1,23 @@
+# Daily pun schedule configuration
+
+BeanBot posts the automatic daily pun according to a configured local wall-clock time and timezone. Existing deployments do not need to add new settings: the default remains **16:20 America/Chicago**.
+
+## Settings
+
+```env
+BEANBOT_DAILY_PUN_TIME=16:20
+BEANBOT_DAILY_PUN_TIMEZONE=America/Chicago
+```
+
+`BEANBOT_DAILY_PUN_TIME` must use 24-hour `HH:mm` format. `BEANBOT_DAILY_PUN_TIMEZONE` accepts a timezone ID recognized by the .NET runtime. IANA IDs such as `America/Chicago` and Windows IDs such as `Central Standard Time` are resolved through the runtime's cross-platform timezone conversion support.
+
+The schedule is validated when BeanBot starts. A malformed time or unknown timezone stops startup with a diagnostic that names the affected setting without echoing its configured value. Schedule settings are immutable for the process lifetime, so changing either environment variable requires a normal BeanBot restart.
+
+## Daylight-saving behavior
+
+Scheduling uses the configured timezone rather than the host machine's local timezone.
+
+- If the configured wall-clock time does not exist on a spring-forward date, BeanBot moves that occurrence forward by one hour, matching the legacy scheduler behavior.
+- If the configured wall-clock time occurs twice on a fall-back date, BeanBot selects one standard-time occurrence rather than scheduling both.
+
+The automatic schedule changes only when these settings change. The `%pun` command and the existing three-message daily-pun output are unchanged.


### PR DESCRIPTION
Closes #186

## Summary
- add validated `BEANBOT_DAILY_PUN_TIME` and `BEANBOT_DAILY_PUN_TIMEZONE` settings while preserving the zero-config 16:20 America/Chicago schedule
- resolve configured IANA/Windows timezone IDs through one cross-platform configuration helper and fail startup on malformed time/timezone values without echoing configured values
- make `PunHandler` consume an immutable validated schedule and an injectable `TimeProvider` instead of hardcoded Chicago/time constants or host-local time
- preserve the existing spring-forward adjustment, choose one deterministic standard-time occurrence during fall-back, and keep existing three-message output, `%pun`, bounded send, cancellation, and no-ambiguous-retry behavior unchanged
- document the runtime settings, defaults, restart requirement, and DST behavior

## Planner / implementation scope
The repository-owned Planner inspected `AGENTS.md`, current `develop`, the daily-pun handler/tests, configuration/options/validation pipeline, Dockerfile, verification scripts/workflow, documentation, current issues, and open PRs. Issue #186 had no implementation PR before this branch was created.

Current `develop` does not yet contain #180 / PR #181, so this implementation deliberately does not import unmerged restart-safe scheduling/persistence work. If #181 lands first, conflict resolution must make its catch-up/checkpoint local-date logic consume this configured schedule without weakening its durable at-most-once semantics.

The approved smallest-change plan keeps ordinary work based on and targeting `develop`, changes only schedule configuration/validation/calculation seams plus focused tests/docs, and does not change pun content, destination-channel behavior, dependencies, persistence, Docker contract, health behavior, or release workflows.

## Implementation
- `DailyPunSchedule` owns the validated immutable local time, configured timezone ID, and resolved `TimeZoneInfo`; defaults remain 16:20 / America/Chicago.
- the existing configuration compatibility pipeline now recognizes the two canonical `BEANBOT_*` variables (plus flat legacy aliases), while hierarchical `BeanBot:DailyPun:*` configuration continues to bind normally.
- startup options validation accepts strict 24-hour `HH:mm` time values and runtime-recognized IANA/Windows timezone IDs, with diagnostics that name the setting but do not echo its value.
- timezone resolution uses the BCL's IANA/Windows conversion helpers rather than a Chicago-specific platform branch or a new dependency.
- `PunHandler` uses the configured timezone for all wall-clock calculations/logging and an injected/testable clock; normal production uses `TimeProvider.System`.
- spring-forward invalid wall times retain the legacy +1-hour policy; fall-back ambiguous wall times choose one deterministic standard-time occurrence.
- next-occurrence calculation resolves the chosen local occurrence to an absolute UTC instant before deciding whether that day's occurrence has passed. This prevents a restart during the spring-forward adjustment window or the first repeated fall-back hour from skipping the still-upcoming intended occurrence.
- the existing bounded Discord send/no-ambiguous-retry implementation is unchanged.

## Tests
Focused coverage includes:
- omitted settings preserving 16:20 America/Chicago
- custom canonical and hierarchical schedule configuration
- malformed time and unknown timezone validation without value disclosure
- IANA and Windows timezone resolution through the same helper
- next-occurrence calculation using a custom timezone rather than host-local time
- deterministic spring-forward and fall-back behavior
- regression coverage for the spring-forward adjusted-occurrence window and the first repeated fall-back hour
- prompt shutdown cancellation while waiting on an injected scheduler clock

The repository full gate also keeps the daily-pun message ordering, timeout, cancellation, `%pun`, configuration, Docker/runtime, and broader regression suites green.

## Review-found fixes
- Fresh verification found a DST edge case in the initial implementation: comparing only local `TimeOfDay` could skip the intended same-day occurrence after the nominal wall time but before the resolved DST occurrence. The scheduler now resolves today's intended occurrence to UTC first, compares that absolute instant to `nowUtc`, and only then advances to tomorrow. Deterministic regression tests cover both spring-forward and fall-back cases.
- Copilot review found that `LoggerMessage` binds template values positionally and the original `PunScheduleLog.Scheduled` parameter order did not match the placeholder order. The method signature and call site were reordered so timezone/UTC/current-local values are emitted in the correct structured fields. The review thread is resolved.

## Final verification and review
Final source head: `87f63dbfaacb939d09f43ec463af614286977fe4` against current `develop` `47e4ba8c1180d0777082309ac87665cece38d793` (16 commits ahead / 0 behind).

- Repository Verification #330: **PASS** on exact source head `87f63dbfaacb939d09f43ec463af614286977fe4`. The pull-request workflow checks out the PR candidate, runs `./scripts/verify.sh full`, and pins `BEANBOT_BRANCH_INTEGRITY_CANDIDATE` to the exact PR source head. The full verification job completed successfully.
- CodeQL #165: **PASS** on exact source head `87f63dbfaacb939d09f43ec463af614286977fe4`.
- Dependency Review #139: **PASS** on exact source head `87f63dbfaacb939d09f43ec463af614286977fe4`.
- Fresh repository-owned Verifier after the review fixes: **PASS**. Every applicable #186 acceptance criterion maps to the final diff and exact-head deterministic CI evidence; branch policy is correct and `develop` remains unchanged. The #180-specific criteria are conditional and not applicable because #180 has not landed on `develop`.
- Fresh independent Reviewer after Verifier PASS: **CLEAN**. No consequential correctness, Discord lifecycle/duplicate-send, unbounded wait/retry, cancellation, health, persistence, security, test-quality, Docker/runtime, dependency/release, or unrelated-scope finding remains.
- Review threads: **0 open**; the one Copilot thread is resolved on the final head.

Local focused / `./scripts/verify.sh fast` / `./scripts/verify.sh full` execution is not claimed: this automation runtime cannot resolve `github.com`, so repository-authorized exact-head GitHub Actions evidence supplies the deterministic gates instead.

## Compatibility / manual validation
Existing deployments need no new variables. The default remains 16:20 America/Chicago; changing either schedule variable requires a normal process restart. No package, persistence schema, Docker, command, or release migration is introduced.

After deployment, start once with defaults and once with a non-default schedule/timezone and confirm the schedule log reflects the configured wall-clock/timezone while `%pun` and the automatic three-message wording/order remain unchanged. If #181 lands before this PR, reconcile its catch-up/checkpoint local-date logic to this configured schedule before merging.