### PR TITLE
Add read-only role-menu audit command

### DIFF
--- a/BeanBot.Tests/Discord/RoleMenus/RoleMenuAuditServiceTests.cs
+++ b/BeanBot.Tests/Discord/RoleMenus/RoleMenuAuditServiceTests.cs
@@ -282,9 +282,7 @@ public class RoleMenuAuditServiceTests
 
         internal Fixture(int menuCount = 1)
         {
-            Settings = Enumerable.Range(0, menuCount)
-                .Select(index => CreateSettings((ulong)(5 + index)))
-                .ToList();
+            Settings = [.. Enumerable.Range(0, menuCount).Select(index => CreateSettings((ulong)(5 + index)))];
             _bot = Proxy<IGuildUser>((method, _) => method.Name switch
             {
                 "get_Id" => BotId,

--- a/BeanBot.Tests/Discord/RoleMenus/RoleMenuAuditServiceTests.cs
+++ b/BeanBot.Tests/Discord/RoleMenus/RoleMenuAuditServiceTests.cs
@@ -1,0 +1,395 @@
+using System.Reflection;
+using BeanBot.Discord.RoleMenus;
+using BeanBot.Persistence.Models;
+using Discord;
+using MongoDB.Bson;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.RoleMenus;
+
+public class RoleMenuAuditServiceTests
+{
+    [Fact]
+    public async Task AuditSpecific_Healthy_WhenCurrentStateMatchesSavedPanel()
+    {
+        var fixture = new Fixture();
+
+        var result = await fixture.Service.AuditAsync(
+            Fixture.GuildId,
+            Fixture.BotId,
+            fixture.Settings[0].Id,
+            CancellationToken.None);
+
+        var item = Assert.Single(result.Items);
+        Assert.Equal(RoleMenuAuditStatus.Healthy, item.Status);
+        Assert.False(result.RequestedMenuNotFound);
+        Assert.False(result.PersistenceUnavailable);
+        Assert.Equal(1, fixture.BotReads);
+        Assert.Equal(1, fixture.ChannelReads);
+        Assert.Equal(1, fixture.PanelReads);
+    }
+
+    [Fact]
+    public async Task AuditSpecific_NotFound_DoesNotReadDiscord()
+    {
+        var fixture = new Fixture();
+
+        var result = await fixture.Service.AuditAsync(
+            Fixture.GuildId,
+            Fixture.BotId,
+            ObjectId.GenerateNewId(),
+            CancellationToken.None);
+
+        Assert.True(result.RequestedMenuNotFound);
+        Assert.Empty(result.Items);
+        Assert.Equal(0, fixture.BotReads);
+        Assert.Equal(0, fixture.ChannelReads);
+        Assert.Equal(0, fixture.PanelReads);
+    }
+
+    [Fact]
+    public async Task AuditSpecific_MissingChannel_IsBroken()
+    {
+        var fixture = new Fixture { Channel = null };
+
+        var result = await fixture.AuditFirstAsync();
+
+        var item = Assert.Single(result.Items);
+        Assert.Equal(RoleMenuAuditStatus.Broken, item.Status);
+        Assert.Contains("channel", item.Reason, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, fixture.PanelReads);
+    }
+
+    [Fact]
+    public async Task AuditSpecific_MissingPanel_IsBroken()
+    {
+        var fixture = new Fixture { Panel = null };
+
+        var result = await fixture.AuditFirstAsync();
+
+        var item = Assert.Single(result.Items);
+        Assert.Equal(RoleMenuAuditStatus.Broken, item.Status);
+        Assert.Contains("message", item.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task AuditSpecific_UnexpectedAuthor_IsBroken()
+    {
+        var fixture = new Fixture();
+        fixture.PanelFactory = settings => new RoleMenuPanelSnapshot(
+            Fixture.GuildId,
+            Fixture.ChannelId,
+            ulong.Parse(settings.MessageId),
+            999UL,
+            true);
+
+        var result = await fixture.AuditFirstAsync();
+
+        var item = Assert.Single(result.Items);
+        Assert.Equal(RoleMenuAuditStatus.Broken, item.Status);
+        Assert.Contains("authored", item.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task AuditSpecific_DeletedRole_IsBrokenBeforeChannelRead()
+    {
+        var fixture = new Fixture
+        {
+            RoleValidation = new RoleMenuRoleValidationResult(
+                [],
+                [new RoleMenuRoleIssue(10UL, null, RoleMenuRoleIssueKind.Missing)])
+        };
+
+        var result = await fixture.AuditFirstAsync();
+
+        var item = Assert.Single(result.Items);
+        Assert.Equal(RoleMenuAuditStatus.Broken, item.Status);
+        Assert.Contains("deleted", item.Reason, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, fixture.ChannelReads);
+    }
+
+    [Theory]
+    [InlineData(RoleMenuRoleIssueKind.Managed, "managed")]
+    [InlineData(RoleMenuRoleIssueKind.BotHierarchy, "highest role")]
+    [InlineData(RoleMenuRoleIssueKind.BotMissingManageRoles, "Manage Roles")]
+    public async Task AuditSpecific_UnassignableRoleState_IsBroken(
+        RoleMenuRoleIssueKind issueKind,
+        string expectedReason)
+    {
+        var fixture = new Fixture
+        {
+            RoleValidation = new RoleMenuRoleValidationResult(
+                [],
+                [new RoleMenuRoleIssue(10UL, "Role", issueKind)])
+        };
+
+        var result = await fixture.AuditFirstAsync();
+
+        var item = Assert.Single(result.Items);
+        Assert.Equal(RoleMenuAuditStatus.Broken, item.Status);
+        Assert.Contains(expectedReason, item.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task AuditSpecific_MissingChannelPermission_IsBrokenBeforePanelRead()
+    {
+        var fixture = new Fixture
+        {
+            PermissionFailure =
+                "Bean Bot is missing these permissions in the target channel: **Read Message History**."
+        };
+
+        var result = await fixture.AuditFirstAsync();
+
+        var item = Assert.Single(result.Items);
+        Assert.Equal(RoleMenuAuditStatus.Broken, item.Status);
+        Assert.Contains("Read Message History", item.Reason, StringComparison.Ordinal);
+        Assert.Equal(0, fixture.PanelReads);
+    }
+
+    [Fact]
+    public async Task AuditBulk_TransientLookupFailure_IsUnknownAndLaterMenusStillComplete()
+    {
+        var fixture = new Fixture(menuCount: 2);
+        var firstMenuId = fixture.Settings[0].Id;
+        fixture.ChannelReader = (_, _, _) =>
+        {
+            fixture.ChannelReads++;
+            return fixture.ChannelReads == 1
+                ? Task.FromException<ITextChannel?>(new TimeoutException("Discord lookup timed out."))
+                : Task.FromResult<ITextChannel?>(fixture.Channel);
+        };
+
+        var result = await fixture.Service.AuditAsync(
+            Fixture.GuildId,
+            Fixture.BotId,
+            null,
+            CancellationToken.None);
+
+        Assert.Equal(2, result.Items.Count);
+        Assert.Equal(RoleMenuAuditStatus.Unknown,
+            result.Items.Single(item => item.MenuId == firstMenuId).Status);
+        Assert.Equal(RoleMenuAuditStatus.Healthy,
+            result.Items.Single(item => item.MenuId != firstMenuId).Status);
+        Assert.Equal(2, fixture.ChannelReads);
+        Assert.Equal(1, fixture.PanelReads);
+    }
+
+    [Fact]
+    public async Task AuditBulk_IsHardCappedAtTwentyFiveAndSequential()
+    {
+        var fixture = new Fixture(menuCount: RoleMenuConstants.MaximumListedMenus + 1);
+        var activeReads = 0;
+        var maximumActiveReads = 0;
+        fixture.ChannelReader = async (_, _, cancellationToken) =>
+        {
+            fixture.ChannelReads++;
+            var active = Interlocked.Increment(ref activeReads);
+            maximumActiveReads = Math.Max(maximumActiveReads, active);
+            try
+            {
+                await Task.Yield();
+                cancellationToken.ThrowIfCancellationRequested();
+                return fixture.Channel;
+            }
+            finally
+            {
+                Interlocked.Decrement(ref activeReads);
+            }
+        };
+
+        var result = await fixture.Service.AuditAsync(
+            Fixture.GuildId,
+            Fixture.BotId,
+            null,
+            CancellationToken.None);
+
+        Assert.True(result.HasMore);
+        Assert.Equal(RoleMenuConstants.MaximumListedMenus, result.Items.Count);
+        Assert.Equal(RoleMenuConstants.MaximumListedMenus + 1, fixture.RequestedGuildLimit);
+        Assert.Equal(RoleMenuConstants.MaximumListedMenus, fixture.ChannelReads);
+        Assert.Equal(1, maximumActiveReads);
+    }
+
+    [Fact]
+    public async Task AuditBulk_ParentCancellation_StopsStartingFurtherMenus()
+    {
+        var fixture = new Fixture(menuCount: 2);
+        var readStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        fixture.ChannelReader = async (_, _, cancellationToken) =>
+        {
+            fixture.ChannelReads++;
+            readStarted.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return fixture.Channel;
+        };
+        using var cancellation = new CancellationTokenSource();
+
+        var audit = fixture.Service.AuditAsync(
+            Fixture.GuildId,
+            Fixture.BotId,
+            null,
+            cancellation.Token);
+        await readStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => audit);
+        Assert.Equal(1, fixture.ChannelReads);
+        Assert.Equal(0, fixture.PanelReads);
+    }
+
+    [Fact]
+    public async Task AuditSpecific_PersistenceFailure_IsUnknownWithoutDiscordReads()
+    {
+        var fixture = new Fixture();
+        fixture.SettingsReader = (_, _, _) =>
+            Task.FromException<RoleMenuSettings?>(new TimeoutException("Mongo timeout"));
+
+        var result = await fixture.AuditFirstAsync();
+
+        var item = Assert.Single(result.Items);
+        Assert.Equal(RoleMenuAuditStatus.Unknown, item.Status);
+        Assert.True(result.PersistenceUnavailable);
+        Assert.Equal(0, fixture.BotReads);
+        Assert.Equal(0, fixture.ChannelReads);
+    }
+
+    [Fact]
+    public void Presentation_BulkResult_RemainsWithinDiscordContentLimit()
+    {
+        var items = Enumerable.Range(0, RoleMenuConstants.MaximumListedMenus)
+            .Select(_ => new RoleMenuAuditItem(
+                ObjectId.GenerateNewId(),
+                RoleMenuAuditStatus.Broken,
+                new string('x', 500)))
+            .ToList();
+
+        var content = RoleMenuAuditPresentation.Format(
+            new RoleMenuAuditBatchResult(items, HasMore: true),
+            null);
+
+        Assert.True(content.Length <= RoleMenuConstants.MaximumResponseContentLength);
+        Assert.Contains("25 newest", content, StringComparison.Ordinal);
+    }
+
+    private sealed class Fixture
+    {
+        internal const ulong GuildId = 1UL;
+        internal const ulong BotId = 2UL;
+        internal const ulong ChannelId = 4UL;
+
+        private readonly IGuildUser _bot;
+
+        internal Fixture(int menuCount = 1)
+        {
+            Settings = Enumerable.Range(0, menuCount)
+                .Select(index => CreateSettings((ulong)(5 + index)))
+                .ToList();
+            _bot = Proxy<IGuildUser>((method, _) => method.Name switch
+            {
+                "get_Id" => BotId,
+                _ => throw new NotSupportedException(method.Name)
+            });
+            Channel = Proxy<ITextChannel>((method, _) => throw new NotSupportedException(method.Name));
+            PanelFactory = settings => new RoleMenuPanelSnapshot(
+                GuildId,
+                ChannelId,
+                ulong.Parse(settings.MessageId),
+                BotId,
+                true);
+            SettingsReader = (menuId, guildId, cancellationToken) =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return Task.FromResult<RoleMenuSettings?>(
+                    Settings.FirstOrDefault(item => item.Id == menuId && item.GuildId == guildId.ToString()));
+            };
+            GuildSettingsReader = (guildId, maximumResults, cancellationToken) =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                RequestedGuildLimit = maximumResults;
+                return Task.FromResult<IReadOnlyList<RoleMenuSettings>>(
+                    Settings.Where(item => item.GuildId == guildId.ToString())
+                        .Take(maximumResults)
+                        .ToList());
+            };
+            ChannelReader = (_, _, cancellationToken) =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                ChannelReads++;
+                return Task.FromResult(Channel);
+            };
+
+            Service = new RoleMenuAuditService(new RoleMenuAuditOperations(
+                (menuId, guildId, cancellationToken) =>
+                    SettingsReader(menuId, guildId, cancellationToken),
+                (guildId, maximumResults, cancellationToken) =>
+                    GuildSettingsReader(guildId, maximumResults, cancellationToken),
+                (_, _, cancellationToken) =>
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    BotReads++;
+                    return Task.FromResult<IGuildUser?>(_bot);
+                },
+                (_, _) => RoleValidation,
+                (guildId, channelId, cancellationToken) =>
+                    ChannelReader(guildId, channelId, cancellationToken),
+                (_, _) => PermissionFailure,
+                (_, _, messageId, menuId, cancellationToken) =>
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    PanelReads++;
+                    var settings = Settings.Single(item => item.Id == menuId);
+                    Assert.Equal(ulong.Parse(settings.MessageId), messageId);
+                    return Task.FromResult(PanelFactory(settings));
+                }));
+        }
+
+        internal RoleMenuAuditService Service { get; }
+        internal List<RoleMenuSettings> Settings { get; }
+        internal ITextChannel? Channel { get; set; }
+        internal RoleMenuPanelSnapshot? Panel
+        {
+            set => PanelFactory = _ => value;
+        }
+        internal Func<RoleMenuSettings, RoleMenuPanelSnapshot?> PanelFactory { get; set; }
+        internal RoleMenuRoleValidationResult RoleValidation { get; set; } =
+            new([], []);
+        internal string? PermissionFailure { get; set; }
+        internal int BotReads { get; private set; }
+        internal int ChannelReads { get; set; }
+        internal int PanelReads { get; private set; }
+        internal int RequestedGuildLimit { get; private set; }
+        internal Func<ObjectId, ulong, CancellationToken, Task<RoleMenuSettings?>> SettingsReader { get; set; }
+        internal Func<ulong, int, CancellationToken, Task<IReadOnlyList<RoleMenuSettings>>> GuildSettingsReader { get; set; }
+        internal Func<ulong, ulong, CancellationToken, Task<ITextChannel?>> ChannelReader { get; set; }
+
+        internal Task<RoleMenuAuditBatchResult> AuditFirstAsync()
+            => Service.AuditAsync(GuildId, BotId, Settings[0].Id, CancellationToken.None);
+
+        private static RoleMenuSettings CreateSettings(ulong messageId)
+            => new(
+                ObjectId.GenerateNewId(),
+                GuildId.ToString(),
+                ChannelId.ToString(),
+                messageId.ToString(),
+                "Roles",
+                string.Empty,
+                ["10"],
+                RoleMenuSelectionMode.Multiple);
+    }
+
+    private static T Proxy<T>(Func<MethodInfo, object?[], object?> handler) where T : class
+    {
+        var proxy = DispatchProxy.Create<T, DiscordProxy>();
+        ((DiscordProxy)(object)proxy).Handler = handler;
+        return proxy;
+    }
+
+    public class DiscordProxy : DispatchProxy
+    {
+        internal Func<MethodInfo, object?[], object?> Handler { get; set; } = null!;
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+            => Handler(targetMethod!, args ?? []);
+    }
+}

--- a/BeanBot.Tests/Discord/RoleMenus/RoleMenuAuditServiceTests.cs
+++ b/BeanBot.Tests/Discord/RoleMenus/RoleMenuAuditServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Reflection;
 using BeanBot.Discord.RoleMenus;
 using BeanBot.Persistence.Models;
@@ -79,7 +80,7 @@ public class RoleMenuAuditServiceTests
         fixture.PanelFactory = settings => new RoleMenuPanelSnapshot(
             Fixture.GuildId,
             Fixture.ChannelId,
-            ulong.Parse(settings.MessageId),
+            ulong.Parse(settings.MessageId, CultureInfo.InvariantCulture),
             999UL,
             true);
 
@@ -293,21 +294,22 @@ public class RoleMenuAuditServiceTests
             PanelFactory = settings => new RoleMenuPanelSnapshot(
                 GuildId,
                 ChannelId,
-                ulong.Parse(settings.MessageId),
+                ulong.Parse(settings.MessageId, CultureInfo.InvariantCulture),
                 BotId,
                 true);
             SettingsReader = (menuId, guildId, cancellationToken) =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 return Task.FromResult<RoleMenuSettings?>(
-                    Settings.FirstOrDefault(item => item.Id == menuId && item.GuildId == guildId.ToString()));
+                    Settings.FirstOrDefault(item => item.Id == menuId
+                        && item.GuildId == guildId.ToString(CultureInfo.InvariantCulture)));
             };
             GuildSettingsReader = (guildId, maximumResults, cancellationToken) =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 RequestedGuildLimit = maximumResults;
                 return Task.FromResult<IReadOnlyList<RoleMenuSettings>>(
-                    Settings.Where(item => item.GuildId == guildId.ToString())
+                    Settings.Where(item => item.GuildId == guildId.ToString(CultureInfo.InvariantCulture))
                         .Take(maximumResults)
                         .ToList());
             };
@@ -315,7 +317,7 @@ public class RoleMenuAuditServiceTests
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 ChannelReads++;
-                return Task.FromResult(Channel);
+                return Task.FromResult<ITextChannel?>(Channel);
             };
 
             Service = new RoleMenuAuditService(new RoleMenuAuditOperations(
@@ -338,7 +340,7 @@ public class RoleMenuAuditServiceTests
                     cancellationToken.ThrowIfCancellationRequested();
                     PanelReads++;
                     var settings = Settings.Single(item => item.Id == menuId);
-                    Assert.Equal(ulong.Parse(settings.MessageId), messageId);
+                    Assert.Equal(ulong.Parse(settings.MessageId, CultureInfo.InvariantCulture), messageId);
                     return Task.FromResult(PanelFactory(settings));
                 }));
         }
@@ -368,9 +370,9 @@ public class RoleMenuAuditServiceTests
         private static RoleMenuSettings CreateSettings(ulong messageId)
             => new(
                 ObjectId.GenerateNewId(),
-                GuildId.ToString(),
-                ChannelId.ToString(),
-                messageId.ToString(),
+                GuildId.ToString(CultureInfo.InvariantCulture),
+                ChannelId.ToString(CultureInfo.InvariantCulture),
+                messageId.ToString(CultureInfo.InvariantCulture),
                 "Roles",
                 string.Empty,
                 ["10"],

--- a/BeanBot.Tests/Discord/RoleMenus/RoleMenuAuditServiceTests.cs
+++ b/BeanBot.Tests/Discord/RoleMenus/RoleMenuAuditServiceTests.cs
@@ -109,13 +109,14 @@ public class RoleMenuAuditServiceTests
     }
 
     [Theory]
-    [InlineData(RoleMenuRoleIssueKind.Managed, "managed")]
-    [InlineData(RoleMenuRoleIssueKind.BotHierarchy, "highest role")]
-    [InlineData(RoleMenuRoleIssueKind.BotMissingManageRoles, "Manage Roles")]
+    [InlineData((int)RoleMenuRoleIssueKind.Managed, "managed")]
+    [InlineData((int)RoleMenuRoleIssueKind.BotHierarchy, "highest role")]
+    [InlineData((int)RoleMenuRoleIssueKind.BotMissingManageRoles, "Manage Roles")]
     public async Task AuditSpecific_UnassignableRoleState_IsBroken(
-        RoleMenuRoleIssueKind issueKind,
+        int issueKindValue,
         string expectedReason)
     {
+        var issueKind = (RoleMenuRoleIssueKind)issueKindValue;
         var fixture = new Fixture
         {
             RoleValidation = new RoleMenuRoleValidationResult(

--- a/BeanBot.Tests/Discord/RoleMenus/RoleMenuInteractionServiceTests.cs
+++ b/BeanBot.Tests/Discord/RoleMenus/RoleMenuInteractionServiceTests.cs
@@ -20,6 +20,7 @@ public class RoleMenuInteractionServiceTests
 
         var administration = new RoleMenuAdministrationService(
             fixture.Service, discord, NullLogger<RoleMenuAdministrationService>.Instance);
+        var audit = new RoleMenuAuditService(fixture.Service, discord);
         var members = new RoleMenuMemberService(
             fixture.Service, discord, NullLogger<RoleMenuMemberService>.Instance);
 
@@ -27,16 +28,25 @@ public class RoleMenuInteractionServiceTests
             null!,
             discord,
             administration,
+            audit,
             NullLogger<RoleMenuAdminModule>.Instance));
         Assert.Throws<ArgumentNullException>(() => new RoleMenuAdminModule(
             fixture.Service,
             discord,
             administration,
+            null!,
+            NullLogger<RoleMenuAdminModule>.Instance));
+        Assert.Throws<ArgumentNullException>(() => new RoleMenuAdminModule(
+            fixture.Service,
+            discord,
+            administration,
+            audit,
             null!));
         _ = new RoleMenuAdminModule(
             fixture.Service,
             discord,
             administration,
+            audit,
             NullLogger<RoleMenuAdminModule>.Instance);
 
         Assert.Throws<ArgumentNullException>(() => new RoleMenuMemberModule(

--- a/BeanBot/Discord/Interactions/BeanBotInteractionServiceCollectionExtensions.cs
+++ b/BeanBot/Discord/Interactions/BeanBotInteractionServiceCollectionExtensions.cs
@@ -30,6 +30,7 @@ internal static class BeanBotInteractionServiceCollectionExtensions
         services.AddSingleton<DiscordRoleMenuClient>();
         services.AddSingleton<RoleMenuMemberService>();
         services.AddSingleton<RoleMenuAdministrationService>();
+        services.AddSingleton<RoleMenuAuditService>();
         services.AddSingleton<InteractionHandler>();
         services.AddSingleton<BeanBotInteractionHostedService>();
         services.AddSingleton<IHostedService>(provider =>

--- a/BeanBot/Discord/RoleMenus/RoleMenuAdminModule.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuAdminModule.cs
@@ -25,17 +25,20 @@ public sealed class RoleMenuAdminModule : RoleMenuModuleBase
 {
     private readonly DiscordRoleMenuClient _discord;
     private readonly RoleMenuAdministrationService _administration;
+    private readonly RoleMenuAuditService _audit;
     private readonly ILogger<RoleMenuAdminModule> _logger;
 
     public RoleMenuAdminModule(
         RoleMenuInteractionService roleMenuService,
         DiscordRoleMenuClient discord,
         RoleMenuAdministrationService administration,
+        RoleMenuAuditService audit,
         ILogger<RoleMenuAdminModule> logger)
         : base(roleMenuService)
     {
         _discord = discord ?? throw new ArgumentNullException(nameof(discord));
         _administration = administration ?? throw new ArgumentNullException(nameof(administration));
+        _audit = audit ?? throw new ArgumentNullException(nameof(audit));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -300,6 +303,56 @@ public sealed class RoleMenuAdminModule : RoleMenuModuleBase
 
         await RespondToInvalidComponentAsync(
             "Role-menu creation cancelled.",
+            cancellation.Token);
+    }
+
+    [SlashCommand(
+        "audit",
+        "Audit saved role menus for stale panels, roles, or permissions.",
+        runMode: RunMode.Sync)]
+    public async Task AuditAsync(
+        [Summary("menu-id", "Optional ID shown in the role panel footer")]
+        string? menuId = null)
+    {
+        using var cancellation = RoleMenus.CreateOperationCancellation();
+        await RoleMenus.ExecuteInitialResponseAsync(
+            supportsOriginalResponse: true,
+            operationToken => DeferAsync(
+                ephemeral: true,
+                CreateRequestOptions(operationToken)),
+            operationToken => ReplaceResponseAsync(
+                "Auditing role menus…",
+                operationToken),
+            cancellation.Token);
+        if (Context.Guild is null)
+        {
+            await ReplaceResponseAsync(
+                "Role menus can only be audited inside a server.",
+                cancellation.Token);
+            return;
+        }
+
+        ObjectId? requestedMenuId = null;
+        if (!string.IsNullOrWhiteSpace(menuId))
+        {
+            if (!RoleMenuCustomIds.TryParseMenuId(menuId.Trim(), out var parsedMenuId))
+            {
+                await ReplaceResponseAsync(
+                    "That menu ID is invalid. Copy the ID from the role panel footer.",
+                    cancellation.Token);
+                return;
+            }
+
+            requestedMenuId = parsedMenuId;
+        }
+
+        var result = await _audit.AuditAsync(
+            Context.Guild.Id,
+            Context.Guild.CurrentUser.Id,
+            requestedMenuId,
+            cancellation.Token);
+        await ReplaceResponseAsync(
+            RoleMenuAuditPresentation.Format(result, requestedMenuId),
             cancellation.Token);
     }
 

--- a/BeanBot/Discord/RoleMenus/RoleMenuAuditService.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuAuditService.cs
@@ -1,0 +1,359 @@
+using BeanBot.Persistence.Models;
+using Discord;
+using MongoDB.Bson;
+
+using static BeanBot.Discord.RoleMenus.DiscordRoleMenuClient;
+using static BeanBot.Discord.RoleMenus.RoleMenuSetupValidation;
+
+namespace BeanBot.Discord.RoleMenus;
+
+internal enum RoleMenuAuditStatus
+{
+    Healthy,
+    Broken,
+    Unknown
+}
+
+internal sealed record RoleMenuAuditItem(
+    ObjectId MenuId,
+    RoleMenuAuditStatus Status,
+    string Reason);
+
+internal sealed record RoleMenuAuditBatchResult(
+    IReadOnlyList<RoleMenuAuditItem> Items,
+    bool HasMore = false,
+    bool RequestedMenuNotFound = false,
+    bool PersistenceUnavailable = false);
+
+internal sealed record RoleMenuAuditOperations(
+    Func<ObjectId, ulong, CancellationToken, Task<RoleMenuSettings?>> ReadSettings,
+    Func<ulong, int, CancellationToken, Task<IReadOnlyList<RoleMenuSettings>>> ReadGuildSettings,
+    Func<ulong, ulong, CancellationToken, Task<IGuildUser?>> ReadBot,
+    Func<IReadOnlyCollection<ulong>, IGuildUser, RoleMenuRoleValidationResult> ValidateRoles,
+    Func<ulong, ulong, CancellationToken, Task<ITextChannel?>> ReadChannel,
+    Func<IGuildUser, ITextChannel, string?> GetChannelPermissionFailure,
+    Func<ITextChannel, ulong, ulong, ObjectId, CancellationToken, Task<RoleMenuPanelSnapshot?>> ReadPanel);
+
+public sealed class RoleMenuAuditService
+{
+    internal static readonly TimeSpan LookupTimeout = TimeSpan.FromSeconds(5);
+
+    private readonly RoleMenuAuditOperations _operations;
+
+    public RoleMenuAuditService(
+        RoleMenuInteractionService roleMenus,
+        DiscordRoleMenuClient discord)
+        : this(new RoleMenuAuditOperations(
+            roleMenus.GetAsync,
+            async (guildId, maximumResults, cancellationToken) =>
+                await roleMenus.GetByGuildAsync(guildId, maximumResults, cancellationToken),
+            async (guildId, botUserId, cancellationToken) =>
+                await discord.GetGuildUserAsync(
+                    guildId,
+                    botUserId,
+                    CreateRequestOptions(cancellationToken)),
+            ValidateRoles,
+            async (guildId, channelId, cancellationToken) =>
+                await discord.GetGuildTextChannelAsync(
+                    guildId,
+                    channelId,
+                    CreateRequestOptions(cancellationToken)),
+            GetChannelPermissionFailure,
+            ReadPublicationPanelAsync))
+    {
+        ArgumentNullException.ThrowIfNull(roleMenus);
+        ArgumentNullException.ThrowIfNull(discord);
+    }
+
+    internal RoleMenuAuditService(RoleMenuAuditOperations operations)
+    {
+        _operations = operations ?? throw new ArgumentNullException(nameof(operations));
+    }
+
+    internal async Task<RoleMenuAuditBatchResult> AuditAsync(
+        ulong guildId,
+        ulong botUserId,
+        ObjectId? requestedMenuId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfZero(guildId);
+        ArgumentOutOfRangeException.ThrowIfZero(botUserId);
+
+        IReadOnlyList<RoleMenuSettings> settings;
+        if (requestedMenuId is { } menuId)
+        {
+            var read = await TryReadAsync(
+                token => _operations.ReadSettings(menuId, guildId, token),
+                cancellationToken);
+            if (!read.Succeeded)
+            {
+                return new RoleMenuAuditBatchResult(
+                    [Unknown(menuId, "Saved configuration could not be read.")],
+                    PersistenceUnavailable: true);
+            }
+
+            if (read.Value is null)
+            {
+                return new RoleMenuAuditBatchResult([], RequestedMenuNotFound: true);
+            }
+
+            settings = [read.Value];
+        }
+        else
+        {
+            var read = await TryReadAsync(
+                token => _operations.ReadGuildSettings(
+                    guildId,
+                    RoleMenuConstants.MaximumListedMenus + 1,
+                    token),
+                cancellationToken);
+            if (!read.Succeeded || read.Value is null)
+            {
+                return new RoleMenuAuditBatchResult([], PersistenceUnavailable: true);
+            }
+
+            settings = read.Value;
+        }
+
+        var hasMore = settings.Count > RoleMenuConstants.MaximumListedMenus;
+        var boundedSettings = settings.Take(RoleMenuConstants.MaximumListedMenus).ToList();
+        if (boundedSettings.Count == 0)
+        {
+            return new RoleMenuAuditBatchResult([], hasMore);
+        }
+
+        var botRead = await TryReadAsync(
+            token => _operations.ReadBot(guildId, botUserId, token),
+            cancellationToken);
+        if (!botRead.Succeeded || botRead.Value is null)
+        {
+            return new RoleMenuAuditBatchResult(
+                boundedSettings
+                    .Select(menu => Unknown(
+                        menu.Id,
+                        "Bean Bot's current server role state could not be verified."))
+                    .ToList(),
+                hasMore);
+        }
+
+        var results = new List<RoleMenuAuditItem>(boundedSettings.Count);
+        foreach (var menu in boundedSettings)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            results.Add(await AuditOneAsync(
+                menu,
+                guildId,
+                botRead.Value,
+                cancellationToken));
+        }
+
+        return new RoleMenuAuditBatchResult(results, hasMore);
+    }
+
+    private async Task<RoleMenuAuditItem> AuditOneAsync(
+        RoleMenuSettings settings,
+        ulong guildId,
+        IGuildUser bot,
+        CancellationToken cancellationToken)
+    {
+        if (!RoleMenuSettingsParser.TryParse(settings, out var parsed, out var settingsIssue))
+        {
+            return Broken(
+                settings.Id,
+                $"Saved configuration is invalid ({settingsIssue}).");
+        }
+
+        if (parsed.GuildId != guildId)
+        {
+            return Broken(settings.Id, "Saved configuration belongs to a different server.");
+        }
+
+        RoleMenuRoleValidationResult roleValidation;
+        try
+        {
+            roleValidation = _operations.ValidateRoles(parsed.RoleIds, bot);
+        }
+        catch (Exception) when (!cancellationToken.IsCancellationRequested)
+        {
+            return Unknown(settings.Id, "Current role state could not be verified.");
+        }
+
+        if (!roleValidation.IsValid)
+        {
+            return Broken(settings.Id, FormatRoleIssue(roleValidation.Issues[0]));
+        }
+
+        var channelRead = await TryReadAsync(
+            token => _operations.ReadChannel(guildId, parsed.ChannelId, token),
+            cancellationToken);
+        if (!channelRead.Succeeded)
+        {
+            return Unknown(settings.Id, "Target channel state could not be verified.");
+        }
+
+        if (channelRead.Value is null)
+        {
+            return Broken(settings.Id, "Target text channel is missing or no longer valid.");
+        }
+
+        string? permissionFailure;
+        try
+        {
+            permissionFailure = _operations.GetChannelPermissionFailure(bot, channelRead.Value);
+        }
+        catch (Exception) when (!cancellationToken.IsCancellationRequested)
+        {
+            return Unknown(settings.Id, "Target channel permissions could not be verified.");
+        }
+
+        if (permissionFailure is not null)
+        {
+            return Broken(settings.Id, permissionFailure);
+        }
+
+        var panelRead = await TryReadAsync(
+            token => _operations.ReadPanel(
+                channelRead.Value,
+                parsed.ChannelId,
+                parsed.MessageId,
+                settings.Id,
+                token),
+            cancellationToken);
+        if (!panelRead.Succeeded)
+        {
+            return Unknown(settings.Id, "Published panel state could not be verified.");
+        }
+
+        if (panelRead.Value is null)
+        {
+            return Broken(settings.Id, "Published panel message is missing.");
+        }
+
+        var panelIssue = RoleMenuPanelContextValidator.Validate(
+            parsed,
+            guildId,
+            panelRead.Value.ChannelId,
+            panelRead.Value.MessageId,
+            panelRead.Value.AuthorId,
+            bot.Id,
+            panelRead.Value.HasManageButton);
+        if (panelIssue != RoleMenuPanelContextIssue.None)
+        {
+            return Broken(settings.Id, FormatPanelIssue(panelIssue));
+        }
+
+        return new RoleMenuAuditItem(
+            settings.Id,
+            RoleMenuAuditStatus.Healthy,
+            "Panel, roles, and required permissions were verified.");
+    }
+
+    private static async Task<ReadResult<T>> TryReadAsync<T>(
+        Func<CancellationToken, Task<T>> operation,
+        CancellationToken cancellationToken)
+    {
+        using var lookupCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        lookupCancellation.CancelAfter(LookupTimeout);
+        try
+        {
+            return new ReadResult<T>(true, await operation(lookupCancellation.Token));
+        }
+        catch (OperationCanceledException)
+            when (!cancellationToken.IsCancellationRequested && lookupCancellation.IsCancellationRequested)
+        {
+            return new ReadResult<T>(false, default);
+        }
+        catch (Exception) when (!cancellationToken.IsCancellationRequested)
+        {
+            return new ReadResult<T>(false, default);
+        }
+    }
+
+    private static string FormatRoleIssue(RoleMenuRoleIssue issue)
+        => issue.Kind switch
+        {
+            RoleMenuRoleIssueKind.BotMissingManageRoles =>
+                "Bean Bot no longer has the Manage Roles permission.",
+            RoleMenuRoleIssueKind.Missing => "A configured role was deleted.",
+            RoleMenuRoleIssueKind.Everyone => "The menu contains the @everyone role.",
+            RoleMenuRoleIssueKind.Managed => "A configured role is now managed by Discord or an integration.",
+            RoleMenuRoleIssueKind.BotHierarchy =>
+                "A configured role is now at or above Bean Bot's highest role.",
+            RoleMenuRoleIssueKind.Duplicate => "The saved menu contains a duplicate role.",
+            _ => "A configured role is no longer assignable by Bean Bot."
+        };
+
+    private static string FormatPanelIssue(RoleMenuPanelContextIssue issue)
+        => issue switch
+        {
+            RoleMenuPanelContextIssue.GuildMismatch => "Published panel points at the wrong server.",
+            RoleMenuPanelContextIssue.ChannelMismatch => "Published panel points at the wrong channel.",
+            RoleMenuPanelContextIssue.MessageMismatch => "Published panel points at the wrong message.",
+            RoleMenuPanelContextIssue.UnexpectedAuthor => "Referenced message was not authored by Bean Bot.",
+            RoleMenuPanelContextIssue.MissingManageButton =>
+                "Referenced message no longer contains this menu's Manage Roles button.",
+            _ => "Published panel identity is invalid."
+        };
+
+    private static RoleMenuAuditItem Broken(ObjectId menuId, string reason)
+        => new(menuId, RoleMenuAuditStatus.Broken, reason);
+
+    private static RoleMenuAuditItem Unknown(ObjectId menuId, string reason)
+        => new(menuId, RoleMenuAuditStatus.Unknown, reason);
+
+    private readonly record struct ReadResult<T>(bool Succeeded, T? Value);
+}
+
+internal static class RoleMenuAuditPresentation
+{
+    internal static string Format(RoleMenuAuditBatchResult result, ObjectId? requestedMenuId)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        if (result.RequestedMenuNotFound)
+        {
+            return "No saved role menu with that ID exists in this server.";
+        }
+
+        if (result.PersistenceUnavailable && result.Items.Count == 0)
+        {
+            return "**Unknown** — Bean Bot could not read the saved role-menu configuration. " +
+                   "No Discord state was changed.";
+        }
+
+        if (requestedMenuId is not null && result.Items.Count == 1)
+        {
+            var item = result.Items[0];
+            return $"**{item.Status}** — `{item.MenuId}`\n{item.Reason}\n\n" +
+                   "Audit is read-only; no Discord or saved role-menu state was changed.";
+        }
+
+        if (result.Items.Count == 0)
+        {
+            return "This server has no saved dropdown role menus.";
+        }
+
+        var healthy = result.Items.Count(item => item.Status == RoleMenuAuditStatus.Healthy);
+        var broken = result.Items.Count(item => item.Status == RoleMenuAuditStatus.Broken);
+        var unknown = result.Items.Count(item => item.Status == RoleMenuAuditStatus.Unknown);
+        var lines = new List<string>
+        {
+            $"Role-menu audit: **{healthy} Healthy**, **{broken} Broken**, **{unknown} Unknown**."
+        };
+        foreach (var item in result.Items)
+        {
+            var reason = item.Status == RoleMenuAuditStatus.Healthy
+                ? string.Empty
+                : " — " + RoleMenuText.TruncateWithEllipsis(item.Reason, 32);
+            lines.Add($"{item.Status} `{item.MenuId}`{reason}");
+        }
+
+        if (result.HasMore)
+        {
+            lines.Add(
+                "Only the 25 newest menus were audited. Audit an older panel by passing its footer ID.");
+        }
+
+        lines.Add("Read-only audit: no Discord or saved state was changed.");
+        return RoleMenuPresentation.BoundResponseContent(string.Join('\n', lines));
+    }
+}

--- a/docs/role-menus.md
+++ b/docs/role-menus.md
@@ -4,7 +4,7 @@ BeanBot can publish persistent Discord panels that let members add or remove an 
 
 ## Requirements
 
-The administrator running `/role-menu create` or `/role-menu delete` must:
+The administrator running `/role-menu create`, `/role-menu audit`, or `/role-menu delete` must:
 
 - run the command in a server, not a direct message;
 - have the server-level **Manage Roles** permission; and
@@ -16,7 +16,7 @@ BeanBot must have:
 - a highest role above every role configured in the menu; and
 - **View Channel**, **Send Messages**, **Embed Links**, and **Read Message History** in the target channel.
 
-Discord does not allow BeanBot to assign `@everyone`, integration-managed roles, or roles at or above BeanBot's highest role. BeanBot validates these rules during setup, immediately before publication, when a member opens a panel, and immediately before applying a selection.
+Discord does not allow BeanBot to assign `@everyone`, integration-managed roles, or roles at or above BeanBot's highest role. BeanBot validates these rules during setup, immediately before publication, when a member opens a panel, immediately before applying a selection, and when an administrator audits a saved menu.
 
 ## Create and publish a panel
 
@@ -40,6 +40,20 @@ Selecting **Manage Roles** opens a private selector bound to that member and pan
 
 Submissions for the same member are serialized, including submissions from overlapping menus. Different members may update roles from the same menu concurrently. Publication and deletion take an exclusive menu lifecycle lock so they cannot race member changes or resurrect a deleted configuration. Before changing anything, BeanBot reloads the persisted configuration, confirms the original panel still exists and belongs to BeanBot, fetches current member roles, revalidates role hierarchy, and rejects malformed or non-allowlisted values. After every valid submission, including a no-op or interrupted mutation, BeanBot performs a separate bounded read of Discord's current member roles. It reports confirmed results from that observed state and explicitly asks the member to reopen the menu when the final state cannot be confirmed.
 
+## Audit published panels
+
+Run `/role-menu audit` to inspect the 25 newest saved menus without changing Discord or MongoDB. For an older menu, or to inspect one panel in detail, copy the menu ID from its footer and run `/role-menu audit menu-id:<id>`.
+
+Each menu is reported as:
+
+- **Healthy** when BeanBot can positively verify the saved configuration, current roles and hierarchy, required channel permissions, and the original BeanBot-authored panel identity.
+- **Broken** when BeanBot can positively identify a stale or unusable condition, such as a deleted channel or message, a role that was deleted or moved above BeanBot, a managed role, missing permissions, or a message that no longer matches the saved panel.
+- **Unknown** when a bounded MongoDB or Discord lookup fails, times out, or otherwise prevents BeanBot from proving the current state. Unknown is intentionally not treated as Broken; retry the audit after the transient problem clears.
+
+Bulk auditing is deliberately capped at 25 menus and checks them sequentially so a server with many historical menus cannot create an unbounded MongoDB query or Discord REST burst. Audit lookups share the normal interaction shutdown cancellation and use a shorter per-lookup cancellation bound. Audit never republishes panels, edits or deletes messages, changes roles, or modifies saved menu records.
+
+For **Broken** results, correct the reported Discord role/channel permission problem when possible. If the saved message or channel is gone, use `/role-menu delete menu-id:<id>` to remove the stale saved configuration and then `/role-menu create` if a replacement panel is needed. For **Unknown**, do not delete state based only on the audit result; retry after the dependency recovers.
+
 ## Delete a panel
 
 Run `/role-menu delete` to choose from the 25 newest saved menus. For an older menu, copy the ID from its panel footer and run `/role-menu delete menu-id:<id>`.
@@ -50,23 +64,24 @@ Deletion requires a private confirmation. BeanBot deletes a matching BeanBot-own
 
 Use a test server with BeanBot's role below one test role and above two other test roles.
 
-1. Confirm `/role-menu create` is unavailable to a member without **Manage Roles** and cannot run in a direct message.
+1. Confirm `/role-menu create`, `/role-menu audit`, and `/role-menu delete` are unavailable to a member without **Manage Roles** and cannot run in a direct message.
 2. Confirm setup rejects `@everyone`, a managed role, the role above BeanBot, and a role at or above a non-owner administrator.
 3. Publish a two-role multiple menu and confirm the preview is private while the panel is public in the selected channel.
-4. Open the same panel as two different members and confirm each receives an independent private selector with only their own current menu roles preselected.
-5. As a member, add both menu roles, remove one, and clear the menu. Confirm an unrelated role remains assigned throughout.
-6. Publish a single menu, switch between its roles, and confirm no gap is introduced when the replacement can be added.
-7. Delete one configured role in Discord and confirm the stale panel fails privately without changing any remaining or unrelated role.
-8. Restart BeanBot and confirm the remaining panels still work from their persisted configuration.
-9. Delete a panel through `/role-menu delete`, then confirm its old controls cannot mutate roles.
-10. Temporarily remove BeanBot's hierarchy or permissions and confirm operations fail privately without exposing exception details or changing unrelated roles.
-11. Use an existing legacy reaction-role panel and confirm its reactions still add and remove roles exactly as before.
+4. Run `/role-menu audit menu-id:<id>` and confirm it reports **Healthy** without changing the panel, roles, or saved record.
+5. Open the same panel as two different members and confirm each receives an independent private selector with only their own current menu roles preselected.
+6. As a member, add both menu roles, remove one, and clear the menu. Confirm an unrelated role remains assigned throughout.
+7. Publish a single menu, switch between its roles, and confirm no gap is introduced when the replacement can be added.
+8. Delete one configured role in Discord and confirm the stale panel fails privately without changing any remaining or unrelated role; audit the menu and confirm it reports **Broken**.
+9. Restart BeanBot and confirm the remaining panels still work from their persisted configuration.
+10. Delete a panel through `/role-menu delete`, then confirm its old controls cannot mutate roles.
+11. Temporarily remove BeanBot's hierarchy or permissions and confirm operations fail privately without exposing exception details or changing unrelated roles; audit reports **Broken** for a positively verified permission failure.
+12. Use an existing legacy reaction-role panel and confirm its reactions still add and remove roles exactly as before.
 
 ## Code organization
 
 `RoleMenuAdminModule` and `RoleMenuMemberModule` validate Discord control bindings and acknowledge interactions before starting work. Their shared `RoleMenuModuleBase` handles private responses, mention suppression, and acknowledgement reconciliation.
 
-`RoleMenuAdministrationService` prepares drafts and connects publication and deletion to persistence. `RoleMenuMemberService` loads selectors and applies member choices through the mutation coordinator. These services take IDs and submitted values, without an interaction context. Each member operation keeps its own Discord member reference, so concurrent requests cannot share a mutation target.
+`RoleMenuAdministrationService` prepares drafts and connects publication and deletion to persistence. `RoleMenuAuditService` performs bounded read-only health checks against saved role menus and current Discord state. `RoleMenuMemberService` loads selectors and applies member choices through the mutation coordinator. These services take IDs and submitted values, without an interaction context. Each member operation keeps its own Discord member reference, so concurrent requests cannot share a mutation target.
 
 `DiscordRoleMenuClient` contains Discord REST reads and mutations. `RoleMenuSetupValidation` and `RoleMenuPresentation` keep validation and result text separate from transport. The publication, deletion, and member workflows retain their independently tested rules for ambiguous outcomes, rollback, final-state reconciliation, and cancellation. `RoleMenuInteractionService` supplies the shared bounded execution, draft, persistence, and lock operations used by those entry points.
 

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -8,9 +8,10 @@ BeanBot supports Discord application commands alongside the existing message-com
 - `/pun` uses the same cached `IPunProvider` as the legacy `%pun` command.
 - `/help` summarizes the slash-command surface and points users to `%help` for the complete legacy command list.
 - `/role-menu create` opens a native Discord setup form for an administrator with **Manage Roles**.
+- `/role-menu audit [menu-id]` performs a read-only health check of saved dropdown role panels. Without an ID it audits at most the 25 newest menus; an exact footer ID audits one menu. Results are **Healthy**, **Broken**, or **Unknown** when current state cannot be proven because a dependency lookup failed.
 - `/role-menu delete [menu-id]` removes a published dropdown role panel and its saved configuration. The optional exact ID supports servers with more than 25 menus.
 
-Role-menu setup and deletion are server-only. Members manage their own allowlisted roles from each published panel without needing **Manage Roles**. See [Dropdown role menus](role-menus.md) for the full workflow and operational checks.
+Role-menu setup, audit, and deletion are server-only and require **Manage Roles**. Audit responses are private and never repair or mutate Discord or MongoDB state. Members manage their own allowlisted roles from each published panel without needing **Manage Roles**. See [Dropdown role menus](role-menus.md) for the full workflow and operational checks.
 
 The existing `%`, `succ `, and mention-prefix commands remain supported and are not replaced by slash commands.
 


### PR DESCRIPTION
Closes #190

## Summary
- adds `/role-menu audit [menu-id]` under the existing guild-only, Manage-Roles-gated administrator command group
- positively verifies saved configuration, current BeanBot role/hierarchy state, target text-channel permissions, and persisted BeanBot panel identity
- reports `Healthy`, `Broken`, or `Unknown`; transient dependency failures are Unknown rather than guessed as healthy or broken
- caps bulk audits at the 25 newest menus and performs Discord checks sequentially to avoid REST fan-out
- remains strictly read-only: no role changes, panel edits/deletes, publication, or MongoDB writes/deletes
- documents status meaning, the bulk bound, and remediation guidance

## Reliability / lifecycle
- reuses the existing role-menu parser, role validator, channel-permission validation, panel identity validator, Discord client read paths, and interaction lifecycle cancellation
- each dependency read gets a 5-second linked cancellation bound and is not retried
- parent interaction/shutdown cancellation propagates instead of becoming `Unknown`, so cancellation stops admission of later bulk checks
- positive stale-state evidence is `Broken`; inability to establish truth within the bounded operation is `Unknown`

## Tests
Deterministic coverage includes healthy and missing-ID audits; missing channel/message; mismatched panel author/identity; deleted, managed, and hierarchy-invalid roles; missing permissions; transient lookup failure -> Unknown while later bulk items continue; 25-menu bounding and sequential execution; parent cancellation; persistence failure; response-length bounding; and constructor/DI coverage for the new audit service.

## Verification
Final source head: `0595b507fcab9feb33dc3aeba82ada4e5ca78bb0` against `develop` `9a157b8008fb05405433bf6bb6ec2b3a0d88efc3` (10 commits ahead, 0 behind).

- Repository Verification #395: **PASS**. The PR workflow is associated with exact source head `0595b507fcab9feb33dc3aeba82ada4e5ca78bb0`; by repository design it checked out merge candidate `a4275f007211382e27713f04f863fc250caa3ee7` while pinning the branch-integrity candidate to the exact source head. `./scripts/verify.sh full` completed successfully with locked restore, formatting/analyzers, Release build, **947/947 tests**, coverage baseline (**75.78% lines / 68.47% branches**), branch integrity, vulnerable-package audit, Docker build, hardened-container smoke, and SIGTERM shutdown smoke.
- CodeQL #230: **PASS** on exact source head `0595b507fcab9feb33dc3aeba82ada4e5ca78bb0`.
- Dependency Review #188: **PASS** on exact source head `0595b507fcab9feb33dc3aeba82ada4e5ca78bb0`.
- Fresh Verifier (2026-09-10 review pass): **PASS**. The original #190 acceptance criteria were remapped to the complete 7-file diff and current deterministic evidence; branch policy is satisfied and no required gate is missing.
- Fresh independent Reviewer (2026-09-10 review pass): **CLEAN**. Re-inspection found no consequential correctness, Discord lifecycle/race, duplicate-message/subscription, unbounded-wait/retry, cancellation, health-truthfulness, persistence, security, Docker/runtime, dependency/release, test-quality, or unrelated-scope finding.
- Review threads: **0 open**.

Local focused/fast/full execution is not claimed because the local environment could not resolve `github.com`; the repository-authorized GitHub Actions path supplied the deterministic verification evidence instead. The full gate also exercises the same build/test/analyzer path covered by the fast gate, plus coverage, vulnerability, Docker, and hardened-container checks.

## Repair history
Exact-head CI caught and drove four small integration/test fixes before the final green head: collection-expression style required by analyzers; public xUnit theory parameter accessibility; existing `RoleMenuAdminModule` constructor tests needing the new audit dependency; and nullable/invariant-culture analyzer issues in the new tests. These were fixed without weakening validations or expanding product scope. No additional source correction was required by the fresh review pass.

## Manual validation
In a test guild, run one exact-ID and one bulk `/role-menu audit` and confirm responses are ephemeral and read-only. A healthy panel should report Healthy; deliberately removing a configured role/required permission or deleting a panel should report Broken; a transient dependency failure should remain Unknown rather than prompting destructive remediation.