### PR TITLE
Add safe in-place role menu editing

### DIFF
--- a/BeanBot.Tests/Discord/RoleMenus/RoleMenuEditCoordinationTests.cs
+++ b/BeanBot.Tests/Discord/RoleMenus/RoleMenuEditCoordinationTests.cs
@@ -1,0 +1,44 @@
+using BeanBot.Discord.RoleMenus;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.RoleMenus;
+
+public class RoleMenuEditCoordinationTests
+{
+    [Fact]
+    public async Task RunMenuWriteAsync_EditAndDeleteForSameMenu_AreSerialized()
+    {
+        var coordinator = new RoleMenuMutationCoordinator();
+        var editEntered = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseEdit = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var deleteEntered = false;
+
+        var edit = coordinator.RunMenuWriteAsync(
+            "menu:edit-delete",
+            async _ =>
+            {
+                editEntered.SetResult();
+                await releaseEdit.Task;
+                return 1;
+            },
+            CancellationToken.None);
+        await editEntered.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        var delete = coordinator.RunMenuWriteAsync(
+            "menu:edit-delete",
+            _ =>
+            {
+                deleteEntered = true;
+                return Task.FromResult(2);
+            },
+            CancellationToken.None);
+
+        await Task.Yield();
+        Assert.False(deleteEntered);
+        releaseEdit.SetResult();
+
+        await Task.WhenAll(edit, delete);
+        Assert.True(deleteEntered);
+    }
+}

--- a/BeanBot.Tests/Discord/RoleMenus/RoleMenuEditDraftRegistryTests.cs
+++ b/BeanBot.Tests/Discord/RoleMenus/RoleMenuEditDraftRegistryTests.cs
@@ -1,0 +1,187 @@
+using BeanBot.Discord.RoleMenus;
+using BeanBot.Persistence.Models;
+using MongoDB.Bson;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.RoleMenus;
+
+public class RoleMenuEditDraftRegistryTests
+{
+    private static readonly ObjectId MenuId =
+        ObjectId.Parse("64e7611aaac75f172f0f6789");
+
+    [Fact]
+    public void Create_ReplacesPreviousDraftForSameOwner()
+    {
+        var registry = CreateRegistry(capacity: 2);
+
+        Assert.Equal(
+            RoleMenuEditDraftCreateStatus.Created,
+            registry.Create(
+                MenuId,
+                1,
+                2,
+                "First",
+                string.Empty,
+                [10],
+                RoleMenuSelectionMode.Multiple,
+                out var first));
+        Assert.Equal(
+            RoleMenuEditDraftCreateStatus.Created,
+            registry.Create(
+                MenuId,
+                1,
+                2,
+                "Second",
+                string.Empty,
+                [11],
+                RoleMenuSelectionMode.Exclusive,
+                out var second));
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.NotEqual(first.Id, second.Id);
+        Assert.Equal(
+            RoleMenuEditDraftAccessStatus.NotFound,
+            registry.TryGet(first.Id, 1, 2, out _));
+        Assert.Equal(
+            RoleMenuEditDraftAccessStatus.Acquired,
+            registry.TryGet(second.Id, 1, 2, out var current));
+        Assert.Equal("Second", current!.Title);
+    }
+
+    [Fact]
+    public void Create_WhenAtCapacity_RejectsAdditionalOwner()
+    {
+        var registry = CreateRegistry(capacity: 1);
+        Assert.Equal(
+            RoleMenuEditDraftCreateStatus.Created,
+            registry.Create(
+                MenuId,
+                1,
+                2,
+                "First",
+                string.Empty,
+                [10],
+                RoleMenuSelectionMode.Multiple,
+                out _));
+
+        Assert.Equal(
+            RoleMenuEditDraftCreateStatus.CapacityReached,
+            registry.Create(
+                ObjectId.GenerateNewId(),
+                1,
+                3,
+                "Second",
+                string.Empty,
+                [11],
+                RoleMenuSelectionMode.Multiple,
+                out var rejected));
+        Assert.Null(rejected);
+    }
+
+    [Fact]
+    public void TryGet_WrongOwnerCannotAccessDraft()
+    {
+        var registry = CreateRegistry();
+        registry.Create(
+            MenuId,
+            1,
+            2,
+            "Menu",
+            string.Empty,
+            [10],
+            RoleMenuSelectionMode.Multiple,
+            out var draft);
+
+        Assert.Equal(
+            RoleMenuEditDraftAccessStatus.WrongOwner,
+            registry.TryGet(draft!.Id, 1, 99, out var inaccessible));
+        Assert.Null(inaccessible);
+    }
+
+    [Fact]
+    public void TryBeginSubmit_PreventsDuplicateSubmissionAndOwnerReplacement()
+    {
+        var registry = CreateRegistry();
+        registry.Create(
+            MenuId,
+            1,
+            2,
+            "Menu",
+            string.Empty,
+            [10],
+            RoleMenuSelectionMode.Multiple,
+            out var draft);
+
+        Assert.Equal(
+            RoleMenuEditDraftAccessStatus.Acquired,
+            registry.TryBeginSubmit(draft!.Id, 1, 2, out _));
+        Assert.Equal(
+            RoleMenuEditDraftAccessStatus.AlreadySubmitting,
+            registry.TryBeginSubmit(draft.Id, 1, 2, out _));
+        Assert.Equal(
+            RoleMenuEditDraftCreateStatus.AlreadySubmitting,
+            registry.Create(
+                ObjectId.GenerateNewId(),
+                1,
+                2,
+                "Replacement",
+                string.Empty,
+                [11],
+                RoleMenuSelectionMode.Multiple,
+                out var replacement));
+        Assert.Null(replacement);
+    }
+
+    [Fact]
+    public void ExpiredDraft_IsPurgedAndCapacityBecomesAvailable()
+    {
+        var time = new TestTimeProvider(
+            new DateTimeOffset(2026, 9, 11, 14, 0, 0, TimeSpan.Zero));
+        var registry = new RoleMenuEditDraftRegistry(
+            time,
+            capacity: 1,
+            lifetime: TimeSpan.FromMinutes(10));
+        registry.Create(
+            MenuId,
+            1,
+            2,
+            "Menu",
+            string.Empty,
+            [10],
+            RoleMenuSelectionMode.Multiple,
+            out var expired);
+
+        time.UtcNow = time.UtcNow.AddMinutes(11);
+
+        Assert.Equal(
+            RoleMenuEditDraftCreateStatus.Created,
+            registry.Create(
+                ObjectId.GenerateNewId(),
+                1,
+                3,
+                "New menu",
+                string.Empty,
+                [11],
+                RoleMenuSelectionMode.Multiple,
+                out var created));
+        Assert.NotNull(created);
+        Assert.Equal(
+            RoleMenuEditDraftAccessStatus.NotFound,
+            registry.TryGet(expired!.Id, 1, 2, out _));
+    }
+
+    private static RoleMenuEditDraftRegistry CreateRegistry(int capacity = 4)
+        => new(
+            TimeProvider.System,
+            capacity,
+            TimeSpan.FromMinutes(10));
+
+    private sealed class TestTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public DateTimeOffset UtcNow { get; set; } = utcNow;
+
+        public override DateTimeOffset GetUtcNow() => UtcNow;
+    }
+}

--- a/BeanBot.Tests/Discord/RoleMenus/RoleMenuEditMemberRegressionTests.cs
+++ b/BeanBot.Tests/Discord/RoleMenus/RoleMenuEditMemberRegressionTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using BeanBot.Discord.RoleMenus;
 using BeanBot.Persistence.Models;
 using MongoDB.Bson;
@@ -23,12 +24,12 @@ public class RoleMenuEditMemberRegressionTests
         var mutationCount = 0;
         var updatedSettings = new RoleMenuSettings(
             MenuId,
-            GuildId.ToString(System.Globalization.CultureInfo.InvariantCulture),
-            ChannelId.ToString(System.Globalization.CultureInfo.InvariantCulture),
-            MessageId.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            GuildId.ToString(CultureInfo.InvariantCulture),
+            ChannelId.ToString(CultureInfo.InvariantCulture),
+            MessageId.ToString(CultureInfo.InvariantCulture),
             "Updated menu",
             string.Empty,
-            [RemainingRoleId.ToString(System.Globalization.CultureInfo.InvariantCulture)],
+            [RemainingRoleId.ToString(CultureInfo.InvariantCulture)],
             RoleMenuSelectionMode.Multiple);
         var operations = new RoleMenuMemberOperations(
             (_, _, _) => Task.FromResult<RoleMenuSettings?>(updatedSettings),
@@ -59,8 +60,8 @@ public class RoleMenuEditMemberRegressionTests
                     ],
                     new RoleMenuActorSnapshot(
                         CanManageRoles: true,
-                        HighestRolePosition: 10,
-                        IsOwner: false))),
+                        Hierarchy: 10,
+                        IsGuildOwner: false))),
             (_, _, _) => Task.FromResult<RoleMenuMemberSnapshot?>(
                 new RoleMenuMemberSnapshot(GuildId, MemberUserId, [])),
             (_, _, _, _) =>
@@ -81,7 +82,7 @@ public class RoleMenuEditMemberRegressionTests
             BotUserId,
             MemberUserId,
             MessageId,
-            [RemovedRoleId.ToString(System.Globalization.CultureInfo.InvariantCulture)],
+            [RemovedRoleId.ToString(CultureInfo.InvariantCulture)],
             operations,
             CancellationToken.None);
 

--- a/BeanBot.Tests/Discord/RoleMenus/RoleMenuEditMemberRegressionTests.cs
+++ b/BeanBot.Tests/Discord/RoleMenus/RoleMenuEditMemberRegressionTests.cs
@@ -1,0 +1,92 @@
+using BeanBot.Discord.RoleMenus;
+using BeanBot.Persistence.Models;
+using MongoDB.Bson;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.RoleMenus;
+
+public class RoleMenuEditMemberRegressionTests
+{
+    private const ulong GuildId = 101;
+    private const ulong ChannelId = 202;
+    private const ulong MessageId = 303;
+    private const ulong BotUserId = 404;
+    private const ulong MemberUserId = 505;
+    private const ulong RemainingRoleId = 10;
+    private const ulong RemovedRoleId = 11;
+    private static readonly ObjectId MenuId =
+        ObjectId.Parse("64e7611aaac75f172f0f7890");
+
+    [Fact]
+    public async Task ExecuteAsync_StalePreEditSelection_CannotGrantRemovedRole()
+    {
+        var mutationCount = 0;
+        var updatedSettings = new RoleMenuSettings(
+            MenuId,
+            GuildId.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            ChannelId.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            MessageId.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            "Updated menu",
+            string.Empty,
+            [RemainingRoleId.ToString(System.Globalization.CultureInfo.InvariantCulture)],
+            RoleMenuSelectionMode.Multiple);
+        var operations = new RoleMenuMemberOperations(
+            (_, _, _) => Task.FromResult<RoleMenuSettings?>(updatedSettings),
+            (_, _, _, _) => Task.FromResult<RoleMenuPanelSnapshot?>(
+                new RoleMenuPanelSnapshot(
+                    GuildId,
+                    ChannelId,
+                    MessageId,
+                    BotUserId,
+                    HasManageButton: true)),
+            (_, _, _) => Task.FromResult<RoleMenuBotSnapshot?>(
+                new RoleMenuBotSnapshot(
+                    GuildId,
+                    BotUserId,
+                    [
+                        new RoleMenuRoleSnapshot(
+                            RemainingRoleId,
+                            "Remaining",
+                            IsEveryone: false,
+                            IsManaged: false,
+                            Position: 1),
+                        new RoleMenuRoleSnapshot(
+                            RemovedRoleId,
+                            "Removed",
+                            IsEveryone: false,
+                            IsManaged: false,
+                            Position: 1)
+                    ],
+                    new RoleMenuActorSnapshot(
+                        CanManageRoles: true,
+                        HighestRolePosition: 10,
+                        IsOwner: false))),
+            (_, _, _) => Task.FromResult<RoleMenuMemberSnapshot?>(
+                new RoleMenuMemberSnapshot(GuildId, MemberUserId, [])),
+            (_, _, _, _) =>
+            {
+                mutationCount++;
+                return Task.CompletedTask;
+            },
+            (_, _, _, _) =>
+            {
+                mutationCount++;
+                return Task.CompletedTask;
+            });
+
+        var result = await RoleMenuMemberWorkflow.ExecuteAsync(
+            MenuId,
+            GuildId,
+            ChannelId,
+            BotUserId,
+            MemberUserId,
+            MessageId,
+            [RemovedRoleId.ToString(System.Globalization.CultureInfo.InvariantCulture)],
+            operations,
+            CancellationToken.None);
+
+        Assert.Equal(RoleMenuMemberWorkflowStatus.InvalidSelection, result.Status);
+        Assert.Equal(RoleMenuSelectionIssue.RoleNotAllowed, result.SelectionIssue);
+        Assert.Equal(0, mutationCount);
+    }
+}

--- a/BeanBot.Tests/Discord/RoleMenus/RoleMenuEditWorkflowTests.cs
+++ b/BeanBot.Tests/Discord/RoleMenus/RoleMenuEditWorkflowTests.cs
@@ -1,0 +1,189 @@
+using BeanBot.Discord.RoleMenus;
+using BeanBot.Persistence.Models;
+using MongoDB.Bson;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.RoleMenus;
+
+public class RoleMenuEditWorkflowTests
+{
+    private static readonly ObjectId MenuId =
+        ObjectId.Parse("64e7611aaac75f172f0f5678");
+
+    [Fact]
+    public async Task ExecuteAsync_Success_PersistsBeforeUpdatingExistingPanel()
+    {
+        var calls = new List<string>();
+        var replacement = CreateSettings();
+        var result = await RoleMenuEditWorkflow.ExecuteAsync(
+            replacement,
+            new RoleMenuEditCommitOperations(
+                (settings, _) =>
+                {
+                    Assert.Same(replacement, settings);
+                    calls.Add("persist");
+                    return Task.CompletedTask;
+                },
+                (settings, _) =>
+                {
+                    Assert.Same(replacement, settings);
+                    calls.Add("panel");
+                    return Task.FromResult(RoleMenuPanelUpdateStatus.Updated);
+                },
+                () => false),
+            CancellationToken.None);
+
+        Assert.Equal(RoleMenuEditCommitStatus.Updated, result.Status);
+        Assert.Equal(["persist", "panel"], calls);
+        Assert.Empty(result.Failures);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PersistenceFailure_DoesNotTouchPanel()
+    {
+        var expected = new InvalidOperationException("mongo outcome unknown");
+        var panelCalls = 0;
+        var result = await RoleMenuEditWorkflow.ExecuteAsync(
+            CreateSettings(),
+            new RoleMenuEditCommitOperations(
+                (_, _) => Task.FromException(expected),
+                (_, _) =>
+                {
+                    panelCalls++;
+                    return Task.FromResult(RoleMenuPanelUpdateStatus.Updated);
+                },
+                () => false),
+            CancellationToken.None);
+
+        Assert.Equal(RoleMenuEditCommitStatus.PersistenceOutcomeUnknown, result.Status);
+        Assert.Equal(0, panelCalls);
+        var failure = Assert.Single(result.Failures);
+        Assert.Equal(RoleMenuEditFailurePhase.Persistence, failure.Phase);
+        Assert.Same(expected, failure.Exception);
+    }
+
+    [Theory]
+    [InlineData(RoleMenuPanelUpdateStatus.Missing, RoleMenuEditCommitStatus.PanelMissing)]
+    [InlineData(RoleMenuPanelUpdateStatus.UnexpectedMessage, RoleMenuEditCommitStatus.PanelUnexpected)]
+    public async Task ExecuteAsync_DefinitePanelFailure_KeepsPersistedEdit(
+        RoleMenuPanelUpdateStatus panelStatus,
+        RoleMenuEditCommitStatus expectedStatus)
+    {
+        var persistCalls = 0;
+        var result = await RoleMenuEditWorkflow.ExecuteAsync(
+            CreateSettings(),
+            new RoleMenuEditCommitOperations(
+                (_, _) =>
+                {
+                    persistCalls++;
+                    return Task.CompletedTask;
+                },
+                (_, _) => Task.FromResult(panelStatus),
+                () => false),
+            CancellationToken.None);
+
+        Assert.Equal(expectedStatus, result.Status);
+        Assert.Equal(1, persistCalls);
+        Assert.Empty(result.Failures);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AmbiguousPanelFailure_DoesNotRetryOrRollbackPersistence()
+    {
+        var expected = new TimeoutException("discord outcome unknown");
+        var persistCalls = 0;
+        var panelCalls = 0;
+        var result = await RoleMenuEditWorkflow.ExecuteAsync(
+            CreateSettings(),
+            new RoleMenuEditCommitOperations(
+                (_, _) =>
+                {
+                    persistCalls++;
+                    return Task.CompletedTask;
+                },
+                (_, _) =>
+                {
+                    panelCalls++;
+                    return Task.FromException<RoleMenuPanelUpdateStatus>(expected);
+                },
+                () => false),
+            CancellationToken.None);
+
+        Assert.Equal(RoleMenuEditCommitStatus.PanelOutcomeUnknown, result.Status);
+        Assert.Equal(1, persistCalls);
+        Assert.Equal(1, panelCalls);
+        var failure = Assert.Single(result.Failures);
+        Assert.Equal(RoleMenuEditFailurePhase.PanelUpdate, failure.Phase);
+        Assert.Same(expected, failure.Exception);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RepeatedSuccessfulEdit_IsIdempotentAtWorkflowBoundary()
+    {
+        var persistCalls = 0;
+        var panelCalls = 0;
+        var operations = new RoleMenuEditCommitOperations(
+            (_, _) =>
+            {
+                persistCalls++;
+                return Task.CompletedTask;
+            },
+            (_, _) =>
+            {
+                panelCalls++;
+                return Task.FromResult(RoleMenuPanelUpdateStatus.Updated);
+            },
+            () => false);
+        var replacement = CreateSettings();
+
+        var first = await RoleMenuEditWorkflow.ExecuteAsync(
+            replacement,
+            operations,
+            CancellationToken.None);
+        var second = await RoleMenuEditWorkflow.ExecuteAsync(
+            replacement,
+            operations,
+            CancellationToken.None);
+
+        Assert.Equal(RoleMenuEditCommitStatus.Updated, first.Status);
+        Assert.Equal(RoleMenuEditCommitStatus.Updated, second.Status);
+        Assert.Equal(2, persistCalls);
+        Assert.Equal(2, panelCalls);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShutdownCancellation_PropagatesWithoutPanelWork()
+    {
+        var panelCalls = 0;
+        var cancellation = new OperationCanceledException("shutdown");
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            RoleMenuEditWorkflow.ExecuteAsync(
+                CreateSettings(),
+                new RoleMenuEditCommitOperations(
+                    (_, _) => Task.FromException(cancellation),
+                    (_, _) =>
+                    {
+                        panelCalls++;
+                        return Task.FromResult(RoleMenuPanelUpdateStatus.Updated);
+                    },
+                    () => true),
+                CancellationToken.None));
+
+        Assert.Equal(0, panelCalls);
+    }
+
+    private static RoleMenuSettings CreateSettings()
+        => new(
+            MenuId,
+            "101",
+            "202",
+            "303",
+            "Edited roles",
+            "Updated description",
+            ["404", "405"],
+            RoleMenuSelectionMode.Multiple)
+        {
+            CreatedAtUtc = new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.Zero)
+        };
+}

--- a/BeanBot.Tests/Discord/RoleMenus/RoleMenuEditWorkflowTests.cs
+++ b/BeanBot.Tests/Discord/RoleMenus/RoleMenuEditWorkflowTests.cs
@@ -193,6 +193,6 @@ public class RoleMenuEditWorkflowTests
             ["404", "405"],
             RoleMenuSelectionMode.Multiple)
         {
-            CreatedAtUtc = new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.Zero)
+            CreatedAtUtc = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc)
         };
 }

--- a/BeanBot.Tests/Discord/RoleMenus/RoleMenuEditWorkflowTests.cs
+++ b/BeanBot.Tests/Discord/RoleMenus/RoleMenuEditWorkflowTests.cs
@@ -62,30 +62,17 @@ public class RoleMenuEditWorkflowTests
         Assert.Same(expected, failure.Exception);
     }
 
-    [Theory]
-    [InlineData(RoleMenuPanelUpdateStatus.Missing, RoleMenuEditCommitStatus.PanelMissing)]
-    [InlineData(RoleMenuPanelUpdateStatus.UnexpectedMessage, RoleMenuEditCommitStatus.PanelUnexpected)]
-    public async Task ExecuteAsync_DefinitePanelFailure_KeepsPersistedEdit(
-        RoleMenuPanelUpdateStatus panelStatus,
-        RoleMenuEditCommitStatus expectedStatus)
-    {
-        var persistCalls = 0;
-        var result = await RoleMenuEditWorkflow.ExecuteAsync(
-            CreateSettings(),
-            new RoleMenuEditCommitOperations(
-                (_, _) =>
-                {
-                    persistCalls++;
-                    return Task.CompletedTask;
-                },
-                (_, _) => Task.FromResult(panelStatus),
-                () => false),
-            CancellationToken.None);
+    [Fact]
+    public Task ExecuteAsync_MissingPanel_KeepsPersistedEdit()
+        => AssertDefinitePanelFailureAsync(
+            RoleMenuPanelUpdateStatus.Missing,
+            RoleMenuEditCommitStatus.PanelMissing);
 
-        Assert.Equal(expectedStatus, result.Status);
-        Assert.Equal(1, persistCalls);
-        Assert.Empty(result.Failures);
-    }
+    [Fact]
+    public Task ExecuteAsync_UnexpectedPanel_KeepsPersistedEdit()
+        => AssertDefinitePanelFailureAsync(
+            RoleMenuPanelUpdateStatus.UnexpectedMessage,
+            RoleMenuEditCommitStatus.PanelUnexpected);
 
     [Fact]
     public async Task ExecuteAsync_AmbiguousPanelFailure_DoesNotRetryOrRollbackPersistence()
@@ -171,6 +158,28 @@ public class RoleMenuEditWorkflowTests
                 CancellationToken.None));
 
         Assert.Equal(0, panelCalls);
+    }
+
+    private static async Task AssertDefinitePanelFailureAsync(
+        RoleMenuPanelUpdateStatus panelStatus,
+        RoleMenuEditCommitStatus expectedStatus)
+    {
+        var persistCalls = 0;
+        var result = await RoleMenuEditWorkflow.ExecuteAsync(
+            CreateSettings(),
+            new RoleMenuEditCommitOperations(
+                (_, _) =>
+                {
+                    persistCalls++;
+                    return Task.CompletedTask;
+                },
+                (_, _) => Task.FromResult(panelStatus),
+                () => false),
+            CancellationToken.None);
+
+        Assert.Equal(expectedStatus, result.Status);
+        Assert.Equal(1, persistCalls);
+        Assert.Empty(result.Failures);
     }
 
     private static RoleMenuSettings CreateSettings()

--- a/BeanBot.Tests/Discord/RoleMenus/RoleMenuInteractionMetadataTests.cs
+++ b/BeanBot.Tests/Discord/RoleMenus/RoleMenuInteractionMetadataTests.cs
@@ -29,6 +29,23 @@ public class RoleMenuInteractionMetadataTests
     }
 
     [Fact]
+    public void AdminCommands_ShareOneGroupedInteractionModule()
+    {
+        var groupedRoleMenuModules = typeof(RoleMenuAdminModule).Assembly
+            .GetTypes()
+            .Where(type => !type.IsAbstract
+                           && typeof(RoleMenuModuleBase).IsAssignableFrom(type)
+                           && type.GetCustomAttribute<GroupAttribute>() is not null)
+            .ToList();
+
+        var module = Assert.Single(groupedRoleMenuModules);
+        Assert.Equal(typeof(RoleMenuAdminModule), module);
+        Assert.NotNull(module.GetMethod(nameof(RoleMenuAdminModule.CreateAsync)));
+        Assert.NotNull(module.GetMethod(nameof(RoleMenuAdminModule.EditAsync)));
+        Assert.NotNull(module.GetMethod(nameof(RoleMenuAdminModule.DeleteAsync)));
+    }
+
+    [Fact]
     public void CreateModal_UsesNativeBoundedRoleAndTextChannelSelectors()
     {
         var roles = Assert.IsAssignableFrom<PropertyInfo>(
@@ -88,6 +105,7 @@ public class RoleMenuInteractionMetadataTests
         {
             typeof(RoleMenuAdminModule).GetMethod(nameof(RoleMenuAdminModule.HandleCreateModalAsync)),
             typeof(RoleMenuAdminModule).GetMethod(nameof(RoleMenuAdminModule.PublishAsync)),
+            typeof(RoleMenuAdminModule).GetMethod(nameof(RoleMenuAdminModule.HandleEditModalAsync)),
             typeof(RoleMenuAdminModule).GetMethod(nameof(RoleMenuAdminModule.ConfirmDeleteAsync)),
             typeof(RoleMenuMemberModule).GetMethod(nameof(RoleMenuMemberModule.SaveAsync)),
             typeof(RoleMenuMemberModule).GetMethod(nameof(RoleMenuMemberModule.ClearAsync))

--- a/BeanBot.Tests/Discord/RoleMenus/RoleMenuSetupValidationTests.cs
+++ b/BeanBot.Tests/Discord/RoleMenus/RoleMenuSetupValidationTests.cs
@@ -1,0 +1,15 @@
+using BeanBot.Discord.RoleMenus;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.RoleMenus;
+
+public class RoleMenuSetupValidationTests
+{
+    [Fact]
+    public void TryParseSelectionMode_Null_ReturnsFalse()
+    {
+        var parsed = RoleMenuSetupValidation.TryParseSelectionMode(null, out _);
+
+        Assert.False(parsed);
+    }
+}

--- a/BeanBot/Discord/RoleMenus/DiscordRoleMenuClient.cs
+++ b/BeanBot/Discord/RoleMenus/DiscordRoleMenuClient.cs
@@ -300,6 +300,77 @@ public sealed class DiscordRoleMenuClient
         }
     }
 
+    internal async Task<RoleMenuPanelUpdateStatus> UpdatePanelAsync(
+        ulong guildId,
+        ObjectId menuId,
+        ulong channelId,
+        ulong messageId,
+        ulong botUserId,
+        RoleMenuSettings replacement,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(replacement);
+        var requestOptions = CreateRequestOptions(cancellationToken);
+        IChannel? channel;
+        try
+        {
+            channel = await _getChannel(channelId, requestOptions);
+        }
+        catch (HttpException exception) when (exception.HttpCode == HttpStatusCode.NotFound)
+        {
+            return RoleMenuPanelUpdateStatus.Missing;
+        }
+
+        if (channel is not ITextChannel textChannel || textChannel.GuildId != guildId)
+        {
+            return RoleMenuPanelUpdateStatus.UnexpectedMessage;
+        }
+
+        IMessage? message;
+        try
+        {
+            message = await textChannel.GetMessageAsync(
+                messageId,
+                CacheMode.AllowDownload,
+                requestOptions);
+        }
+        catch (HttpException exception) when (exception.HttpCode == HttpStatusCode.NotFound)
+        {
+            return RoleMenuPanelUpdateStatus.Missing;
+        }
+
+        if (message is not IUserMessage userMessage
+            || userMessage.Author.Id != botUserId
+            || !RoleMenuComponents.HasManageButton(userMessage, menuId))
+        {
+            return RoleMenuPanelUpdateStatus.UnexpectedMessage;
+        }
+
+        try
+        {
+            await userMessage.ModifyAsync(
+                properties =>
+                {
+                    properties.Embeds =
+                    [
+                        RoleMenuComponents.BuildPublicEmbed(
+                            menuId,
+                            replacement.Title,
+                            replacement.Description,
+                            replacement.SelectionMode)
+                    ];
+                    properties.Components = RoleMenuComponents.BuildPublicComponents(menuId);
+                    properties.AllowedMentions = AllowedMentions.None;
+                },
+                requestOptions);
+            return RoleMenuPanelUpdateStatus.Updated;
+        }
+        catch (HttpException exception) when (exception.HttpCode == HttpStatusCode.NotFound)
+        {
+            return RoleMenuPanelUpdateStatus.Missing;
+        }
+    }
+
     internal async Task<RoleMenuPanelSnapshot?> ReadPanelSnapshotAsync(
         ulong guildId,
         ObjectId menuId,

--- a/BeanBot/Discord/RoleMenus/DiscordRoleMenuClient.cs
+++ b/BeanBot/Discord/RoleMenus/DiscordRoleMenuClient.cs
@@ -351,7 +351,7 @@ public sealed class DiscordRoleMenuClient
             await userMessage.ModifyAsync(
                 properties =>
                 {
-                    properties.Embeds =
+                    Embed[] embeds =
                     [
                         RoleMenuComponents.BuildPublicEmbed(
                             menuId,
@@ -359,6 +359,7 @@ public sealed class DiscordRoleMenuClient
                             replacement.Description,
                             replacement.SelectionMode)
                     ];
+                    properties.Embeds = embeds;
                     properties.Components = RoleMenuComponents.BuildPublicComponents(menuId);
                     properties.AllowedMentions = AllowedMentions.None;
                 },

--- a/BeanBot/Discord/RoleMenus/RoleMenuAdminModule.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuAdminModule.cs
@@ -21,7 +21,7 @@ namespace BeanBot.Discord.RoleMenus;
 [RequireContext(ContextType.Guild)]
 [RequireUserPermission(GuildPermission.ManageRoles)]
 [DefaultMemberPermissions(GuildPermission.ManageRoles)]
-public sealed class RoleMenuAdminModule : RoleMenuModuleBase
+public sealed partial class RoleMenuAdminModule : RoleMenuModuleBase
 {
     private readonly DiscordRoleMenuClient _discord;
     private readonly RoleMenuAdministrationService _administration;

--- a/BeanBot/Discord/RoleMenus/RoleMenuAdministrationService.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuAdministrationService.cs
@@ -45,7 +45,7 @@ public sealed class RoleMenuAdministrationService
             return new RoleMenuPreviewResult("Bean Bot couldn't refresh the current server role hierarchy. Try again in a moment.");
         }
 
-        var title = request.Title.Trim();
+        var title = request.Title?.Trim() ?? string.Empty;
         var description = request.Description?.Trim() ?? string.Empty;
         if (!TryParseAndValidateModal(
                 request,
@@ -225,7 +225,7 @@ public sealed class RoleMenuAdministrationService
                 "Bean Bot couldn't refresh the current server role hierarchy. Try again in a moment.");
         }
 
-        var title = request.Title.Trim();
+        var title = request.Title?.Trim() ?? string.Empty;
         var description = request.Description?.Trim() ?? string.Empty;
         if (!TryParseAndValidateEdit(
                 request,

--- a/BeanBot/Discord/RoleMenus/RoleMenuAdministrationService.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuAdministrationService.cs
@@ -186,6 +186,185 @@ public sealed class RoleMenuAdministrationService
                 menuId,
                 cancellationToken));
 
+    internal async Task<RoleMenuEditResult> EditAsync(
+        ObjectId menuId,
+        RoleMenuEditRequest request,
+        ulong guildId,
+        ulong administratorId,
+        ulong botUserId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var settings = await _roleMenuService.GetAsync(menuId, guildId, cancellationToken);
+        if (settings is null)
+        {
+            return new RoleMenuEditResult(
+                RoleMenuEditStatus.NotFound,
+                "That role menu was deleted or no longer exists in this server.");
+        }
+
+        if (settings.Id != menuId
+            || !RoleMenuSettingsParser.TryParse(settings, out var parsed, out _)
+            || parsed.GuildId != guildId)
+        {
+            return new RoleMenuEditResult(
+                RoleMenuEditStatus.InvalidStoredConfiguration,
+                "That saved role menu is invalid and cannot be edited safely. Use `/role-menu delete` to clean it up.");
+        }
+
+        var requestOptions = CreateRequestOptions(cancellationToken);
+        var currentAdministrator = await _discord.GetGuildUserAsync(
+            guildId,
+            administratorId,
+            requestOptions);
+        var currentBot = await _discord.GetGuildUserAsync(guildId, botUserId, requestOptions);
+        if (currentAdministrator is null || currentBot is null)
+        {
+            return new RoleMenuEditResult(
+                RoleMenuEditStatus.ValidationFailed,
+                "Bean Bot couldn't refresh the current server role hierarchy. Try again in a moment.");
+        }
+
+        var title = request.Title.Trim();
+        var description = request.Description?.Trim() ?? string.Empty;
+        if (!TryParseAndValidateEdit(
+                request,
+                currentAdministrator,
+                currentBot,
+                title,
+                description,
+                out var selectionMode,
+                out _,
+                out var validationMessage))
+        {
+            return new RoleMenuEditResult(
+                currentAdministrator.GuildPermissions.ManageRoles
+                    ? RoleMenuEditStatus.ValidationFailed
+                    : RoleMenuEditStatus.AuthorizationDenied,
+                validationMessage);
+        }
+
+        var targetChannel = await _discord.GetGuildTextChannelAsync(
+            guildId,
+            parsed.ChannelId,
+            requestOptions);
+        if (targetChannel is null)
+        {
+            return new RoleMenuEditResult(
+                RoleMenuEditStatus.PanelUnavailable,
+                "The saved target channel is missing or is no longer a normal text channel. The menu was not changed.");
+        }
+
+        var channelPermissionFailure = GetChannelPermissionFailure(currentBot, targetChannel);
+        if (channelPermissionFailure is not null)
+        {
+            return new RoleMenuEditResult(
+                RoleMenuEditStatus.ValidationFailed,
+                channelPermissionFailure.Replace("published", "updated", StringComparison.Ordinal));
+        }
+
+        var panelLookup = await _discord.ReadDeletionPanelAsync(
+            guildId,
+            menuId,
+            parsed.ChannelId,
+            parsed.MessageId,
+            cancellationToken);
+        if (!IsExpectedPanel(panelLookup, guildId, parsed.ChannelId, parsed.MessageId, botUserId))
+        {
+            return new RoleMenuEditResult(
+                RoleMenuEditStatus.PanelUnavailable,
+                "The saved message is missing or no longer matches Bean Bot's role-menu panel. Nothing was changed; use `/role-menu audit` or `/role-menu delete` to inspect it.");
+        }
+
+        var replacement = new RoleMenuSettings(
+            settings.Id,
+            settings.GuildId,
+            settings.ChannelId,
+            settings.MessageId,
+            title,
+            description,
+            request.RoleIds!.Select(roleId => roleId.ToString(CultureInfo.InvariantCulture)),
+            selectionMode)
+        {
+            CreatedAtUtc = settings.CreatedAtUtc
+        };
+        var commit = await RoleMenuEditWorkflow.ExecuteAsync(
+            replacement,
+            new RoleMenuEditCommitOperations(
+                (candidate, operationToken) =>
+                    _roleMenuService.UpsertAsync(candidate, operationToken),
+                (candidate, operationToken) => _discord.UpdatePanelAsync(
+                    guildId,
+                    menuId,
+                    parsed.ChannelId,
+                    parsed.MessageId,
+                    botUserId,
+                    candidate,
+                    operationToken),
+                () => _roleMenuService.IsShuttingDown),
+            cancellationToken);
+        LogEditFailures(menuId, commit.Failures);
+        return commit.Status switch
+        {
+            RoleMenuEditCommitStatus.Updated => new RoleMenuEditResult(
+                RoleMenuEditStatus.Updated,
+                "Role menu updated in place. The stable menu ID, channel, and message were preserved."),
+            RoleMenuEditCommitStatus.PersistenceOutcomeUnknown => new RoleMenuEditResult(
+                RoleMenuEditStatus.PersistenceOutcomeUnknown,
+                "Bean Bot couldn't confirm whether MongoDB saved the edit, so it left the public panel untouched. Reopen `/role-menu edit` to inspect persisted truth before retrying."),
+            RoleMenuEditCommitStatus.PanelMissing => new RoleMenuEditResult(
+                RoleMenuEditStatus.PanelUpdateFailed,
+                "The edited settings were saved and are now authoritative, but the public panel disappeared before Bean Bot could update it. Use `/role-menu audit` or `/role-menu delete` to reconcile the stale presentation."),
+            RoleMenuEditCommitStatus.PanelUnexpected => new RoleMenuEditResult(
+                RoleMenuEditStatus.PanelUpdateFailed,
+                "The edited settings were saved and are now authoritative, but the saved message stopped matching Bean Bot's panel before it could be updated. The message was left untouched; inspect it with `/role-menu audit`."),
+            RoleMenuEditCommitStatus.PanelOutcomeUnknown => new RoleMenuEditResult(
+                RoleMenuEditStatus.PanelOutcomeUnknown,
+                "The edited settings were saved and are now authoritative, but Bean Bot could not confirm the Discord panel update. It did not retry or publish a replacement. Inspect the existing message, then rerun the same edit to reconcile it safely."),
+            _ => throw new InvalidOperationException("Unknown role-menu edit result.")
+        };
+    }
+
+    private static bool IsExpectedPanel(
+        RoleMenuPanelLookupResult lookup,
+        ulong guildId,
+        ulong channelId,
+        ulong messageId,
+        ulong botUserId)
+        => lookup.Status == RoleMenuPanelLookupStatus.Found
+           && lookup.Panel is
+           {
+               HasManageButton: true
+           } panel
+           && panel.GuildId == guildId
+           && panel.ChannelId == channelId
+           && panel.MessageId == messageId
+           && panel.AuthorId == botUserId;
+
+    private void LogEditFailures(
+        ObjectId menuId,
+        IReadOnlyCollection<RoleMenuEditFailure> failures)
+    {
+        foreach (var failure in failures)
+        {
+            switch (failure.Phase)
+            {
+                case RoleMenuEditFailurePhase.Persistence:
+                    BeanBotLog.RoleMenuEditPersistenceFailed(
+                        _logger,
+                        menuId.ToString(),
+                        failure.Exception);
+                    break;
+                case RoleMenuEditFailurePhase.PanelUpdate:
+                    BeanBotLog.RoleMenuEditPanelUpdateFailed(
+                        _logger,
+                        menuId.ToString(),
+                        failure.Exception);
+                    break;
+            }
+        }
+    }
+
     internal async Task<RoleMenuDeletionResult> DeleteAsync(
         ObjectId menuId,
         ulong guildId,
@@ -271,7 +450,7 @@ public sealed class RoleMenuAdministrationService
                     messageId,
                     cancellationToken),
             (panel, cancellationToken) => _discord.DeleteDeletionPanelAsync(
-                    guildId,
+                guildId,
                 menuId,
                 panel,
                 cancellationToken),
@@ -296,3 +475,26 @@ internal sealed record RoleMenuPreviewResult(
     string Content,
     RoleMenuDraft? Draft = null,
     IReadOnlyCollection<RoleMenuRoleSnapshot>? Roles = null);
+
+internal sealed record RoleMenuEditRequest(
+    string Title,
+    string? Description,
+    string SelectionMode,
+    IReadOnlyCollection<ulong>? RoleIds);
+
+internal enum RoleMenuEditStatus
+{
+    Updated,
+    NotFound,
+    InvalidStoredConfiguration,
+    AuthorizationDenied,
+    ValidationFailed,
+    PanelUnavailable,
+    PersistenceOutcomeUnknown,
+    PanelUpdateFailed,
+    PanelOutcomeUnknown
+}
+
+internal sealed record RoleMenuEditResult(
+    RoleMenuEditStatus Status,
+    string Content);

--- a/BeanBot/Discord/RoleMenus/RoleMenuComponents.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuComponents.cs
@@ -136,14 +136,60 @@ internal static class RoleMenuComponents
             conflictingSingleSelection);
     }
 
+    internal static MessageComponent BuildEditSelector(
+        ulong userId,
+        IReadOnlyCollection<RoleMenuSettings> settings)
+        => BuildAdministrativeSelector(
+            RoleMenuCustomIds.EditSelect(userId),
+            "Choose a role menu to edit",
+            settings);
+
+    internal static Embed BuildEditSummaryEmbed(RoleMenuEditDraft draft)
+    {
+        ArgumentNullException.ThrowIfNull(draft);
+        var roleMentions = string.Join(
+            " ",
+            draft.RoleIds.Select(roleId =>
+                $"<@&{roleId.ToString(CultureInfo.InvariantCulture)}>"));
+        var mode = draft.SelectionMode == RoleMenuSelectionMode.Exclusive
+            ? "Single selection"
+            : "Multiple selection";
+        return new EmbedBuilder()
+            .WithTitle(draft.Title)
+            .WithDescription(string.IsNullOrWhiteSpace(draft.Description)
+                ? DefaultDescription
+                : draft.Description)
+            .AddField("Roles", roleMentions)
+            .AddField("Mode", mode, inline: true)
+            .WithFooter($"Current values • ID: {draft.MenuId}")
+            .Build();
+    }
+
+    internal static MessageComponent BuildEditOpenComponents(Guid draftId)
+        => new ComponentBuilder()
+            .WithButton(
+                "Edit values",
+                RoleMenuCustomIds.EditOpen(draftId),
+                ButtonStyle.Primary)
+            .Build();
+
     internal static MessageComponent BuildDeleteSelector(
         ulong userId,
+        IReadOnlyCollection<RoleMenuSettings> settings)
+        => BuildAdministrativeSelector(
+            RoleMenuCustomIds.DeleteSelect(userId),
+            "Choose a role menu to delete",
+            settings);
+
+    private static MessageComponent BuildAdministrativeSelector(
+        string customId,
+        string placeholder,
         IReadOnlyCollection<RoleMenuSettings> settings)
     {
         ArgumentNullException.ThrowIfNull(settings);
         var selector = new SelectMenuBuilder()
-            .WithCustomId(RoleMenuCustomIds.DeleteSelect(userId))
-            .WithPlaceholder("Choose a role menu to delete")
+            .WithCustomId(customId)
+            .WithPlaceholder(placeholder)
             .WithMinValues(1)
             .WithMaxValues(1);
         foreach (var menu in settings)

--- a/BeanBot/Discord/RoleMenus/RoleMenuCustomIds.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuCustomIds.cs
@@ -12,6 +12,9 @@ internal static class RoleMenuCustomIds
     internal const string ClearPattern = "role-menu:clear:*:*:*";
     internal const string PublishPattern = "role-menu:publish:*";
     internal const string CancelPublishPattern = "role-menu:cancel-publish:*";
+    internal const string EditSelectPattern = "role-menu:edit-select:*";
+    internal const string EditOpenPattern = "role-menu:edit-open:*";
+    internal const string EditModalPattern = "role-menu:edit-modal:*";
     internal const string DeleteSelectPattern = "role-menu:delete-select:*";
     internal const string DeleteConfirmPattern = "role-menu:delete-confirm:*:*";
     internal const string DeleteCancelPattern = "role-menu:delete-cancel:*";
@@ -36,6 +39,15 @@ internal static class RoleMenuCustomIds
 
     internal static string CancelPublish(Guid draftId)
         => EnsureValid($"role-menu:cancel-publish:{draftId:N}");
+
+    internal static string EditSelect(ulong userId)
+        => EnsureValid($"role-menu:edit-select:{userId.ToString(CultureInfo.InvariantCulture)}");
+
+    internal static string EditOpen(Guid draftId)
+        => EnsureValid($"role-menu:edit-open:{draftId:N}");
+
+    internal static string EditModal(Guid draftId)
+        => EnsureValid($"role-menu:edit-modal:{draftId:N}");
 
     internal static string DeleteSelect(ulong userId)
         => EnsureValid($"role-menu:delete-select:{userId.ToString(CultureInfo.InvariantCulture)}");

--- a/BeanBot/Discord/RoleMenus/RoleMenuDraftRegistry.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuDraftRegistry.cs
@@ -44,6 +44,7 @@ internal sealed class RoleMenuDraftRegistry
     private readonly TimeProvider _timeProvider;
     private readonly int _capacity;
     private readonly TimeSpan _lifetime;
+    private readonly RoleMenuEditDraftRegistry _editDraftRegistry;
 
     public RoleMenuDraftRegistry()
         : this(
@@ -63,6 +64,7 @@ internal sealed class RoleMenuDraftRegistry
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(lifetime, TimeSpan.Zero);
         _capacity = capacity;
         _lifetime = lifetime;
+        _editDraftRegistry = new RoleMenuEditDraftRegistry(timeProvider, capacity, lifetime);
     }
 
     internal RoleMenuDraftCreateStatus Create(
@@ -204,6 +206,45 @@ internal sealed class RoleMenuDraftRegistry
             }
         }
     }
+
+    internal RoleMenuEditDraftCreateStatus CreateEdit(
+        ObjectId menuId,
+        ulong guildId,
+        ulong userId,
+        string title,
+        string description,
+        IReadOnlyCollection<ulong> roleIds,
+        RoleMenuSelectionMode selectionMode,
+        out RoleMenuEditDraft? draft)
+        => _editDraftRegistry.Create(
+            menuId,
+            guildId,
+            userId,
+            title,
+            description,
+            roleIds,
+            selectionMode,
+            out draft);
+
+    internal RoleMenuEditDraftAccessStatus TryGetEdit(
+        Guid draftId,
+        ulong guildId,
+        ulong userId,
+        out RoleMenuEditDraft? draft)
+        => _editDraftRegistry.TryGet(draftId, guildId, userId, out draft);
+
+    internal RoleMenuEditDraftAccessStatus TryBeginEdit(
+        Guid draftId,
+        ulong guildId,
+        ulong userId,
+        out RoleMenuEditDraft? draft)
+        => _editDraftRegistry.TryBeginSubmit(draftId, guildId, userId, out draft);
+
+    internal void ReleaseEdit(Guid draftId, ulong guildId, ulong userId)
+        => _editDraftRegistry.Release(draftId, guildId, userId);
+
+    internal void CompleteEdit(Guid draftId, ulong guildId, ulong userId)
+        => _editDraftRegistry.Complete(draftId, guildId, userId);
 
     private void PurgeExpiredUnsafe()
     {

--- a/BeanBot/Discord/RoleMenus/RoleMenuEditAdminModule.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuEditAdminModule.cs
@@ -3,31 +3,12 @@ using BeanBot.Persistence.Models;
 using Discord;
 using Discord.Interactions;
 using Discord.WebSocket;
-using Microsoft.Extensions.Logging;
 using static BeanBot.Discord.RoleMenus.DiscordRoleMenuClient;
 
 namespace BeanBot.Discord.RoleMenus;
 
-[Group("role-menu", "Create and remove self-assignable role menus.")]
-[CommandContextType(InteractionContextType.Guild)]
-[RequireContext(ContextType.Guild)]
-[RequireUserPermission(GuildPermission.ManageRoles)]
-[DefaultMemberPermissions(GuildPermission.ManageRoles)]
-public sealed class RoleMenuEditAdminModule : RoleMenuModuleBase
+public sealed partial class RoleMenuAdminModule
 {
-    private readonly RoleMenuAdministrationService _administration;
-    private readonly ILogger<RoleMenuEditAdminModule> _logger;
-
-    public RoleMenuEditAdminModule(
-        RoleMenuInteractionService roleMenuService,
-        RoleMenuAdministrationService administration,
-        ILogger<RoleMenuEditAdminModule> logger)
-        : base(roleMenuService)
-    {
-        _administration = administration ?? throw new ArgumentNullException(nameof(administration));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-    }
-
     [SlashCommand(
         "edit",
         "Edit a published role menu in place.",
@@ -364,41 +345,5 @@ public sealed class RoleMenuEditAdminModule : RoleMenuModuleBase
             cancellationToken,
             RoleMenuComponents.BuildEditSummaryEmbed(draft),
             RoleMenuComponents.BuildEditOpenComponents(draft.Id));
-    }
-
-    private static bool IsValidPrivateComponent(
-        SocketMessageComponent component,
-        SocketGuild guild,
-        ComponentType expectedType,
-        string expectedCustomId,
-        string? selectedValue = null)
-    {
-        if (!IsEphemeral(component)
-            || component.Message.Author.Id != guild.CurrentUser.Id
-            || component.Data.Type != expectedType
-            || !string.Equals(
-                component.Data.CustomId,
-                expectedCustomId,
-                StringComparison.Ordinal))
-        {
-            return false;
-        }
-
-        var sourceComponent = component.Message.Components
-            .OfType<ActionRowComponent>()
-            .SelectMany(row => row.Components)
-            .OfType<IInteractableComponent>()
-            .FirstOrDefault(candidate => candidate.Type == expectedType
-                                         && string.Equals(
-                                             candidate.CustomId,
-                                             expectedCustomId,
-                                             StringComparison.Ordinal));
-        return sourceComponent is not null
-               && (selectedValue is null
-                   || sourceComponent is SelectMenuComponent selector
-                   && selector.Options.Any(option => string.Equals(
-                       option.Value,
-                       selectedValue,
-                       StringComparison.Ordinal)));
     }
 }

--- a/BeanBot/Discord/RoleMenus/RoleMenuEditAdminModule.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuEditAdminModule.cs
@@ -1,0 +1,404 @@
+using BeanBot.Logging;
+using BeanBot.Persistence.Models;
+using Discord;
+using Discord.Interactions;
+using Discord.WebSocket;
+using Microsoft.Extensions.Logging;
+using static BeanBot.Discord.RoleMenus.DiscordRoleMenuClient;
+
+namespace BeanBot.Discord.RoleMenus;
+
+[Group("role-menu", "Create and remove self-assignable role menus.")]
+[CommandContextType(InteractionContextType.Guild)]
+[RequireContext(ContextType.Guild)]
+[RequireUserPermission(GuildPermission.ManageRoles)]
+[DefaultMemberPermissions(GuildPermission.ManageRoles)]
+public sealed class RoleMenuEditAdminModule : RoleMenuModuleBase
+{
+    private readonly RoleMenuAdministrationService _administration;
+    private readonly ILogger<RoleMenuEditAdminModule> _logger;
+
+    public RoleMenuEditAdminModule(
+        RoleMenuInteractionService roleMenuService,
+        RoleMenuAdministrationService administration,
+        ILogger<RoleMenuEditAdminModule> logger)
+        : base(roleMenuService)
+    {
+        _administration = administration ?? throw new ArgumentNullException(nameof(administration));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    [SlashCommand(
+        "edit",
+        "Edit a published role menu in place.",
+        runMode: RunMode.Sync)]
+    public async Task EditAsync(
+        [Summary("menu-id", "Optional ID shown in the role panel footer")]
+        string? menuId = null)
+    {
+        using var cancellation = RoleMenus.CreateOperationCancellation();
+        await RoleMenus.ExecuteInitialResponseAsync(
+            supportsOriginalResponse: true,
+            operationToken => DeferAsync(
+                ephemeral: true,
+                CreateRequestOptions(operationToken)),
+            operationToken => ReplaceResponseAsync(
+                "Loading role menus…",
+                operationToken),
+            cancellation.Token);
+        if (Context.Guild is null)
+        {
+            await ReplaceResponseAsync(
+                "Role menus can only be edited inside a server.",
+                cancellation.Token);
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(menuId))
+        {
+            if (!RoleMenuCustomIds.TryParseMenuId(menuId.Trim(), out var parsedMenuId))
+            {
+                await ReplaceResponseAsync(
+                    "That menu ID is invalid. Copy the ID from the role panel footer.",
+                    cancellation.Token);
+                return;
+            }
+
+            var settings = await RoleMenus.GetAsync(
+                parsedMenuId,
+                Context.Guild.Id,
+                cancellation.Token);
+            if (settings is null)
+            {
+                await ReplaceResponseAsync(
+                    "No saved role menu with that ID exists in this server.",
+                    cancellation.Token);
+                return;
+            }
+
+            await ShowEditPreviewAsync(settings, cancellation.Token);
+            return;
+        }
+
+        var menus = await RoleMenus.GetByGuildAsync(
+            Context.Guild.Id,
+            RoleMenuConstants.MaximumListedMenus + 1,
+            cancellation.Token);
+        if (menus.Count == 0)
+        {
+            await ReplaceResponseAsync(
+                "This server has no saved dropdown role menus.",
+                cancellation.Token);
+            return;
+        }
+
+        var hasMore = menus.Count > RoleMenuConstants.MaximumListedMenus;
+        var listedMenus = menus.Take(RoleMenuConstants.MaximumListedMenus).ToList();
+        await ReplaceResponseAsync(
+            hasMore
+                ? "Choose one of the 25 newest menus. For an older panel, rerun `/role-menu edit` " +
+                  "with the ID shown in its footer."
+                : "Choose the role menu you want to edit.",
+            cancellation.Token,
+            components: RoleMenuComponents.BuildEditSelector(Context.User.Id, listedMenus));
+    }
+
+    [ComponentInteraction(
+        RoleMenuCustomIds.EditSelectPattern,
+        ignoreGroupNames: true,
+        runMode: RunMode.Sync)]
+    public async Task SelectEditAsync(string userIdValue, string[] selectedMenuIds)
+    {
+        using var cancellation = RoleMenus.CreateOperationCancellation();
+        if (!RoleMenuCustomIds.TryParseSnowflake(userIdValue, out var boundUserId)
+            || boundUserId != Context.User.Id
+            || selectedMenuIds is not { Length: 1 }
+            || !RoleMenuCustomIds.TryParseMenuId(selectedMenuIds[0], out var menuId)
+            || Context.Guild is null
+            || Context.Interaction is not SocketMessageComponent component
+            || !IsValidPrivateComponent(
+                component,
+                Context.Guild,
+                ComponentType.SelectMenu,
+                RoleMenuCustomIds.EditSelect(boundUserId),
+                selectedMenuIds[0]))
+        {
+            await RespondToInvalidComponentAsync(
+                "That edit selection is invalid or belongs to another administrator.",
+                cancellation.Token);
+            return;
+        }
+
+        if (!await AcknowledgeEphemeralComponentAsync(
+                "Loading the selected role menu…",
+                cancellation.Token))
+        {
+            return;
+        }
+
+        var settings = await RoleMenus.GetAsync(
+            menuId,
+            Context.Guild.Id,
+            cancellation.Token);
+        if (settings is null)
+        {
+            await ReplaceResponseAsync(
+                "That role menu was deleted or no longer exists.",
+                cancellation.Token);
+            return;
+        }
+
+        await ShowEditPreviewAsync(settings, cancellation.Token);
+    }
+
+    [ComponentInteraction(
+        RoleMenuCustomIds.EditOpenPattern,
+        ignoreGroupNames: true,
+        runMode: RunMode.Sync)]
+    public async Task OpenEditAsync(string draftIdValue)
+    {
+        using var cancellation = RoleMenus.CreateOperationCancellation();
+        if (!RoleMenuCustomIds.TryParseDraftId(draftIdValue, out var draftId)
+            || Context.Guild is null
+            || Context.Interaction is not SocketMessageComponent component
+            || !IsValidPrivateComponent(
+                component,
+                Context.Guild,
+                ComponentType.Button,
+                RoleMenuCustomIds.EditOpen(draftId)))
+        {
+            await RespondToInvalidComponentAsync(
+                "That role-menu edit preview is invalid or no longer available.",
+                cancellation.Token);
+            return;
+        }
+
+        var accessStatus = RoleMenus.TryGetEditDraft(
+            draftId,
+            Context.Guild.Id,
+            Context.User.Id,
+            out var draft);
+        if (accessStatus != RoleMenuEditDraftAccessStatus.Acquired || draft is null)
+        {
+            await RespondToInvalidComponentAsync(
+                accessStatus == RoleMenuEditDraftAccessStatus.AlreadySubmitting
+                    ? "That role-menu edit is already being submitted."
+                    : "That role-menu edit preview expired or belongs to another administrator.",
+                cancellation.Token);
+            return;
+        }
+
+        var roles = draft.RoleIds
+            .Select(Context.Guild.GetRole)
+            .Where(role => role is not null)
+            .Cast<IRole>()
+            .ToArray();
+        var modal = new RoleMenuEditModal
+        {
+            PanelTitle = draft.Title,
+            Description = draft.Description,
+            Roles = roles,
+            SelectionMode = draft.SelectionMode == RoleMenuSelectionMode.Exclusive
+                ? "single"
+                : "multiple"
+        };
+        await RoleMenus.ExecuteInitialResponseAsync(
+            supportsOriginalResponse: false,
+            operationToken => RespondWithModalAsync(
+                RoleMenuCustomIds.EditModal(draft.Id),
+                modal,
+                CreateRequestOptions(operationToken)),
+            _ => Task.CompletedTask,
+            cancellation.Token);
+    }
+
+    [ModalInteraction(
+        RoleMenuCustomIds.EditModalPattern,
+        ignoreGroupNames: true,
+        runMode: RunMode.Sync)]
+    public async Task HandleEditModalAsync(string draftIdValue, RoleMenuEditModal modal)
+    {
+        ArgumentNullException.ThrowIfNull(modal);
+        using var cancellation = RoleMenus.CreateOperationCancellation();
+        if (!RoleMenuCustomIds.TryParseDraftId(draftIdValue, out var draftId)
+            || Context.Guild is null)
+        {
+            await RespondToInvalidComponentAsync(
+                "That role-menu edit preview is invalid or no longer available.",
+                cancellation.Token);
+            return;
+        }
+
+        var accessStatus = RoleMenus.TryBeginEdit(
+            draftId,
+            Context.Guild.Id,
+            Context.User.Id,
+            out var draft);
+        if (accessStatus != RoleMenuEditDraftAccessStatus.Acquired || draft is null)
+        {
+            await RespondToInvalidComponentAsync(
+                accessStatus == RoleMenuEditDraftAccessStatus.AlreadySubmitting
+                    ? "That role-menu edit is already being submitted."
+                    : "That role-menu edit preview expired or belongs to another administrator.",
+                cancellation.Token);
+            return;
+        }
+
+        var completed = false;
+        try
+        {
+            await RoleMenus.ExecuteInitialResponseAsync(
+                supportsOriginalResponse: true,
+                operationToken => DeferAsync(
+                    ephemeral: true,
+                    CreateRequestOptions(operationToken)),
+                operationToken => ReplaceResponseAsync(
+                    "Saving the role-menu edit…",
+                    operationToken),
+                cancellation.Token);
+
+            var bot = Context.Guild.CurrentUser;
+            if (bot is null)
+            {
+                await ReplaceResponseAsync(
+                    "Bean Bot couldn't resolve its current server identity. Try again.",
+                    cancellation.Token);
+                return;
+            }
+
+            var mutationStarted = false;
+            RoleMenuEditResult result;
+            try
+            {
+                result = await RoleMenus.RunMenuMutationAsync(
+                    draft.MenuId,
+                    operationToken =>
+                    {
+                        mutationStarted = true;
+                        return _administration.EditAsync(
+                            draft.MenuId,
+                            new RoleMenuEditRequest(
+                                modal.PanelTitle,
+                                modal.Description,
+                                modal.SelectionMode,
+                                modal.Roles?.Select(role => role.Id).ToArray()),
+                            Context.Guild.Id,
+                            Context.User.Id,
+                            bot.Id,
+                            operationToken);
+                    },
+                    cancellation.Token);
+            }
+            catch (OperationCanceledException)
+                when (cancellation.IsCancellationRequested && !RoleMenus.IsShuttingDown)
+            {
+                await SendFreshFeedbackAsync(
+                    mutationStarted
+                        ? "Bean Bot ran out of time while editing this menu and could not confirm the final state. Inspect the saved menu and existing panel before retrying; no replacement panel was published."
+                        : "Bean Bot was busy and did not begin editing this role menu. Try again.");
+                return;
+            }
+
+            await ReplaceResponseAsync(result.Content, cancellation.Token);
+            if (result.Status == RoleMenuEditStatus.Updated)
+            {
+                RoleMenus.CompleteEdit(draft.Id, draft.GuildId, draft.UserId);
+                completed = true;
+            }
+        }
+        catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            BeanBotLog.RoleMenuEditOperationFailed(
+                _logger,
+                draft.MenuId.ToString(),
+                exception);
+            await SendFreshFeedbackAsync(
+                "Bean Bot couldn't confirm the role-menu edit. Inspect the saved menu and existing panel before retrying; no replacement panel was published.");
+        }
+        finally
+        {
+            if (!completed)
+            {
+                RoleMenus.ReleaseEdit(draft.Id, draft.GuildId, draft.UserId);
+            }
+        }
+    }
+
+    private async Task ShowEditPreviewAsync(
+        RoleMenuSettings settings,
+        CancellationToken cancellationToken)
+    {
+        if (!RoleMenuSettingsParser.TryParse(settings, out var parsed, out _))
+        {
+            await ReplaceResponseAsync(
+                "That saved role menu is invalid and cannot be edited safely. Use `/role-menu delete` to clean it up.",
+                cancellationToken);
+            return;
+        }
+
+        var createStatus = RoleMenus.CreateEditDraft(
+            settings.Id,
+            parsed.GuildId,
+            Context.User.Id,
+            settings.Title,
+            settings.Description,
+            parsed.RoleIds,
+            settings.SelectionMode,
+            out var draft);
+        if (createStatus != RoleMenuEditDraftCreateStatus.Created || draft is null)
+        {
+            await ReplaceResponseAsync(
+                createStatus == RoleMenuEditDraftCreateStatus.AlreadySubmitting
+                    ? "Your previous role-menu edit is still being submitted. Wait for it to finish."
+                    : "Bean Bot is already holding the maximum number of role-menu edit previews. Try again after another preview expires.",
+                cancellationToken);
+            return;
+        }
+
+        await ReplaceResponseAsync(
+            "Review the current values below. Select **Edit values** to open a pre-filled form; the saved menu is revalidated again when you submit it.",
+            cancellationToken,
+            RoleMenuComponents.BuildEditSummaryEmbed(draft),
+            RoleMenuComponents.BuildEditOpenComponents(draft.Id));
+    }
+
+    private static bool IsValidPrivateComponent(
+        SocketMessageComponent component,
+        SocketGuild guild,
+        ComponentType expectedType,
+        string expectedCustomId,
+        string? selectedValue = null)
+    {
+        if (!IsEphemeral(component)
+            || component.Message.Author.Id != guild.CurrentUser.Id
+            || component.Data.Type != expectedType
+            || !string.Equals(
+                component.Data.CustomId,
+                expectedCustomId,
+                StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var sourceComponent = component.Message.Components
+            .OfType<ActionRowComponent>()
+            .SelectMany(row => row.Components)
+            .OfType<IInteractableComponent>()
+            .FirstOrDefault(candidate => candidate.Type == expectedType
+                                         && string.Equals(
+                                             candidate.CustomId,
+                                             expectedCustomId,
+                                             StringComparison.Ordinal));
+        return sourceComponent is not null
+               && (selectedValue is null
+                   || sourceComponent is SelectMenuComponent selector
+                   && selector.Options.Any(option => string.Equals(
+                       option.Value,
+                       selectedValue,
+                       StringComparison.Ordinal)));
+    }
+}

--- a/BeanBot/Discord/RoleMenus/RoleMenuEditDraftRegistry.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuEditDraftRegistry.cs
@@ -1,0 +1,251 @@
+using BeanBot.Persistence.Models;
+using MongoDB.Bson;
+
+namespace BeanBot.Discord.RoleMenus;
+
+internal enum RoleMenuEditDraftCreateStatus
+{
+    Created,
+    CapacityReached,
+    AlreadySubmitting
+}
+
+internal enum RoleMenuEditDraftAccessStatus
+{
+    Acquired,
+    NotFound,
+    WrongOwner,
+    AlreadySubmitting
+}
+
+internal sealed record RoleMenuEditDraft(
+    Guid Id,
+    ObjectId MenuId,
+    ulong GuildId,
+    ulong UserId,
+    string Title,
+    string Description,
+    IReadOnlyList<ulong> RoleIds,
+    RoleMenuSelectionMode SelectionMode,
+    DateTimeOffset ExpiresAtUtc);
+
+internal sealed class RoleMenuEditDraftRegistry
+{
+    private sealed class DraftEntry
+    {
+        public required RoleMenuEditDraft Draft { get; set; }
+        public bool IsSubmitting { get; set; }
+    }
+
+    private readonly object _syncRoot = new();
+    private readonly Dictionary<Guid, DraftEntry> _drafts = [];
+    private readonly Dictionary<(ulong GuildId, ulong UserId), Guid> _draftByOwner = [];
+    private readonly TimeProvider _timeProvider;
+    private readonly int _capacity;
+    private readonly TimeSpan _lifetime;
+
+    public RoleMenuEditDraftRegistry()
+        : this(
+            TimeProvider.System,
+            RoleMenuConstants.MaximumDrafts,
+            RoleMenuConstants.DraftLifetime)
+    {
+    }
+
+    internal RoleMenuEditDraftRegistry(
+        TimeProvider timeProvider,
+        int capacity,
+        TimeSpan lifetime)
+    {
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        ArgumentOutOfRangeException.ThrowIfLessThan(capacity, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(lifetime, TimeSpan.Zero);
+        _capacity = capacity;
+        _lifetime = lifetime;
+    }
+
+    internal RoleMenuEditDraftCreateStatus Create(
+        ObjectId menuId,
+        ulong guildId,
+        ulong userId,
+        string title,
+        string description,
+        IReadOnlyCollection<ulong> roleIds,
+        RoleMenuSelectionMode selectionMode,
+        out RoleMenuEditDraft? draft)
+    {
+        if (menuId == ObjectId.Empty)
+        {
+            throw new ArgumentException("A role menu ID is required.", nameof(menuId));
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(title);
+        ArgumentNullException.ThrowIfNull(description);
+        ArgumentNullException.ThrowIfNull(roleIds);
+
+        lock (_syncRoot)
+        {
+            PurgeExpiredUnsafe();
+            var owner = (guildId, userId);
+            if (_draftByOwner.TryGetValue(owner, out var existingId)
+                && _drafts.TryGetValue(existingId, out var existingEntry)
+                && existingEntry.IsSubmitting)
+            {
+                draft = null;
+                return RoleMenuEditDraftCreateStatus.AlreadySubmitting;
+            }
+
+            if (_draftByOwner.Remove(owner, out existingId))
+            {
+                _drafts.Remove(existingId);
+            }
+
+            if (_drafts.Count >= _capacity)
+            {
+                draft = null;
+                return RoleMenuEditDraftCreateStatus.CapacityReached;
+            }
+
+            var now = _timeProvider.GetUtcNow();
+            draft = new RoleMenuEditDraft(
+                Guid.NewGuid(),
+                menuId,
+                guildId,
+                userId,
+                title,
+                description,
+                [.. roleIds],
+                selectionMode,
+                now.Add(_lifetime));
+            _drafts[draft.Id] = new DraftEntry { Draft = draft };
+            _draftByOwner[owner] = draft.Id;
+            return RoleMenuEditDraftCreateStatus.Created;
+        }
+    }
+
+    internal RoleMenuEditDraftAccessStatus TryGet(
+        Guid draftId,
+        ulong guildId,
+        ulong userId,
+        out RoleMenuEditDraft? draft)
+    {
+        lock (_syncRoot)
+        {
+            PurgeExpiredUnsafe();
+            if (!_drafts.TryGetValue(draftId, out var entry))
+            {
+                draft = null;
+                return RoleMenuEditDraftAccessStatus.NotFound;
+            }
+
+            if (entry.Draft.GuildId != guildId || entry.Draft.UserId != userId)
+            {
+                draft = null;
+                return RoleMenuEditDraftAccessStatus.WrongOwner;
+            }
+
+            if (entry.IsSubmitting)
+            {
+                draft = null;
+                return RoleMenuEditDraftAccessStatus.AlreadySubmitting;
+            }
+
+            entry.Draft = entry.Draft with
+            {
+                ExpiresAtUtc = _timeProvider.GetUtcNow().Add(_lifetime)
+            };
+            draft = entry.Draft;
+            return RoleMenuEditDraftAccessStatus.Acquired;
+        }
+    }
+
+    internal RoleMenuEditDraftAccessStatus TryBeginSubmit(
+        Guid draftId,
+        ulong guildId,
+        ulong userId,
+        out RoleMenuEditDraft? draft)
+    {
+        lock (_syncRoot)
+        {
+            PurgeExpiredUnsafe();
+            if (!_drafts.TryGetValue(draftId, out var entry))
+            {
+                draft = null;
+                return RoleMenuEditDraftAccessStatus.NotFound;
+            }
+
+            if (entry.Draft.GuildId != guildId || entry.Draft.UserId != userId)
+            {
+                draft = null;
+                return RoleMenuEditDraftAccessStatus.WrongOwner;
+            }
+
+            if (entry.IsSubmitting)
+            {
+                draft = null;
+                return RoleMenuEditDraftAccessStatus.AlreadySubmitting;
+            }
+
+            entry.IsSubmitting = true;
+            entry.Draft = entry.Draft with
+            {
+                ExpiresAtUtc = _timeProvider.GetUtcNow().Add(_lifetime)
+            };
+            draft = entry.Draft;
+            return RoleMenuEditDraftAccessStatus.Acquired;
+        }
+    }
+
+    internal void Release(Guid draftId, ulong guildId, ulong userId)
+    {
+        lock (_syncRoot)
+        {
+            if (_drafts.TryGetValue(draftId, out var entry)
+                && entry.Draft.GuildId == guildId
+                && entry.Draft.UserId == userId)
+            {
+                entry.IsSubmitting = false;
+                entry.Draft = entry.Draft with
+                {
+                    ExpiresAtUtc = _timeProvider.GetUtcNow().Add(_lifetime)
+                };
+            }
+        }
+    }
+
+    internal void Complete(Guid draftId, ulong guildId, ulong userId)
+    {
+        lock (_syncRoot)
+        {
+            if (_drafts.TryGetValue(draftId, out var entry)
+                && entry.Draft.GuildId == guildId
+                && entry.Draft.UserId == userId)
+            {
+                RemoveUnsafe(entry.Draft);
+            }
+        }
+    }
+
+    private void PurgeExpiredUnsafe()
+    {
+        var now = _timeProvider.GetUtcNow();
+        foreach (var entry in _drafts.Values
+                     .Where(candidate => !candidate.IsSubmitting
+                                         && candidate.Draft.ExpiresAtUtc <= now)
+                     .ToList())
+        {
+            RemoveUnsafe(entry.Draft);
+        }
+    }
+
+    private void RemoveUnsafe(RoleMenuEditDraft draft)
+    {
+        _drafts.Remove(draft.Id);
+        var owner = (draft.GuildId, draft.UserId);
+        if (_draftByOwner.TryGetValue(owner, out var ownerDraftId)
+            && ownerDraftId == draft.Id)
+        {
+            _draftByOwner.Remove(owner);
+        }
+    }
+}

--- a/BeanBot/Discord/RoleMenus/RoleMenuEditModal.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuEditModal.cs
@@ -1,0 +1,49 @@
+using Discord;
+using Discord.Interactions;
+
+namespace BeanBot.Discord.RoleMenus;
+
+public sealed class RoleMenuEditModal : IModal
+{
+    public string Title => "Edit role menu";
+
+    [InputLabel("Panel title")]
+    [ModalTextInput(
+        "title",
+        TextInputStyle.Short,
+        "Game Roles",
+        1,
+        RoleMenuConstants.MaximumTitleLength)]
+    public string PanelTitle { get; set; } = string.Empty;
+
+    [InputLabel("Description", "Optional text shown below the title")]
+    [RequiredInput(false)]
+    [ModalTextInput(
+        "description",
+        TextInputStyle.Paragraph,
+        "Choose the games you play. You can update this at any time.",
+        0,
+        RoleMenuConstants.MaximumDescriptionLength)]
+    public string Description { get; set; } = string.Empty;
+
+    [InputLabel("Self-assignable roles", "Choose 1–25 existing roles")]
+    [ModalRoleSelect(
+        "roles",
+        1,
+        RoleMenuConstants.MaximumRoles,
+        Placeholder = "Choose roles")]
+    public IRole[] Roles { get; set; } = [];
+
+    [InputLabel("Selection mode")]
+    [ModalRadioGroup("selection-mode")]
+    [ModalRadioGroupOption(
+        "Multiple",
+        "multiple",
+        "Members may choose any combination.",
+        true)]
+    [ModalRadioGroupOption(
+        "Single",
+        "single",
+        "Choosing one role replaces another from this menu.")]
+    public string SelectionMode { get; set; } = "multiple";
+}

--- a/BeanBot/Discord/RoleMenus/RoleMenuEditWorkflow.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuEditWorkflow.cs
@@ -1,0 +1,98 @@
+using BeanBot.Persistence.Models;
+
+namespace BeanBot.Discord.RoleMenus;
+
+internal enum RoleMenuPanelUpdateStatus
+{
+    Updated,
+    Missing,
+    UnexpectedMessage
+}
+
+internal enum RoleMenuEditCommitStatus
+{
+    Updated,
+    PersistenceOutcomeUnknown,
+    PanelMissing,
+    PanelUnexpected,
+    PanelOutcomeUnknown
+}
+
+internal enum RoleMenuEditFailurePhase
+{
+    Persistence,
+    PanelUpdate
+}
+
+internal sealed record RoleMenuEditFailure(
+    RoleMenuEditFailurePhase Phase,
+    Exception Exception);
+
+internal sealed record RoleMenuEditCommitResult(
+    RoleMenuEditCommitStatus Status,
+    IReadOnlyList<RoleMenuEditFailure>? FailureList = null)
+{
+    internal IReadOnlyList<RoleMenuEditFailure> Failures { get; } = FailureList ?? [];
+}
+
+internal sealed record RoleMenuEditCommitOperations(
+    Func<RoleMenuSettings, CancellationToken, Task> PersistSettings,
+    Func<RoleMenuSettings, CancellationToken, Task<RoleMenuPanelUpdateStatus>> UpdatePanel,
+    Func<bool> IsShuttingDown);
+
+internal static class RoleMenuEditWorkflow
+{
+    internal static async Task<RoleMenuEditCommitResult> ExecuteAsync(
+        RoleMenuSettings replacement,
+        RoleMenuEditCommitOperations operations,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(replacement);
+        ArgumentNullException.ThrowIfNull(operations);
+        ArgumentNullException.ThrowIfNull(operations.PersistSettings);
+        ArgumentNullException.ThrowIfNull(operations.UpdatePanel);
+        ArgumentNullException.ThrowIfNull(operations.IsShuttingDown);
+
+        try
+        {
+            await operations.PersistSettings(replacement, cancellationToken);
+        }
+        catch (OperationCanceledException) when (operations.IsShuttingDown())
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            // The repository write may have reached MongoDB before an error became visible.
+            // Presentation therefore remains untouched and the administrator must re-run
+            // the edit to reconcile from persisted truth rather than guessing or rolling back.
+            return new RoleMenuEditCommitResult(
+                RoleMenuEditCommitStatus.PersistenceOutcomeUnknown,
+                [new RoleMenuEditFailure(RoleMenuEditFailurePhase.Persistence, exception)]);
+        }
+
+        try
+        {
+            var panelStatus = await operations.UpdatePanel(replacement, cancellationToken);
+            return new RoleMenuEditCommitResult(panelStatus switch
+            {
+                RoleMenuPanelUpdateStatus.Updated => RoleMenuEditCommitStatus.Updated,
+                RoleMenuPanelUpdateStatus.Missing => RoleMenuEditCommitStatus.PanelMissing,
+                RoleMenuPanelUpdateStatus.UnexpectedMessage => RoleMenuEditCommitStatus.PanelUnexpected,
+                _ => throw new InvalidOperationException("Unknown role-menu panel update status.")
+            });
+        }
+        catch (OperationCanceledException) when (operations.IsShuttingDown())
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            // Persisted settings are authoritative. Do not retry the Discord mutation here:
+            // the first request may have succeeded even though its result was not observed.
+            return new RoleMenuEditCommitResult(
+                RoleMenuEditCommitStatus.PanelOutcomeUnknown,
+                [new RoleMenuEditFailure(RoleMenuEditFailurePhase.PanelUpdate, exception)]);
+        }
+    }
+}

--- a/BeanBot/Discord/RoleMenus/RoleMenuInteractionService.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuInteractionService.cs
@@ -10,20 +10,17 @@ public sealed class RoleMenuInteractionService
 {
     private readonly RoleMenuRepository _repository;
     private readonly RoleMenuDraftRegistry _draftRegistry;
-    private readonly RoleMenuEditDraftRegistry _editDraftRegistry;
     private readonly RoleMenuMutationCoordinator _mutationCoordinator;
     private readonly InteractionExecutionContext _executionContext;
 
     internal RoleMenuInteractionService(
         RoleMenuRepository repository,
         RoleMenuDraftRegistry draftRegistry,
-        RoleMenuEditDraftRegistry editDraftRegistry,
         RoleMenuMutationCoordinator mutationCoordinator,
         InteractionExecutionContext executionContext)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
         _draftRegistry = draftRegistry ?? throw new ArgumentNullException(nameof(draftRegistry));
-        _editDraftRegistry = editDraftRegistry ?? throw new ArgumentNullException(nameof(editDraftRegistry));
         _mutationCoordinator = mutationCoordinator ?? throw new ArgumentNullException(nameof(mutationCoordinator));
         _executionContext = executionContext ?? throw new ArgumentNullException(nameof(executionContext));
     }
@@ -114,7 +111,7 @@ public sealed class RoleMenuInteractionService
         IReadOnlyCollection<ulong> roleIds,
         RoleMenuSelectionMode selectionMode,
         out RoleMenuEditDraft? draft)
-        => _editDraftRegistry.Create(
+        => _draftRegistry.CreateEdit(
             menuId,
             guildId,
             userId,
@@ -129,20 +126,20 @@ public sealed class RoleMenuInteractionService
         ulong guildId,
         ulong userId,
         out RoleMenuEditDraft? draft)
-        => _editDraftRegistry.TryGet(draftId, guildId, userId, out draft);
+        => _draftRegistry.TryGetEdit(draftId, guildId, userId, out draft);
 
     internal RoleMenuEditDraftAccessStatus TryBeginEdit(
         Guid draftId,
         ulong guildId,
         ulong userId,
         out RoleMenuEditDraft? draft)
-        => _editDraftRegistry.TryBeginSubmit(draftId, guildId, userId, out draft);
+        => _draftRegistry.TryBeginEdit(draftId, guildId, userId, out draft);
 
     internal void ReleaseEdit(Guid draftId, ulong guildId, ulong userId)
-        => _editDraftRegistry.Release(draftId, guildId, userId);
+        => _draftRegistry.ReleaseEdit(draftId, guildId, userId);
 
     internal void CompleteEdit(Guid draftId, ulong guildId, ulong userId)
-        => _editDraftRegistry.Complete(draftId, guildId, userId);
+        => _draftRegistry.CompleteEdit(draftId, guildId, userId);
 
     internal Task UpsertAsync(
         RoleMenuSettings settings,

--- a/BeanBot/Discord/RoleMenus/RoleMenuInteractionService.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuInteractionService.cs
@@ -10,17 +10,20 @@ public sealed class RoleMenuInteractionService
 {
     private readonly RoleMenuRepository _repository;
     private readonly RoleMenuDraftRegistry _draftRegistry;
+    private readonly RoleMenuEditDraftRegistry _editDraftRegistry;
     private readonly RoleMenuMutationCoordinator _mutationCoordinator;
     private readonly InteractionExecutionContext _executionContext;
 
     internal RoleMenuInteractionService(
         RoleMenuRepository repository,
         RoleMenuDraftRegistry draftRegistry,
+        RoleMenuEditDraftRegistry editDraftRegistry,
         RoleMenuMutationCoordinator mutationCoordinator,
         InteractionExecutionContext executionContext)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
         _draftRegistry = draftRegistry ?? throw new ArgumentNullException(nameof(draftRegistry));
+        _editDraftRegistry = editDraftRegistry ?? throw new ArgumentNullException(nameof(editDraftRegistry));
         _mutationCoordinator = mutationCoordinator ?? throw new ArgumentNullException(nameof(mutationCoordinator));
         _executionContext = executionContext ?? throw new ArgumentNullException(nameof(executionContext));
     }
@@ -101,6 +104,45 @@ public sealed class RoleMenuInteractionService
 
     internal void CompletePublish(Guid draftId, ulong guildId, ulong userId)
         => _draftRegistry.CompletePublish(draftId, guildId, userId);
+
+    internal RoleMenuEditDraftCreateStatus CreateEditDraft(
+        ObjectId menuId,
+        ulong guildId,
+        ulong userId,
+        string title,
+        string description,
+        IReadOnlyCollection<ulong> roleIds,
+        RoleMenuSelectionMode selectionMode,
+        out RoleMenuEditDraft? draft)
+        => _editDraftRegistry.Create(
+            menuId,
+            guildId,
+            userId,
+            title,
+            description,
+            roleIds,
+            selectionMode,
+            out draft);
+
+    internal RoleMenuEditDraftAccessStatus TryGetEditDraft(
+        Guid draftId,
+        ulong guildId,
+        ulong userId,
+        out RoleMenuEditDraft? draft)
+        => _editDraftRegistry.TryGet(draftId, guildId, userId, out draft);
+
+    internal RoleMenuEditDraftAccessStatus TryBeginEdit(
+        Guid draftId,
+        ulong guildId,
+        ulong userId,
+        out RoleMenuEditDraft? draft)
+        => _editDraftRegistry.TryBeginSubmit(draftId, guildId, userId, out draft);
+
+    internal void ReleaseEdit(Guid draftId, ulong guildId, ulong userId)
+        => _editDraftRegistry.Release(draftId, guildId, userId);
+
+    internal void CompleteEdit(Guid draftId, ulong guildId, ulong userId)
+        => _editDraftRegistry.Complete(draftId, guildId, userId);
 
     internal Task UpsertAsync(
         RoleMenuSettings settings,

--- a/BeanBot/Discord/RoleMenus/RoleMenuSetupValidation.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuSetupValidation.cs
@@ -31,8 +31,6 @@ internal static class RoleMenuSetupValidation
         selectionMode = default;
         roleValidation = null;
         if (!TryValidateEditableFields(
-                request.Title,
-                request.Description,
                 request.SelectionMode,
                 request.RoleIds,
                 administrator,
@@ -68,8 +66,6 @@ internal static class RoleMenuSetupValidation
         [NotNullWhen(true)] out RoleMenuRoleValidationResult? roleValidation,
         out string validationMessage)
         => TryValidateEditableFields(
-            request.Title,
-            request.Description,
             request.SelectionMode,
             request.RoleIds,
             administrator,
@@ -81,9 +77,7 @@ internal static class RoleMenuSetupValidation
             out validationMessage);
 
     private static bool TryValidateEditableFields(
-        string rawTitle,
-        string? rawDescription,
-        string rawSelectionMode,
+        string? rawSelectionMode,
         IReadOnlyCollection<ulong>? roleIds,
         IGuildUser administrator,
         IGuildUser bot,
@@ -93,8 +87,6 @@ internal static class RoleMenuSetupValidation
         [NotNullWhen(true)] out RoleMenuRoleValidationResult? roleValidation,
         out string validationMessage)
     {
-        ArgumentNullException.ThrowIfNull(rawTitle);
-        ArgumentNullException.ThrowIfNull(rawSelectionMode);
         selectionMode = default;
         roleValidation = null;
         if (string.IsNullOrWhiteSpace(title)
@@ -137,7 +129,7 @@ internal static class RoleMenuSetupValidation
     }
 
     internal static bool TryParseSelectionMode(
-        string value,
+        string? value,
         out RoleMenuSelectionMode selectionMode)
     {
         if (string.Equals(value, "multiple", StringComparison.Ordinal))

--- a/BeanBot/Discord/RoleMenus/RoleMenuSetupValidation.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuSetupValidation.cs
@@ -30,6 +30,73 @@ internal static class RoleMenuSetupValidation
         targetChannelId = 0;
         selectionMode = default;
         roleValidation = null;
+        if (!TryValidateEditableFields(
+                request.Title,
+                request.Description,
+                request.SelectionMode,
+                request.RoleIds,
+                administrator,
+                bot,
+                title,
+                description,
+                out selectionMode,
+                out roleValidation,
+                out validationMessage))
+        {
+            return false;
+        }
+
+        if (request.TargetChannelId is null
+            || request.TargetChannelGuildId != guildId
+            || request.TargetChannelType != ChannelType.Text)
+        {
+            validationMessage = "Choose a normal text channel from this server.";
+            return false;
+        }
+
+        targetChannelId = request.TargetChannelId.Value;
+        return true;
+    }
+
+    internal static bool TryParseAndValidateEdit(
+        RoleMenuEditRequest request,
+        IGuildUser administrator,
+        IGuildUser bot,
+        string title,
+        string description,
+        out RoleMenuSelectionMode selectionMode,
+        [NotNullWhen(true)] out RoleMenuRoleValidationResult? roleValidation,
+        out string validationMessage)
+        => TryValidateEditableFields(
+            request.Title,
+            request.Description,
+            request.SelectionMode,
+            request.RoleIds,
+            administrator,
+            bot,
+            title,
+            description,
+            out selectionMode,
+            out roleValidation,
+            out validationMessage);
+
+    private static bool TryValidateEditableFields(
+        string rawTitle,
+        string? rawDescription,
+        string rawSelectionMode,
+        IReadOnlyCollection<ulong>? roleIds,
+        IGuildUser administrator,
+        IGuildUser bot,
+        string title,
+        string description,
+        out RoleMenuSelectionMode selectionMode,
+        [NotNullWhen(true)] out RoleMenuRoleValidationResult? roleValidation,
+        out string validationMessage)
+    {
+        ArgumentNullException.ThrowIfNull(rawTitle);
+        ArgumentNullException.ThrowIfNull(rawSelectionMode);
+        selectionMode = default;
+        roleValidation = null;
         if (string.IsNullOrWhiteSpace(title)
             || title.Length > RoleMenuConstants.MaximumTitleLength)
         {
@@ -45,32 +112,20 @@ internal static class RoleMenuSetupValidation
             return false;
         }
 
-        if (!TryParseSelectionMode(request.SelectionMode, out selectionMode))
+        if (!TryParseSelectionMode(rawSelectionMode, out selectionMode))
         {
             validationMessage = "Choose either single-selection or multiple-selection mode.";
             return false;
         }
 
-        if (request.TargetChannelId is null
-            || request.TargetChannelGuildId != guildId
-            || request.TargetChannelType != ChannelType.Text)
-        {
-            validationMessage = "Choose a normal text channel from this server.";
-            return false;
-        }
-
-        targetChannelId = request.TargetChannelId.Value;
-        if (request.RoleIds is not { Count: >= 1 and <= RoleMenuConstants.MaximumRoles })
+        if (roleIds is not { Count: >= 1 and <= RoleMenuConstants.MaximumRoles })
         {
             validationMessage =
                 $"Choose between 1 and {RoleMenuConstants.MaximumRoles} roles.";
             return false;
         }
 
-        roleValidation = ValidateRoles(
-            request.RoleIds,
-            administrator,
-            bot);
+        roleValidation = ValidateRoles(roleIds, administrator, bot);
         if (!roleValidation.IsValid)
         {
             validationMessage = FormatRoleValidationFailure(roleValidation);

--- a/BeanBot/Logging/BeanBotRoleMenuEditLog.cs
+++ b/BeanBot/Logging/BeanBotRoleMenuEditLog.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.Logging;
+
+namespace BeanBot.Logging;
+
+internal static partial class BeanBotLog
+{
+    [LoggerMessage(
+        Level = LogLevel.Error,
+        Message = "Role-menu edit persistence outcome was not confirmed for menu {MenuId}")]
+    internal static partial void RoleMenuEditPersistenceFailed(
+        ILogger logger,
+        string menuId,
+        Exception exception);
+
+    [LoggerMessage(
+        Level = LogLevel.Error,
+        Message = "Role-menu edit panel update outcome was not confirmed for menu {MenuId}")]
+    internal static partial void RoleMenuEditPanelUpdateFailed(
+        ILogger logger,
+        string menuId,
+        Exception exception);
+}

--- a/BeanBot/Logging/BeanBotRoleMenuEditLog.cs
+++ b/BeanBot/Logging/BeanBotRoleMenuEditLog.cs
@@ -19,4 +19,12 @@ internal static partial class BeanBotLog
         ILogger logger,
         string menuId,
         Exception exception);
+
+    [LoggerMessage(
+        Level = LogLevel.Error,
+        Message = "Role-menu edit operation failed unexpectedly for menu {MenuId}")]
+    internal static partial void RoleMenuEditOperationFailed(
+        ILogger logger,
+        string menuId,
+        Exception exception);
 }

--- a/docs/role-menus.md
+++ b/docs/role-menus.md
@@ -91,7 +91,7 @@ Use a test server with BeanBot's role below one test role and above two other te
 
 ## Code organization
 
-`RoleMenuAdminModule`, `RoleMenuEditAdminModule`, and `RoleMenuMemberModule` validate Discord control bindings and acknowledge interactions before starting work. Their shared `RoleMenuModuleBase` handles private responses, mention suppression, and acknowledgement reconciliation.
+`RoleMenuAdminModule` owns the create, edit, and delete administrator interactions; its edit handlers are split into a partial-class source file to keep the feature readable without registering a second top-level Discord command module. `RoleMenuMemberModule` handles member-facing controls. Their shared `RoleMenuModuleBase` handles private responses, mention suppression, and acknowledgement reconciliation.
 
 `RoleMenuAdministrationService` prepares drafts and connects publication, editing, and deletion to persistence. `RoleMenuMemberService` loads selectors and applies member choices through the mutation coordinator. These services take IDs and submitted values, without an interaction context. Each member operation keeps its own Discord member reference, so concurrent requests cannot share a mutation target.
 

--- a/docs/role-menus.md
+++ b/docs/role-menus.md
@@ -4,7 +4,7 @@ BeanBot can publish persistent Discord panels that let members add or remove an 
 
 ## Requirements
 
-The administrator running `/role-menu create` or `/role-menu delete` must:
+The administrator running `/role-menu create`, `/role-menu edit`, or `/role-menu delete` must:
 
 - run the command in a server, not a direct message;
 - have the server-level **Manage Roles** permission; and
@@ -16,7 +16,7 @@ BeanBot must have:
 - a highest role above every role configured in the menu; and
 - **View Channel**, **Send Messages**, **Embed Links**, and **Read Message History** in the target channel.
 
-Discord does not allow BeanBot to assign `@everyone`, integration-managed roles, or roles at or above BeanBot's highest role. BeanBot validates these rules during setup, immediately before publication, when a member opens a panel, and immediately before applying a selection.
+Discord does not allow BeanBot to assign `@everyone`, integration-managed roles, or roles at or above BeanBot's highest role. BeanBot validates these rules during setup, immediately before publication or an edit, when a member opens a panel, and immediately before applying a selection.
 
 ## Create and publish a panel
 
@@ -29,6 +29,30 @@ The preview expires after 10 minutes. BeanBot holds at most 64 previews at once 
 
 Each public panel contains a stable **Manage Roles** button and its menu ID in the embed footer. Saved settings include the server, channel, message, title, description, allowlisted role IDs, selection mode, and UTC timestamps, so published panels continue to work after BeanBot restarts.
 
+## Edit a published panel
+
+Run `/role-menu edit` to choose from the 25 newest saved menus. For an older menu, copy the stable ID from its panel footer and run `/role-menu edit menu-id:<id>`.
+
+BeanBot first shows the menu's current title, description, roles, and selection mode privately. Select **Edit values** to open a pre-filled form, then change any of these fields:
+
+- title;
+- optional description;
+- 1–25 self-assignable roles; and
+- multiple- or single-selection mode.
+
+Editing is intentionally in place. BeanBot keeps the same saved menu ID, server, channel, public message, and original creation timestamp. Moving a panel to another channel is not supported by edit; delete and recreate the panel when its location must change.
+
+When the form is submitted, BeanBot reloads the saved menu and rechecks the administrator permission, current role existence and hierarchy, BeanBot's role permissions, channel permissions, and the exact public message identity. The edit runs under the same exclusive per-menu write coordination used by publication and deletion, so it cannot race a member role mutation or another menu-level write. Member submissions also reload persisted settings before any role change, so a selector opened before an edit cannot grant a role that the edited menu no longer allows.
+
+Persisted settings are the authorization source of truth. BeanBot saves the replacement configuration before modifying the existing public message. This gives failures deterministic behavior:
+
+- if the persistence write cannot be confirmed, BeanBot leaves the public panel untouched and asks the administrator to inspect persisted state before retrying;
+- if persistence succeeds but the panel is definitely missing or no longer matches the expected BeanBot panel, the new configuration remains authoritative and the unrelated/missing message is not modified;
+- if the Discord message update has an ambiguous outcome, BeanBot does not retry, roll the saved configuration back, or publish a replacement panel; inspect the existing message and rerun the same edit to reconcile it in place;
+- rerunning the same edit is safe because it targets the same stable saved menu and same existing message rather than creating another panel.
+
+Edit previews are bounded and expire after 10 minutes. All persistence and Discord work remains under the role-menu interaction timeout and application-shutdown ownership.
+
 ## Member behavior
 
 Selecting **Manage Roles** opens a private selector bound to that member and panel. Current roles from that menu are preselected.
@@ -38,7 +62,7 @@ Selecting **Manage Roles** opens a private selector bound to that member and pan
 - **Clear menu roles** removes every currently assigned role from this menu.
 - Roles that are not configured in the menu are never added or removed.
 
-Submissions for the same member are serialized, including submissions from overlapping menus. Different members may update roles from the same menu concurrently. Publication and deletion take an exclusive menu lifecycle lock so they cannot race member changes or resurrect a deleted configuration. Before changing anything, BeanBot reloads the persisted configuration, confirms the original panel still exists and belongs to BeanBot, fetches current member roles, revalidates role hierarchy, and rejects malformed or non-allowlisted values. After every valid submission, including a no-op or interrupted mutation, BeanBot performs a separate bounded read of Discord's current member roles. It reports confirmed results from that observed state and explicitly asks the member to reopen the menu when the final state cannot be confirmed.
+Submissions for the same member are serialized, including submissions from overlapping menus. Different members may update roles from the same menu concurrently. Publication, editing, and deletion take an exclusive menu lifecycle lock so they cannot race member changes or resurrect stale configuration. Before changing anything, BeanBot reloads the persisted configuration, confirms the original panel still exists and belongs to BeanBot, fetches current member roles, revalidates role hierarchy, and rejects malformed or non-allowlisted values. After every valid submission, including a no-op or interrupted mutation, BeanBot performs a separate bounded read of Discord's current member roles. It reports confirmed results from that observed state and explicitly asks the member to reopen the menu when the final state cannot be confirmed.
 
 ## Delete a panel
 
@@ -50,24 +74,27 @@ Deletion requires a private confirmation. BeanBot deletes a matching BeanBot-own
 
 Use a test server with BeanBot's role below one test role and above two other test roles.
 
-1. Confirm `/role-menu create` is unavailable to a member without **Manage Roles** and cannot run in a direct message.
+1. Confirm `/role-menu create`, `/role-menu edit`, and `/role-menu delete` are unavailable to a member without **Manage Roles** and cannot run in a direct message.
 2. Confirm setup rejects `@everyone`, a managed role, the role above BeanBot, and a role at or above a non-owner administrator.
 3. Publish a two-role multiple menu and confirm the preview is private while the panel is public in the selected channel.
-4. Open the same panel as two different members and confirm each receives an independent private selector with only their own current menu roles preselected.
-5. As a member, add both menu roles, remove one, and clear the menu. Confirm an unrelated role remains assigned throughout.
-6. Publish a single menu, switch between its roles, and confirm no gap is introduced when the replacement can be added.
-7. Delete one configured role in Discord and confirm the stale panel fails privately without changing any remaining or unrelated role.
-8. Restart BeanBot and confirm the remaining panels still work from their persisted configuration.
-9. Delete a panel through `/role-menu delete`, then confirm its old controls cannot mutate roles.
-10. Temporarily remove BeanBot's hierarchy or permissions and confirm operations fail privately without exposing exception details or changing unrelated roles.
-11. Use an existing legacy reaction-role panel and confirm its reactions still add and remove roles exactly as before.
+4. Run `/role-menu edit` for that panel, confirm the current values are shown privately, then rename it, remove one role, add another, and switch selection mode. Confirm the public message ID and footer menu ID are unchanged.
+5. Open a member selector before an edit removes one role, submit that now-stale role after the edit, and confirm BeanBot refuses it without changing member roles.
+6. Temporarily prevent the existing panel from being updated after persistence and confirm BeanBot keeps the edited configuration, does not publish another panel, and reports that presentation needs reconciliation. Restore access and rerun the same edit to reconcile the existing message.
+7. Open the same panel as two different members and confirm each receives an independent private selector with only their own current menu roles preselected.
+8. As a member, add both menu roles, remove one, and clear the menu. Confirm an unrelated role remains assigned throughout.
+9. Publish a single menu, switch between its roles, and confirm no gap is introduced when the replacement can be added.
+10. Delete one configured role in Discord and confirm the stale panel fails privately without changing any remaining or unrelated role.
+11. Restart BeanBot and confirm the remaining panels still work from their persisted configuration.
+12. Delete a panel through `/role-menu delete`, then confirm its old controls cannot mutate roles.
+13. Temporarily remove BeanBot's hierarchy or permissions and confirm operations fail privately without exposing exception details or changing unrelated roles.
+14. Use an existing legacy reaction-role panel and confirm its reactions still add and remove roles exactly as before.
 
 ## Code organization
 
-`RoleMenuAdminModule` and `RoleMenuMemberModule` validate Discord control bindings and acknowledge interactions before starting work. Their shared `RoleMenuModuleBase` handles private responses, mention suppression, and acknowledgement reconciliation.
+`RoleMenuAdminModule`, `RoleMenuEditAdminModule`, and `RoleMenuMemberModule` validate Discord control bindings and acknowledge interactions before starting work. Their shared `RoleMenuModuleBase` handles private responses, mention suppression, and acknowledgement reconciliation.
 
-`RoleMenuAdministrationService` prepares drafts and connects publication and deletion to persistence. `RoleMenuMemberService` loads selectors and applies member choices through the mutation coordinator. These services take IDs and submitted values, without an interaction context. Each member operation keeps its own Discord member reference, so concurrent requests cannot share a mutation target.
+`RoleMenuAdministrationService` prepares drafts and connects publication, editing, and deletion to persistence. `RoleMenuMemberService` loads selectors and applies member choices through the mutation coordinator. These services take IDs and submitted values, without an interaction context. Each member operation keeps its own Discord member reference, so concurrent requests cannot share a mutation target.
 
-`DiscordRoleMenuClient` contains Discord REST reads and mutations. `RoleMenuSetupValidation` and `RoleMenuPresentation` keep validation and result text separate from transport. The publication, deletion, and member workflows retain their independently tested rules for ambiguous outcomes, rollback, final-state reconciliation, and cancellation. `RoleMenuInteractionService` supplies the shared bounded execution, draft, persistence, and lock operations used by those entry points.
+`DiscordRoleMenuClient` contains Discord REST reads and mutations. `RoleMenuSetupValidation` and `RoleMenuPresentation` keep validation and result text separate from transport. The publication, edit, deletion, and member workflows retain independently tested rules for ambiguous outcomes, rollback or no-rollback decisions, final-state reconciliation, and cancellation. `RoleMenuInteractionService` supplies the shared bounded execution, draft, persistence, and lock operations used by those entry points.
 
 Shutdown closes normal interaction, busy-response, and command-registration admission. If a Discord request ignores cancellation and outlives the drain timeout, its ownership remains visible to the application, which skips Discord stop/disposal until the request actually completes. A late `Ready` event cannot restart command registration after shutdown.


### PR DESCRIPTION
Closes #192

## Summary
- adds a guild-only, `Manage Roles`-gated `/role-menu edit [menu-id]` flow with an ephemeral bounded newest-menu selector and pre-filled edit modal
- supports editing title, optional description, configured role allowlist, and Multiple/Exclusive selection mode without moving or recreating the published panel
- preserves the stable menu ID, guild, channel, message ID, and original `CreatedAtUtc`
- re-loads persisted truth and revalidates the administrator, BeanBot permissions/hierarchy, roles, target channel, and expected BeanBot-owned panel immediately before commit
- runs commits through the existing per-menu write coordinator so edits serialize with delete/menu writes while member operations continue to re-read current persisted settings

## Reliability / failure semantics
- persistence remains the runtime authorization/configuration source of truth; the replacement settings are persisted before the existing Discord message is reconciled
- a persistence failure/unknown outcome leaves the public panel untouched
- a definite post-persistence panel failure keeps the new persisted configuration and reports stale presentation
- an ambiguous Discord modification is never retried automatically, rolled back blindly, or replaced with a second panel; rerunning the same edit safely targets the same stable message
- edit preview/session state is finite, owner-bound, expiring, and capacity-bounded
- Discord reads/modifications reuse existing cancellation/request ownership and interaction/shutdown bounds; no background worker, unbounded retry, queue, or detached work was added
- stale pre-edit member submissions still re-read persisted settings and cannot grant a role removed by the edit
- malformed/null interaction title or selection-mode values now fail through normal validation rather than escaping through an unexpected exception path

## Tests
Focused deterministic coverage includes:
- edit transaction ordering, persistence failure, definite panel failure, ambiguous panel outcome, idempotent rerun, and shutdown cancellation
- stale pre-edit member selection rejecting a removed role
- edit/delete serialization through the existing per-menu coordinator
- bounded/expiring/owner-bound edit drafts and duplicate-submission protection
- one grouped `role-menu` interaction module with create/edit/delete and synchronous mutating handlers
- malformed/null selection-mode parsing returning validation failure
- the existing role-menu validator, member workflow, create/delete/audit, persistence, interaction lifecycle, Docker/runtime, and repository suites remain green

## Review-found / CI-found fixes
- **Reviewer:** the first implementation used a second top-level `[Group("role-menu")]` module. Discord.Net registers top-level grouped modules independently, so that could create duplicate `role-menu` roots during global command registration. The edit handlers were folded into the existing `RoleMenuAdminModule` as a partial class and a regression test now asserts there is exactly one grouped role-menu module containing create/edit/delete.
- **Exact-head CI:** fixed an accessibility mismatch in the new workflow tests and corrected the test fixture to use the model's UTC `DateTime` type for `CreatedAtUtc`.
- **Fresh review:** malformed interaction payloads could throw while normalizing a null title/selection mode instead of returning a validation response. Title normalization and selection-mode parsing are now null-safe, with focused regression coverage.
- **Fresh review:** the documentation still named a separate `RoleMenuEditAdminModule` even after the duplicate-command-root fix. The code-organization section now accurately documents the single partial `RoleMenuAdminModule` registration model.

## Verification
Final source head: `84801a835009d4c55228ba3c2e7d346bb887478c`

- Repository Verification #412: **PASS** on the final exact PR head; the workflow checked out `84801a835009d4c55228ba3c2e7d346bb887478c` and `./scripts/verify.sh full` completed successfully
  - this gate covers locked restore, formatting/analyzers, redundant-using checks, Release build/tests with coverage baseline, committed/staged/unstaged diff checks, branch-integrity checks, vulnerable-package audit, Docker build, hardened-container smoke, and SIGTERM shutdown smoke
- CodeQL #247: **PASS** on the final head
- Dependency Review #205: **PASS** on the final head
- Fresh repository-owned Verifier after the review fixes: **PASS**
- Fresh independent Reviewer after Verifier PASS: **CLEAN**
- Open review threads: **0**
- branch remains based on current `develop` (`9a157b8008fb05405433bf6bb6ec2b3a0d88efc3`), 30 commits ahead / 0 behind

Local focused/fast/full execution is not claimed because this runtime cannot resolve `github.com`; repository-authorized exact-head GitHub Actions supplied the deterministic gates instead.

## Manual validation
In a Discord test guild, run both exact-ID and selector-based edits, change each editable field, and confirm the original message/stable footer remains in place and member behavior follows the new allowlist/mode. If practical, also remove the panel or required permission during an edit to confirm the documented safe failure/reconciliation messages.