### PR TITLE
Add preview-first legacy role-panel migration

### DIFF
--- a/BeanBot.Tests/Discord/RoleMenus/LegacyReactionRolePanelIdentityTests.cs
+++ b/BeanBot.Tests/Discord/RoleMenus/LegacyReactionRolePanelIdentityTests.cs
@@ -9,7 +9,7 @@ public class LegacyReactionRolePanelIdentityTests
     [Fact]
     public void TryRecognize_AcceptsExactBeanBotLegacyPanelAndSuggestsLabel()
     {
-        IReadOnlyCollection<IEmbed> embeds =
+        IReadOnlyCollection<Embed> embeds =
         [
             new EmbedBuilder()
                 .AddField("😀", "<@&10>", inline: true)
@@ -32,7 +32,7 @@ public class LegacyReactionRolePanelIdentityTests
     [Fact]
     public void TryRecognize_RejectsWrongAuthorOrPanelShape()
     {
-        IReadOnlyCollection<IEmbed> embeds =
+        IReadOnlyCollection<Embed> embeds =
         [
             new EmbedBuilder()
                 .AddField("😀", "<@&10>", inline: true)
@@ -57,7 +57,7 @@ public class LegacyReactionRolePanelIdentityTests
     [Fact]
     public void TryRecognize_RejectsNonLegacyFooterAndDuplicateExpectedRoles()
     {
-        IReadOnlyCollection<IEmbed> embeds =
+        IReadOnlyCollection<Embed> embeds =
         [
             new EmbedBuilder()
                 .AddField("😀", "<@&10>", inline: true)

--- a/BeanBot.Tests/Discord/RoleMenus/LegacyReactionRolePanelIdentityTests.cs
+++ b/BeanBot.Tests/Discord/RoleMenus/LegacyReactionRolePanelIdentityTests.cs
@@ -9,7 +9,7 @@ public class LegacyReactionRolePanelIdentityTests
     [Fact]
     public void TryRecognize_AcceptsExactBeanBotLegacyPanelAndSuggestsLabel()
     {
-        IReadOnlyCollection<Embed> embeds =
+        IReadOnlyCollection<IEmbed> embeds =
         [
             new EmbedBuilder()
                 .AddField("😀", "<@&10>", inline: true)
@@ -32,7 +32,7 @@ public class LegacyReactionRolePanelIdentityTests
     [Fact]
     public void TryRecognize_RejectsWrongAuthorOrPanelShape()
     {
-        IReadOnlyCollection<Embed> embeds =
+        IReadOnlyCollection<IEmbed> embeds =
         [
             new EmbedBuilder()
                 .AddField("😀", "<@&10>", inline: true)
@@ -57,7 +57,7 @@ public class LegacyReactionRolePanelIdentityTests
     [Fact]
     public void TryRecognize_RejectsNonLegacyFooterAndDuplicateExpectedRoles()
     {
-        IReadOnlyCollection<Embed> embeds =
+        IReadOnlyCollection<IEmbed> embeds =
         [
             new EmbedBuilder()
                 .AddField("😀", "<@&10>", inline: true)

--- a/BeanBot.Tests/Discord/RoleMenus/LegacyReactionRolePanelIdentityTests.cs
+++ b/BeanBot.Tests/Discord/RoleMenus/LegacyReactionRolePanelIdentityTests.cs
@@ -1,0 +1,84 @@
+using BeanBot.Discord.RoleMenus;
+using Discord;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.RoleMenus;
+
+public class LegacyReactionRolePanelIdentityTests
+{
+    [Fact]
+    public void TryRecognize_AcceptsExactBeanBotLegacyPanelAndSuggestsLabel()
+    {
+        IReadOnlyCollection<IEmbed> embeds =
+        [
+            new EmbedBuilder()
+                .AddField("😀", "<@&10>", inline: true)
+                .AddField("😎", "<@&20>", inline: true)
+                .WithFooter("Role Group: Games")
+                .Build()
+        ];
+
+        var recognized = LegacyReactionRolePanelIdentity.TryRecognize(
+            99UL,
+            99UL,
+            embeds,
+            [10UL, 20UL],
+            out var title);
+
+        Assert.True(recognized);
+        Assert.Equal("Games", title);
+    }
+
+    [Fact]
+    public void TryRecognize_RejectsWrongAuthorOrPanelShape()
+    {
+        IReadOnlyCollection<IEmbed> embeds =
+        [
+            new EmbedBuilder()
+                .AddField("😀", "<@&10>", inline: true)
+                .WithFooter("Role Group: Games")
+                .Build()
+        ];
+
+        Assert.False(LegacyReactionRolePanelIdentity.TryRecognize(
+            98UL,
+            99UL,
+            embeds,
+            [10UL],
+            out _));
+        Assert.False(LegacyReactionRolePanelIdentity.TryRecognize(
+            99UL,
+            99UL,
+            embeds,
+            [10UL, 20UL],
+            out _));
+    }
+
+    [Fact]
+    public void TryRecognize_RejectsNonLegacyFooterAndDuplicateExpectedRoles()
+    {
+        IReadOnlyCollection<IEmbed> embeds =
+        [
+            new EmbedBuilder()
+                .AddField("😀", "<@&10>", inline: true)
+                .WithFooter("Role menu: Games")
+                .Build()
+        ];
+
+        Assert.False(LegacyReactionRolePanelIdentity.TryRecognize(
+            99UL,
+            99UL,
+            embeds,
+            [10UL],
+            out _));
+        Assert.False(LegacyReactionRolePanelIdentity.TryRecognize(
+            99UL,
+            99UL,
+            [new EmbedBuilder()
+                .AddField("😀", "<@&10>", inline: true)
+                .WithFooter("Role Group: Games")
+                .Build()],
+            [10UL, 10UL],
+            out _));
+    }
+}

--- a/BeanBot.Tests/Discord/RoleMenus/RoleMenuDraftRegistryTests.cs
+++ b/BeanBot.Tests/Discord/RoleMenus/RoleMenuDraftRegistryTests.cs
@@ -1,5 +1,6 @@
 using BeanBot.Discord.RoleMenus;
 using BeanBot.Persistence.Models;
+using MongoDB.Bson;
 using Xunit;
 
 namespace BeanBot.Tests.Discord.RoleMenus;
@@ -43,6 +44,31 @@ public class RoleMenuDraftRegistryTests
 
         Assert.Equal(RoleMenuDraftCreateStatus.CapacityReached, status);
         Assert.Null(draft);
+    }
+
+    [Fact]
+    public void CreateMigration_PreservesDeterministicIdentityAndMultipleMode()
+    {
+        var registry = CreateRegistry();
+        var menuId = ObjectId.GenerateNewId();
+
+        var status = registry.CreateMigration(
+            1UL,
+            2UL,
+            3UL,
+            "Games",
+            "Migrated roles",
+            [4UL, 5UL],
+            menuId,
+            777UL,
+            out var created);
+
+        var draft = Assert.IsType<RoleMenuDraft>(created);
+        Assert.Equal(RoleMenuDraftCreateStatus.Created, status);
+        Assert.Equal(menuId, draft.MenuId);
+        Assert.Equal(777UL, draft.LegacyReactionRoleMessageId);
+        Assert.Equal(RoleMenuSelectionMode.Multiple, draft.SelectionMode);
+        Assert.Equal([4UL, 5UL], draft.RoleIds);
     }
 
     [Fact]

--- a/BeanBot.Tests/Discord/RoleMenus/RoleMenuInteractionMetadataTests.cs
+++ b/BeanBot.Tests/Discord/RoleMenus/RoleMenuInteractionMetadataTests.cs
@@ -29,6 +29,18 @@ public class RoleMenuInteractionMetadataTests
     }
 
     [Fact]
+    public void MigrationCommand_IsPartOfExistingAdminModule()
+    {
+        var method = typeof(RoleMenuAdminModule).GetMethod(nameof(RoleMenuAdminModule.MigrateAsync));
+
+        Assert.NotNull(method);
+        var slashCommand = method.GetCustomAttribute<SlashCommandAttribute>();
+        Assert.NotNull(slashCommand);
+        Assert.Equal("migrate", slashCommand.Name);
+        Assert.Equal(RunMode.Sync, slashCommand.RunMode);
+    }
+
+    [Fact]
     public void CreateModal_UsesNativeBoundedRoleAndTextChannelSelectors()
     {
         var roles = Assert.IsAssignableFrom<PropertyInfo>(
@@ -88,6 +100,7 @@ public class RoleMenuInteractionMetadataTests
         {
             typeof(RoleMenuAdminModule).GetMethod(nameof(RoleMenuAdminModule.HandleCreateModalAsync)),
             typeof(RoleMenuAdminModule).GetMethod(nameof(RoleMenuAdminModule.PublishAsync)),
+            typeof(RoleMenuAdminModule).GetMethod(nameof(RoleMenuAdminModule.ConfirmMigrationAsync)),
             typeof(RoleMenuAdminModule).GetMethod(nameof(RoleMenuAdminModule.ConfirmDeleteAsync)),
             typeof(RoleMenuMemberModule).GetMethod(nameof(RoleMenuMemberModule.SaveAsync)),
             typeof(RoleMenuMemberModule).GetMethod(nameof(RoleMenuMemberModule.ClearAsync))

--- a/BeanBot.Tests/Discord/RoleMenus/RoleMenuInteractionServiceTests.cs
+++ b/BeanBot.Tests/Discord/RoleMenus/RoleMenuInteractionServiceTests.cs
@@ -11,7 +11,7 @@ namespace BeanBot.Tests.Discord.RoleMenus;
 public class RoleMenuInteractionServiceTests
 {
     [Fact]
-    public void ModuleConstructors_RequireFacadeAndLogger()
+    public void ModuleConstructors_RequireFacadesAndLogger()
     {
         var fixture = CreateFixture();
         var discord = new DiscordRoleMenuClient(
@@ -20,6 +20,15 @@ public class RoleMenuInteractionServiceTests
 
         var administration = new RoleMenuAdministrationService(
             fixture.Service, discord, NullLogger<RoleMenuAdministrationService>.Instance);
+        var migration = new RoleMenuMigrationService(
+            new ReactionRoleRepository(
+                new EmptyReactionRoleStore(),
+                NullLogger<ReactionRoleRepository>.Instance),
+            fixture.Service,
+            discord,
+            new LegacyReactionRoleMigrationClient(
+                (_, _) => Task.FromResult<global::Discord.IChannel?>(null)),
+            administration);
         var members = new RoleMenuMemberService(
             fixture.Service, discord, NullLogger<RoleMenuMemberService>.Instance);
 
@@ -27,16 +36,25 @@ public class RoleMenuInteractionServiceTests
             null!,
             discord,
             administration,
+            migration,
             NullLogger<RoleMenuAdminModule>.Instance));
         Assert.Throws<ArgumentNullException>(() => new RoleMenuAdminModule(
             fixture.Service,
             discord,
             administration,
+            null!,
+            NullLogger<RoleMenuAdminModule>.Instance));
+        Assert.Throws<ArgumentNullException>(() => new RoleMenuAdminModule(
+            fixture.Service,
+            discord,
+            administration,
+            migration,
             null!));
         _ = new RoleMenuAdminModule(
             fixture.Service,
             discord,
             administration,
+            migration,
             NullLogger<RoleMenuAdminModule>.Instance);
 
         Assert.Throws<ArgumentNullException>(() => new RoleMenuMemberModule(
@@ -343,6 +361,34 @@ public class RoleMenuInteractionServiceTests
             }
 
             return Task.FromResult(deleted);
+        }
+    }
+
+    private sealed class EmptyReactionRoleStore : IReactionRoleSettingsStore
+    {
+        public Task InsertAsync(
+            ReactionRoleSettings roleSettings,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+
+        public Task<List<ReactionRoleSettings>> GetRecentAsync(
+            DateTime oldestLastAccessedUtc,
+            int limit,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(new List<ReactionRoleSettings>());
+        }
+
+        public Task<ReactionRoleSettings?> GetByMessageIdAsync(
+            string messageId,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult<ReactionRoleSettings?>(null);
         }
     }
 }

--- a/BeanBot.Tests/Discord/RoleMenus/RoleMenuMigrationIdentityTests.cs
+++ b/BeanBot.Tests/Discord/RoleMenus/RoleMenuMigrationIdentityTests.cs
@@ -1,0 +1,36 @@
+using BeanBot.Discord.RoleMenus;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.RoleMenus;
+
+public class RoleMenuMigrationIdentityTests
+{
+    [Fact]
+    public void CreateMenuId_IsDeterministicForLegacySource()
+    {
+        var first = RoleMenuMigrationIdentity.CreateMenuId(123UL, 456UL);
+        var second = RoleMenuMigrationIdentity.CreateMenuId(123UL, 456UL);
+
+        Assert.NotEqual(default, first);
+        Assert.Equal(first, second);
+        Assert.NotEqual(first, RoleMenuMigrationIdentity.CreateMenuId(124UL, 456UL));
+        Assert.NotEqual(first, RoleMenuMigrationIdentity.CreateMenuId(123UL, 457UL));
+    }
+
+    [Fact]
+    public void CreateMenuId_RejectsMissingSourceIdentity()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => RoleMenuMigrationIdentity.CreateMenuId(0UL, 456UL));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => RoleMenuMigrationIdentity.CreateMenuId(123UL, 0UL));
+    }
+
+    [Fact]
+    public void BuildMessageLink_UsesExactDiscordIdentity()
+    {
+        Assert.Equal(
+            "https://discord.com/channels/1/2/3",
+            RoleMenuMigrationIdentity.BuildMessageLink(1UL, 2UL, 3UL));
+    }
+}

--- a/BeanBot.Tests/Discord/RoleMenus/RoleMenuMigrationServiceTests.cs
+++ b/BeanBot.Tests/Discord/RoleMenus/RoleMenuMigrationServiceTests.cs
@@ -1,0 +1,536 @@
+using System.Reflection;
+using BeanBot.Discord.Interactions;
+using BeanBot.Discord.RoleMenus;
+using BeanBot.Persistence.Models;
+using BeanBot.Persistence.Repositories;
+using Discord;
+using Microsoft.Extensions.Logging.Abstractions;
+using MongoDB.Bson;
+using Xunit;
+
+namespace BeanBot.Tests.Discord.RoleMenus;
+
+public class RoleMenuMigrationServiceTests
+{
+    private const ulong GuildId = 1;
+    private const ulong ChannelId = 10;
+    private const ulong LegacyMessageId = 20;
+    private const ulong AdministratorId = 30;
+    private const ulong BotUserId = 40;
+
+    [Fact]
+    public async Task CreatePreviewAsync_MapsRecognizedLegacyPanelToMultipleRoleMenu()
+    {
+        var fixture = CreateFixture(CreateLegacySettings(GuildId, ChannelId, LegacyMessageId, 4, 5));
+
+        var result = await fixture.Service.CreatePreviewAsync(
+            new RoleMenuMigrationRequest(
+                LegacyMessageId,
+                TargetChannelId: null,
+                TargetChannelGuildId: null,
+                TargetChannelType: null,
+                Title: null,
+                Description: null),
+            GuildId,
+            AdministratorId,
+            BotUserId,
+            CancellationToken.None);
+
+        var draft = Assert.IsType<RoleMenuDraft>(result.Draft);
+        Assert.Equal(RoleMenuSelectionMode.Multiple, draft.SelectionMode);
+        Assert.Equal([4UL, 5UL], draft.RoleIds);
+        Assert.Equal("Games", draft.Title);
+        Assert.Equal(ChannelId, draft.TargetChannelId);
+        Assert.Equal(LegacyMessageId, draft.LegacyReactionRoleMessageId);
+        Assert.Equal(
+            RoleMenuMigrationIdentity.CreateMenuId(GuildId, LegacyMessageId),
+            draft.MenuId);
+        Assert.Contains($"/{GuildId}/{ChannelId}/{LegacyMessageId}", result.SourceMessageLink, StringComparison.Ordinal);
+        Assert.Equal(0, fixture.ReactionStore.InsertCalls);
+        Assert.Equal(0, fixture.RoleMenuStore.UpsertCalls);
+    }
+
+    [Fact]
+    public async Task CreatePreviewAsync_RejectsCrossGuildSourceBeforeDiscordOrPublication()
+    {
+        var fixture = CreateFixture(CreateLegacySettings(999, ChannelId, LegacyMessageId, 4));
+
+        var result = await fixture.Service.CreatePreviewAsync(
+            new RoleMenuMigrationRequest(
+                LegacyMessageId,
+                TargetChannelId: null,
+                TargetChannelGuildId: null,
+                TargetChannelType: null,
+                Title: null,
+                Description: null),
+            GuildId,
+            AdministratorId,
+            BotUserId,
+            CancellationToken.None);
+
+        Assert.Null(result.Draft);
+        Assert.Contains("different server", result.Content, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, fixture.DiscordUserReads);
+        Assert.Equal(0, fixture.DiscordChannelReads);
+        Assert.Equal(0, fixture.ReactionStore.InsertCalls);
+        Assert.Equal(0, fixture.RoleMenuStore.UpsertCalls);
+    }
+
+    [Fact]
+    public async Task ConfirmAsync_ReloadsLegacyStateAndStopsWhenRolesChangedAfterPreview()
+    {
+        var fixture = CreateFixture(CreateLegacySettings(GuildId, ChannelId, LegacyMessageId, 4, 5));
+        var preview = await fixture.Service.CreatePreviewAsync(
+            new RoleMenuMigrationRequest(
+                LegacyMessageId,
+                TargetChannelId: null,
+                TargetChannelGuildId: null,
+                TargetChannelType: null,
+                Title: null,
+                Description: null),
+            GuildId,
+            AdministratorId,
+            BotUserId,
+            CancellationToken.None);
+        var draft = Assert.IsType<RoleMenuDraft>(preview.Draft);
+        var readsAfterPreview = fixture.ReactionStore.GetCalls;
+
+        fixture.ReactionStore.Settings = CreateLegacySettings(
+            GuildId,
+            ChannelId,
+            LegacyMessageId,
+            4,
+            6);
+        fixture.SourceChannel.Message = CreateLegacyMessage(
+            LegacyMessageId,
+            BotUserId,
+            "Games",
+            4,
+            6);
+
+        var result = await fixture.Service.ConfirmAsync(
+            draft,
+            AdministratorId,
+            BotUserId,
+            CancellationToken.None);
+
+        Assert.False(result.Completed);
+        Assert.Contains("changed after this preview", result.Content, StringComparison.OrdinalIgnoreCase);
+        Assert.True(fixture.ReactionStore.GetCalls > readsAfterPreview);
+        Assert.Equal(0, fixture.ReactionStore.InsertCalls);
+        Assert.Equal(0, fixture.RoleMenuStore.UpsertCalls);
+    }
+
+    [Fact]
+    public async Task CreatePreviewAsync_WhenMigrationAlreadyPersisted_ReturnsExistingWithoutTouchingSource()
+    {
+        var fixture = CreateFixture(settings: null);
+        var menuId = RoleMenuMigrationIdentity.CreateMenuId(GuildId, LegacyMessageId);
+        var existing = new RoleMenuSettings(
+            menuId,
+            GuildId.ToString(),
+            ChannelId.ToString(),
+            "99",
+            "Games",
+            string.Empty,
+            ["4", "5"],
+            RoleMenuSelectionMode.Multiple,
+            LegacyMessageId.ToString());
+        fixture.RoleMenuStore.Settings = existing;
+
+        var result = await fixture.Service.CreatePreviewAsync(
+            new RoleMenuMigrationRequest(
+                LegacyMessageId,
+                TargetChannelId: null,
+                TargetChannelGuildId: null,
+                TargetChannelType: null,
+                Title: null,
+                Description: null),
+            GuildId,
+            AdministratorId,
+            BotUserId,
+            CancellationToken.None);
+
+        Assert.Same(existing, result.ExistingMenu);
+        Assert.Null(result.Draft);
+        Assert.Contains("already migrated", result.Content, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, fixture.ReactionStore.GetCalls);
+        Assert.Equal(0, fixture.ReactionStore.InsertCalls);
+        Assert.Equal(0, fixture.RoleMenuStore.UpsertCalls);
+    }
+
+    private static MigrationFixture CreateFixture(ReactionRoleSettings? settings)
+    {
+        var roles = new List<IRole>
+        {
+            CreateRole(1, "@everyone", 0),
+            CreateRole(4, "Alpha", 10),
+            CreateRole(5, "Beta", 20),
+            CreateRole(6, "Gamma", 30),
+            CreateRole(1000, "Bean Bot", 100),
+            CreateRole(1001, "Administrator", 90)
+        };
+        var guild = CreateGuild(GuildId, roles, roles[0]);
+        var bot = CreateGuildUser(BotUserId, guild, [1000]);
+        var administrator = CreateGuildUser(AdministratorId, guild, [1001]);
+        var sourceChannel = CreateTextChannel(
+            GuildId,
+            ChannelId,
+            CreateLegacyMessage(LegacyMessageId, BotUserId, "Games", 4, 5));
+
+        var reactionStore = new TrackingReactionRoleStore { Settings = settings };
+        var reactionRepository = new ReactionRoleRepository(
+            reactionStore,
+            NullLogger<ReactionRoleRepository>.Instance);
+        var roleMenuStore = new TrackingRoleMenuStore();
+        var roleMenuRepository = new RoleMenuRepository(
+            roleMenuStore,
+            NullLogger<RoleMenuRepository>.Instance);
+        var executionContext = new InteractionExecutionContext();
+        var roleMenus = new RoleMenuInteractionService(
+            roleMenuRepository,
+            new RoleMenuDraftRegistry(),
+            new RoleMenuMutationCoordinator(),
+            executionContext);
+
+        var discordUserReads = 0;
+        var discordChannelReads = 0;
+        var discord = new DiscordRoleMenuClient(
+            (guildId, userId, _) =>
+            {
+                discordUserReads++;
+                IGuildUser? user = guildId != GuildId
+                    ? null
+                    : userId switch
+                    {
+                        BotUserId => bot,
+                        AdministratorId => administrator,
+                        _ => null
+                    };
+                return Task.FromResult(user);
+            },
+            (channelId, _) =>
+            {
+                discordChannelReads++;
+                IChannel? channel = channelId == ChannelId ? sourceChannel.Channel : null;
+                return Task.FromResult(channel);
+            });
+        var administration = new RoleMenuAdministrationService(
+            roleMenus,
+            discord,
+            NullLogger<RoleMenuAdministrationService>.Instance);
+        var legacyDiscord = new LegacyReactionRoleMigrationClient(
+            (channelId, _) =>
+            {
+                IChannel? channel = channelId == ChannelId ? sourceChannel.Channel : null;
+                return Task.FromResult(channel);
+            });
+        var service = new RoleMenuMigrationService(
+            reactionRepository,
+            roleMenus,
+            discord,
+            legacyDiscord,
+            administration);
+
+        return new MigrationFixture(
+            service,
+            reactionStore,
+            roleMenuStore,
+            sourceChannel,
+            () => discordUserReads,
+            () => discordChannelReads);
+    }
+
+    private static ReactionRoleSettings CreateLegacySettings(
+        ulong guildId,
+        ulong channelId,
+        ulong messageId,
+        params ulong[] roleIds)
+        => new(
+            [.. roleIds.Select((roleId, index) => new RoleEmotePair(
+                roleId.ToString(),
+                $"emoji-{index}"))],
+            guildId.ToString(),
+            channelId.ToString(),
+            messageId.ToString());
+
+    private static IMessage CreateLegacyMessage(
+        ulong messageId,
+        ulong authorId,
+        string title,
+        params ulong[] roleIds)
+    {
+        var embed = new EmbedBuilder().WithFooter($"Role Group: {title}");
+        foreach (var roleId in roleIds)
+        {
+            embed.AddField("role", $"<@&{roleId}>");
+        }
+
+        var message = DispatchProxy.Create<IMessage, MessageProxy>();
+        var proxy = (MessageProxy)message;
+        proxy.Id = messageId;
+        proxy.Author = CreateUser(authorId);
+        proxy.Embeds = [embed.Build()];
+        return message;
+    }
+
+    private static IUser CreateUser(ulong id)
+    {
+        var user = DispatchProxy.Create<IUser, UserProxy>();
+        ((UserProxy)user).Id = id;
+        return user;
+    }
+
+    private static IRole CreateRole(ulong id, string name, int position)
+    {
+        var role = DispatchProxy.Create<IRole, RoleProxy>();
+        var proxy = (RoleProxy)role;
+        proxy.Id = id;
+        proxy.Name = name;
+        proxy.Position = position;
+        return role;
+    }
+
+    private static IGuild CreateGuild(
+        ulong id,
+        IReadOnlyCollection<IRole> roles,
+        IRole everyoneRole)
+    {
+        var guild = DispatchProxy.Create<IGuild, GuildProxy>();
+        var proxy = (GuildProxy)guild;
+        proxy.Id = id;
+        proxy.Roles = roles;
+        proxy.EveryoneRole = everyoneRole;
+        proxy.OwnerId = 5000;
+        return guild;
+    }
+
+    private static IGuildUser CreateGuildUser(
+        ulong id,
+        IGuild guild,
+        IReadOnlyCollection<ulong> roleIds)
+    {
+        var user = DispatchProxy.Create<IGuildUser, GuildUserProxy>();
+        var proxy = (GuildUserProxy)user;
+        proxy.Id = id;
+        proxy.Guild = guild;
+        proxy.RoleIds = roleIds;
+        return user;
+    }
+
+    private static TextChannelProxy CreateTextChannel(
+        ulong guildId,
+        ulong channelId,
+        IMessage message)
+    {
+        var channel = DispatchProxy.Create<ITextChannel, TextChannelProxy>();
+        var proxy = (TextChannelProxy)channel;
+        proxy.Channel = channel;
+        proxy.GuildId = guildId;
+        proxy.Id = channelId;
+        proxy.Message = message;
+        return proxy;
+    }
+
+    private sealed record MigrationFixture(
+        RoleMenuMigrationService Service,
+        TrackingReactionRoleStore ReactionStore,
+        TrackingRoleMenuStore RoleMenuStore,
+        TextChannelProxy SourceChannel,
+        Func<int> UserReads,
+        Func<int> ChannelReads)
+    {
+        internal int DiscordUserReads => UserReads();
+        internal int DiscordChannelReads => ChannelReads();
+    }
+
+    private sealed class TrackingReactionRoleStore : IReactionRoleSettingsStore
+    {
+        public ReactionRoleSettings? Settings { get; set; }
+        public int GetCalls { get; private set; }
+        public int InsertCalls { get; private set; }
+
+        public Task InsertAsync(ReactionRoleSettings roleSettings, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            InsertCalls++;
+            Settings = roleSettings;
+            return Task.CompletedTask;
+        }
+
+        public Task<List<ReactionRoleSettings>> GetRecentAsync(
+            DateTime oldestLastAccessedUtc,
+            int limit,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(new List<ReactionRoleSettings>());
+        }
+
+        public Task<ReactionRoleSettings?> GetByMessageIdAsync(
+            string messageId,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            GetCalls++;
+            return Task.FromResult(
+                string.Equals(Settings?.MessageId, messageId, StringComparison.Ordinal)
+                    ? Settings
+                    : null);
+        }
+    }
+
+    private sealed class TrackingRoleMenuStore : IRoleMenuStore
+    {
+        public RoleMenuSettings? Settings { get; set; }
+        public int UpsertCalls { get; private set; }
+
+        public Task UpsertAsync(RoleMenuSettings settings, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            UpsertCalls++;
+            Settings = settings;
+            return Task.CompletedTask;
+        }
+
+        public Task<RoleMenuSettings?> GetByIdAsync(
+            ObjectId id,
+            string guildId,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(
+                Settings?.Id == id
+                && string.Equals(Settings.GuildId, guildId, StringComparison.Ordinal)
+                    ? Settings
+                    : null);
+        }
+
+        public Task<List<RoleMenuSettings>> GetByGuildAsync(
+            string guildId,
+            int maximumResults,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            List<RoleMenuSettings> matches = Settings is not null
+                && string.Equals(Settings.GuildId, guildId, StringComparison.Ordinal)
+                ? [Settings]
+                : [];
+            return Task.FromResult(matches.Take(maximumResults).ToList());
+        }
+
+        public Task<bool> DeleteAsync(
+            ObjectId id,
+            string guildId,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(false);
+        }
+    }
+
+    public class RoleProxy : DispatchProxy
+    {
+        public ulong Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public int Position { get; set; }
+        public bool IsManaged { get; set; }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+            => targetMethod?.Name switch
+            {
+                "get_Id" => Id,
+                "get_Name" => Name,
+                "get_Position" => Position,
+                "get_IsManaged" => IsManaged,
+                _ => throw new NotSupportedException(targetMethod?.Name)
+            };
+    }
+
+    public class GuildProxy : DispatchProxy
+    {
+        public ulong Id { get; set; }
+        public ulong OwnerId { get; set; }
+        public IReadOnlyCollection<IRole> Roles { get; set; } = [];
+        public IRole EveryoneRole { get; set; } = null!;
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+            => targetMethod?.Name switch
+            {
+                "get_Id" => Id,
+                "get_OwnerId" => OwnerId,
+                "get_Roles" => Roles,
+                "get_EveryoneRole" => EveryoneRole,
+                _ => throw new NotSupportedException(targetMethod?.Name)
+            };
+    }
+
+    public class GuildUserProxy : DispatchProxy
+    {
+        private const ulong ManageRoles = 1UL << 28;
+        private const ulong RequiredChannelPermissions =
+            (1UL << 10) | (1UL << 11) | (1UL << 14) | (1UL << 16);
+
+        public ulong Id { get; set; }
+        public IGuild Guild { get; set; } = null!;
+        public IReadOnlyCollection<ulong> RoleIds { get; set; } = [];
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+            => targetMethod?.Name switch
+            {
+                "get_Id" => Id,
+                "get_Guild" => Guild,
+                "get_RoleIds" => RoleIds,
+                "get_GuildPermissions" => new GuildPermissions(ManageRoles),
+                nameof(IGuildUser.GetPermissions) => new ChannelPermissions(RequiredChannelPermissions),
+                _ => throw new NotSupportedException(targetMethod?.Name)
+            };
+    }
+
+    public class TextChannelProxy : DispatchProxy
+    {
+        public ITextChannel Channel { get; set; } = null!;
+        public ulong GuildId { get; set; }
+        public ulong Id { get; set; }
+        public IMessage Message { get; set; } = null!;
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            return targetMethod?.Name switch
+            {
+                "get_Id" => Id,
+                "get_GuildId" => GuildId,
+                "get_ChannelType" => ChannelType.Text,
+                nameof(IMessageChannel.GetMessageAsync) => Task.FromResult<IMessage?>(
+                    args is [ulong messageId, ..] && messageId == Message.Id ? Message : null),
+                _ => throw new NotSupportedException(targetMethod?.Name)
+            };
+        }
+    }
+
+    public class MessageProxy : DispatchProxy
+    {
+        public ulong Id { get; set; }
+        public IUser Author { get; set; } = null!;
+        public IReadOnlyCollection<IEmbed> Embeds { get; set; } = [];
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+            => targetMethod?.Name switch
+            {
+                "get_Id" => Id,
+                "get_Author" => Author,
+                "get_Embeds" => Embeds,
+                _ => throw new NotSupportedException(targetMethod?.Name)
+            };
+    }
+
+    public class UserProxy : DispatchProxy
+    {
+        public ulong Id { get; set; }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+            => targetMethod?.Name == "get_Id"
+                ? Id
+                : throw new NotSupportedException(targetMethod?.Name);
+    }
+}

--- a/BeanBot.Tests/Discord/RoleMenus/RoleMenuMigrationServiceTests.cs
+++ b/BeanBot.Tests/Discord/RoleMenus/RoleMenuMigrationServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Reflection;
 using BeanBot.Discord.Interactions;
 using BeanBot.Discord.RoleMenus;
@@ -128,14 +129,14 @@ public class RoleMenuMigrationServiceTests
         var menuId = RoleMenuMigrationIdentity.CreateMenuId(GuildId, LegacyMessageId);
         var existing = new RoleMenuSettings(
             menuId,
-            GuildId.ToString(),
-            ChannelId.ToString(),
+            GuildId.ToString(CultureInfo.InvariantCulture),
+            ChannelId.ToString(CultureInfo.InvariantCulture),
             "99",
             "Games",
             string.Empty,
             ["4", "5"],
             RoleMenuSelectionMode.Multiple,
-            LegacyMessageId.ToString());
+            LegacyMessageId.ToString(CultureInfo.InvariantCulture));
         fixture.RoleMenuStore.Settings = existing;
 
         var result = await fixture.Service.CreatePreviewAsync(
@@ -248,11 +249,11 @@ public class RoleMenuMigrationServiceTests
         params ulong[] roleIds)
         => new(
             [.. roleIds.Select((roleId, index) => new RoleEmotePair(
-                roleId.ToString(),
+                roleId.ToString(CultureInfo.InvariantCulture),
                 $"emoji-{index}"))],
-            guildId.ToString(),
-            channelId.ToString(),
-            messageId.ToString());
+            guildId.ToString(CultureInfo.InvariantCulture),
+            channelId.ToString(CultureInfo.InvariantCulture),
+            messageId.ToString(CultureInfo.InvariantCulture));
 
     private static IMessage CreateLegacyMessage(
         ulong messageId,

--- a/BeanBot.Tests/Discord/RoleMenus/RoleMenuPublicationSettingsTests.cs
+++ b/BeanBot.Tests/Discord/RoleMenus/RoleMenuPublicationSettingsTests.cs
@@ -39,6 +39,20 @@ public class RoleMenuPublicationSettingsTests
         Assert.False(RoleMenuPublicationSettings.Matches(mismatched, draft, 30UL));
     }
 
+    [Fact]
+    public void CreateAndMatches_PreserveLegacyMigrationProvenance()
+    {
+        var menuId = ObjectId.GenerateNewId();
+        var draft = CreateDraft(menuId) with { LegacyReactionRoleMessageId = 777UL };
+
+        var settings = RoleMenuPublicationSettings.Create(draft, 30UL);
+
+        Assert.Equal("777", settings.MigratedFromReactionRoleMessageId);
+        Assert.True(RoleMenuPublicationSettings.Matches(settings, draft, 30UL));
+        var wrongSource = draft with { LegacyReactionRoleMessageId = 778UL };
+        Assert.False(RoleMenuPublicationSettings.Matches(settings, wrongSource, 30UL));
+    }
+
     private static RoleMenuDraft CreateDraft(ObjectId menuId)
         => new(
             Guid.NewGuid(),

--- a/BeanBot.Tests/Persistence/Models/RoleMenuSettingsTests.cs
+++ b/BeanBot.Tests/Persistence/Models/RoleMenuSettingsTests.cs
@@ -44,6 +44,24 @@ public class RoleMenuSettingsTests
     }
 
     [Fact]
+    public void BsonSerialize_NonMigratedRoleMenuOmitsMigrationProvenance()
+    {
+        var settings = new RoleMenuSettings(
+            ObjectId.GenerateNewId(),
+            "1",
+            "2",
+            "3",
+            "Games",
+            string.Empty,
+            ["4"],
+            RoleMenuSelectionMode.Multiple);
+
+        var document = settings.ToBsonDocument();
+
+        Assert.False(document.Contains("migratedFromReactionRoleMessageId"));
+    }
+
+    [Fact]
     public void BsonDeserialize_LegacyRoleMenuWithoutMigrationProvenanceDefaultsEmpty()
     {
         var document = new BsonDocument

--- a/BeanBot.Tests/Persistence/Models/RoleMenuSettingsTests.cs
+++ b/BeanBot.Tests/Persistence/Models/RoleMenuSettingsTests.cs
@@ -18,7 +18,8 @@ public class RoleMenuSettingsTests
             "Games",
             "Choose games",
             ["4", "5"],
-            RoleMenuSelectionMode.Exclusive)
+            RoleMenuSelectionMode.Exclusive,
+            "99")
         {
             CreatedAtUtc = new DateTime(2026, 8, 22, 12, 0, 0, DateTimeKind.Utc),
             UpdatedAtUtc = new DateTime(2026, 8, 22, 12, 1, 0, DateTimeKind.Utc)
@@ -28,6 +29,7 @@ public class RoleMenuSettingsTests
         var actual = BsonSerializer.Deserialize<RoleMenuSettings>(document);
 
         Assert.Equal("Exclusive", document["selectionMode"].AsString);
+        Assert.Equal("99", document["migratedFromReactionRoleMessageId"].AsString);
         Assert.Equal(expected.Id, actual.Id);
         Assert.Equal(expected.GuildId, actual.GuildId);
         Assert.Equal(expected.ChannelId, actual.ChannelId);
@@ -36,8 +38,29 @@ public class RoleMenuSettingsTests
         Assert.Equal(expected.Description, actual.Description);
         Assert.Equal(expected.RoleIds, actual.RoleIds);
         Assert.Equal(expected.SelectionMode, actual.SelectionMode);
+        Assert.Equal(expected.MigratedFromReactionRoleMessageId, actual.MigratedFromReactionRoleMessageId);
         Assert.Equal(DateTimeKind.Utc, actual.CreatedAtUtc.Kind);
         Assert.Equal(DateTimeKind.Utc, actual.UpdatedAtUtc.Kind);
+    }
+
+    [Fact]
+    public void BsonDeserialize_LegacyRoleMenuWithoutMigrationProvenanceDefaultsEmpty()
+    {
+        var document = new BsonDocument
+        {
+            ["_id"] = ObjectId.GenerateNewId(),
+            ["guildId"] = "1",
+            ["channelId"] = "2",
+            ["messageId"] = "3",
+            ["title"] = "Games",
+            ["description"] = string.Empty,
+            ["roleIds"] = new BsonArray(["4"]),
+            ["selectionMode"] = "Multiple"
+        };
+
+        var settings = BsonSerializer.Deserialize<RoleMenuSettings>(document);
+
+        Assert.Equal(string.Empty, settings.MigratedFromReactionRoleMessageId);
     }
 
     [Fact]

--- a/BeanBot/Discord/Interactions/BeanBotInteractionServiceCollectionExtensions.cs
+++ b/BeanBot/Discord/Interactions/BeanBotInteractionServiceCollectionExtensions.cs
@@ -28,8 +28,10 @@ internal static class BeanBotInteractionServiceCollectionExtensions
             provider.GetRequiredService<RoleMenuMutationCoordinator>(),
             provider.GetRequiredService<InteractionExecutionContext>()));
         services.AddSingleton<DiscordRoleMenuClient>();
+        services.AddSingleton<LegacyReactionRoleMigrationClient>();
         services.AddSingleton<RoleMenuMemberService>();
         services.AddSingleton<RoleMenuAdministrationService>();
+        services.AddSingleton<RoleMenuMigrationService>();
         services.AddSingleton<InteractionHandler>();
         services.AddSingleton<BeanBotInteractionHostedService>();
         services.AddSingleton<IHostedService>(provider =>

--- a/BeanBot/Discord/RoleMenus/LegacyReactionRoleMigrationClient.cs
+++ b/BeanBot/Discord/RoleMenus/LegacyReactionRoleMigrationClient.cs
@@ -1,0 +1,100 @@
+using System.Net;
+using Discord;
+using Discord.Net;
+using Discord.WebSocket;
+
+namespace BeanBot.Discord.RoleMenus;
+
+internal enum LegacyReactionRolePanelLookupStatus
+{
+    Found,
+    ChannelMissing,
+    MessageMissing,
+    Unrecognized
+}
+
+internal sealed record LegacyReactionRolePanelLookupResult(
+    LegacyReactionRolePanelLookupStatus Status,
+    string? SuggestedTitle = null);
+
+internal sealed class LegacyReactionRoleMigrationClient
+{
+    private readonly Func<ulong, RequestOptions, Task<IChannel?>> _getChannel;
+
+    public LegacyReactionRoleMigrationClient(DiscordSocketClient client)
+        : this(async (channelId, options) => await client.Rest.GetChannelAsync(channelId, options))
+    {
+        ArgumentNullException.ThrowIfNull(client);
+    }
+
+    internal LegacyReactionRoleMigrationClient(
+        Func<ulong, RequestOptions, Task<IChannel?>> getChannel)
+    {
+        _getChannel = getChannel ?? throw new ArgumentNullException(nameof(getChannel));
+    }
+
+    internal async Task<LegacyReactionRolePanelLookupResult> ReadSourcePanelAsync(
+        ulong guildId,
+        ulong channelId,
+        ulong messageId,
+        ulong botUserId,
+        IReadOnlyCollection<ulong> expectedRoleIds,
+        CancellationToken cancellationToken)
+    {
+        var requestOptions = DiscordRoleMenuClient.CreateRequestOptions(cancellationToken);
+        IChannel? channel;
+        try
+        {
+            channel = await _getChannel(channelId, requestOptions);
+        }
+        catch (HttpException exception) when (exception.HttpCode == HttpStatusCode.NotFound)
+        {
+            return new LegacyReactionRolePanelLookupResult(
+                LegacyReactionRolePanelLookupStatus.ChannelMissing);
+        }
+
+        if (channel is null)
+        {
+            return new LegacyReactionRolePanelLookupResult(
+                LegacyReactionRolePanelLookupStatus.ChannelMissing);
+        }
+
+        if (channel is not ITextChannel textChannel || textChannel.GuildId != guildId)
+        {
+            return new LegacyReactionRolePanelLookupResult(
+                LegacyReactionRolePanelLookupStatus.Unrecognized);
+        }
+
+        IMessage? message;
+        try
+        {
+            message = await textChannel.GetMessageAsync(
+                messageId,
+                CacheMode.AllowDownload,
+                requestOptions);
+        }
+        catch (HttpException exception) when (exception.HttpCode == HttpStatusCode.NotFound)
+        {
+            return new LegacyReactionRolePanelLookupResult(
+                LegacyReactionRolePanelLookupStatus.MessageMissing);
+        }
+
+        if (message is null)
+        {
+            return new LegacyReactionRolePanelLookupResult(
+                LegacyReactionRolePanelLookupStatus.MessageMissing);
+        }
+
+        return LegacyReactionRolePanelIdentity.TryRecognize(
+            message.Author.Id,
+            botUserId,
+            message.Embeds,
+            expectedRoleIds,
+            out var suggestedTitle)
+            ? new LegacyReactionRolePanelLookupResult(
+                LegacyReactionRolePanelLookupStatus.Found,
+                suggestedTitle)
+            : new LegacyReactionRolePanelLookupResult(
+                LegacyReactionRolePanelLookupStatus.Unrecognized);
+    }
+}

--- a/BeanBot/Discord/RoleMenus/LegacyReactionRoleMigrationClient.cs
+++ b/BeanBot/Discord/RoleMenus/LegacyReactionRoleMigrationClient.cs
@@ -17,7 +17,7 @@ internal sealed record LegacyReactionRolePanelLookupResult(
     LegacyReactionRolePanelLookupStatus Status,
     string? SuggestedTitle = null);
 
-internal sealed class LegacyReactionRoleMigrationClient
+public sealed class LegacyReactionRoleMigrationClient
 {
     private readonly Func<ulong, RequestOptions, Task<IChannel?>> _getChannel;
 

--- a/BeanBot/Discord/RoleMenus/LegacyReactionRolePanelIdentity.cs
+++ b/BeanBot/Discord/RoleMenus/LegacyReactionRolePanelIdentity.cs
@@ -39,7 +39,7 @@ internal static class LegacyReactionRolePanelIdentity
             .Select(field => field.Value)
             .Where(value => !string.IsNullOrWhiteSpace(value))
             .ToHashSet(StringComparer.Ordinal);
-        if (embed.Fields.Count != expectedMentions.Count
+        if (embed.Fields.Count() != expectedMentions.Count
             || !actualMentions.SetEquals(expectedMentions))
         {
             return false;

--- a/BeanBot/Discord/RoleMenus/LegacyReactionRolePanelIdentity.cs
+++ b/BeanBot/Discord/RoleMenus/LegacyReactionRolePanelIdentity.cs
@@ -10,7 +10,7 @@ internal static class LegacyReactionRolePanelIdentity
     internal static bool TryRecognize(
         ulong authorId,
         ulong expectedBotUserId,
-        IReadOnlyCollection<IEmbed> embeds,
+        IReadOnlyCollection<Embed> embeds,
         IReadOnlyCollection<ulong> expectedRoleIds,
         out string? suggestedTitle)
     {
@@ -39,7 +39,7 @@ internal static class LegacyReactionRolePanelIdentity
             .Select(field => field.Value)
             .Where(value => !string.IsNullOrWhiteSpace(value))
             .ToHashSet(StringComparer.Ordinal);
-        if (embed.Fields.Count != expectedMentions.Count
+        if (embed.Fields.Length != expectedMentions.Count
             || !actualMentions.SetEquals(expectedMentions))
         {
             return false;

--- a/BeanBot/Discord/RoleMenus/LegacyReactionRolePanelIdentity.cs
+++ b/BeanBot/Discord/RoleMenus/LegacyReactionRolePanelIdentity.cs
@@ -39,7 +39,7 @@ internal static class LegacyReactionRolePanelIdentity
             .Select(field => field.Value)
             .Where(value => !string.IsNullOrWhiteSpace(value))
             .ToHashSet(StringComparer.Ordinal);
-        if (embed.Fields.Count() != expectedMentions.Count
+        if (embed.Fields.Length != expectedMentions.Count
             || !actualMentions.SetEquals(expectedMentions))
         {
             return false;

--- a/BeanBot/Discord/RoleMenus/LegacyReactionRolePanelIdentity.cs
+++ b/BeanBot/Discord/RoleMenus/LegacyReactionRolePanelIdentity.cs
@@ -1,0 +1,52 @@
+using System.Globalization;
+using Discord;
+
+namespace BeanBot.Discord.RoleMenus;
+
+internal static class LegacyReactionRolePanelIdentity
+{
+    private const string FooterPrefix = "Role Group: ";
+
+    internal static bool TryRecognize(
+        ulong authorId,
+        ulong expectedBotUserId,
+        IReadOnlyCollection<Embed> embeds,
+        IReadOnlyCollection<ulong> expectedRoleIds,
+        out string? suggestedTitle)
+    {
+        suggestedTitle = null;
+        if (authorId == 0
+            || authorId != expectedBotUserId
+            || embeds.Count != 1
+            || expectedRoleIds.Count == 0
+            || expectedRoleIds.Distinct().Count() != expectedRoleIds.Count)
+        {
+            return false;
+        }
+
+        var embed = embeds.Single();
+        var footer = embed.Footer?.Text;
+        if (string.IsNullOrWhiteSpace(footer)
+            || !footer.StartsWith(FooterPrefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var expectedMentions = expectedRoleIds
+            .Select(roleId => $"<@&{roleId.ToString(CultureInfo.InvariantCulture)}>")
+            .ToHashSet(StringComparer.Ordinal);
+        var actualMentions = embed.Fields
+            .Select(field => field.Value)
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .ToHashSet(StringComparer.Ordinal);
+        if (embed.Fields.Length != expectedMentions.Count
+            || !actualMentions.SetEquals(expectedMentions))
+        {
+            return false;
+        }
+
+        var label = footer[FooterPrefix.Length..].Trim();
+        suggestedTitle = string.IsNullOrWhiteSpace(label) ? null : label;
+        return true;
+    }
+}

--- a/BeanBot/Discord/RoleMenus/LegacyReactionRolePanelIdentity.cs
+++ b/BeanBot/Discord/RoleMenus/LegacyReactionRolePanelIdentity.cs
@@ -10,7 +10,7 @@ internal static class LegacyReactionRolePanelIdentity
     internal static bool TryRecognize(
         ulong authorId,
         ulong expectedBotUserId,
-        IReadOnlyCollection<Embed> embeds,
+        IReadOnlyCollection<IEmbed> embeds,
         IReadOnlyCollection<ulong> expectedRoleIds,
         out string? suggestedTitle)
     {
@@ -39,7 +39,7 @@ internal static class LegacyReactionRolePanelIdentity
             .Select(field => field.Value)
             .Where(value => !string.IsNullOrWhiteSpace(value))
             .ToHashSet(StringComparer.Ordinal);
-        if (embed.Fields.Length != expectedMentions.Count
+        if (embed.Fields.Count != expectedMentions.Count
             || !actualMentions.SetEquals(expectedMentions))
         {
             return false;

--- a/BeanBot/Discord/RoleMenus/RoleMenuAdminModule.Migration.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuAdminModule.Migration.cs
@@ -1,0 +1,226 @@
+using BeanBot.Logging;
+using Discord;
+using Discord.Interactions;
+using Discord.WebSocket;
+
+using static BeanBot.Discord.RoleMenus.DiscordRoleMenuClient;
+
+namespace BeanBot.Discord.RoleMenus;
+
+public sealed partial class RoleMenuAdminModule
+{
+    [SlashCommand(
+        "migrate",
+        "Preview migration of one legacy reaction-role panel.",
+        runMode: RunMode.Sync)]
+    public async Task MigrateAsync(
+        [Summary("legacy-message-id", "Message ID of the saved legacy reaction-role panel")]
+        string legacyMessageId,
+        [Summary("target-channel", "Optional text channel for the new role menu")]
+        ITextChannel? targetChannel = null,
+        [Summary("title", "Optional replacement title for the new role menu")]
+        string? title = null,
+        [Summary("description", "Optional description for the new role menu")]
+        string? description = null)
+    {
+        using var cancellation = RoleMenus.CreateOperationCancellation();
+        await RoleMenus.ExecuteInitialResponseAsync(
+            supportsOriginalResponse: true,
+            operationToken => DeferAsync(
+                ephemeral: true,
+                CreateRequestOptions(operationToken)),
+            operationToken => ReplaceResponseAsync(
+                "Loading the legacy role panel…",
+                operationToken),
+            cancellation.Token);
+
+        if (!RoleMenuCustomIds.TryParseSnowflake(legacyMessageId, out var parsedMessageId))
+        {
+            await ReplaceResponseAsync(
+                "That legacy message ID is invalid. Copy the numeric ID from the legacy reaction-role message.",
+                cancellation.Token);
+            return;
+        }
+
+        if (!TryGetGuildActors(out var guild, out var administrator, out var bot))
+        {
+            await ReplaceResponseAsync(
+                "Legacy role panels can only be migrated inside a server.",
+                cancellation.Token);
+            return;
+        }
+
+        var preview = await _migration.CreatePreviewAsync(
+            new RoleMenuMigrationRequest(
+                parsedMessageId,
+                targetChannel?.Id,
+                targetChannel?.GuildId,
+                targetChannel?.ChannelType,
+                title,
+                description),
+            guild.Id,
+            administrator.Id,
+            bot.Id,
+            cancellation.Token);
+        if (preview.Draft is null)
+        {
+            await ReplaceResponseAsync(preview.Content, cancellation.Token);
+            return;
+        }
+
+        await ReplaceResponseAsync(
+            preview.Content,
+            cancellation.Token,
+            RoleMenuComponents.BuildMigrationPreviewEmbed(
+                preview.Draft,
+                preview.Roles ?? [],
+                preview.SourceMessageLink
+                    ?? throw new InvalidOperationException("A migration preview did not include its source link.")),
+            RoleMenuComponents.BuildMigrationPreviewComponents(preview.Draft.Id));
+    }
+
+    [ComponentInteraction(
+        RoleMenuCustomIds.MigrateConfirmPattern,
+        ignoreGroupNames: true,
+        runMode: RunMode.Sync)]
+    public async Task ConfirmMigrationAsync(string draftIdValue)
+    {
+        using var cancellation = RoleMenus.CreateOperationCancellation();
+        if (!RoleMenuCustomIds.TryParseDraftId(draftIdValue, out var draftId)
+            || !TryGetGuildActors(out var guild, out var administrator, out var bot)
+            || Context.Interaction is not SocketMessageComponent sourceComponent
+            || !IsValidPrivateComponent(
+                sourceComponent,
+                guild,
+                ComponentType.Button,
+                RoleMenuCustomIds.MigrateConfirm(draftId)))
+        {
+            await RespondToInvalidComponentAsync(
+                "That migration preview is invalid or no longer available.",
+                cancellation.Token);
+            return;
+        }
+
+        var accessStatus = RoleMenus.TryBeginPublish(
+            draftId,
+            guild.Id,
+            administrator.Id,
+            out var draft);
+        if (accessStatus != RoleMenuDraftAccessStatus.Acquired
+            || draft is null
+            || draft.LegacyReactionRoleMessageId is null)
+        {
+            var message = accessStatus switch
+            {
+                RoleMenuDraftAccessStatus.AlreadyPublishing =>
+                    "That migration preview is already being published.",
+                RoleMenuDraftAccessStatus.WrongOwner =>
+                    "Only the administrator who created this migration preview can publish it.",
+                _ => "That migration preview expired or no longer exists. Run `/role-menu migrate` again."
+            };
+            await RespondToInvalidComponentAsync(message, cancellation.Token);
+            return;
+        }
+
+        var mutationStarted = false;
+        try
+        {
+            if (!await AcknowledgeEphemeralComponentAsync(
+                    "Revalidating and publishing the migrated role menu…",
+                    cancellation.Token))
+            {
+                return;
+            }
+
+            var result = await RoleMenus.RunMenuMutationAsync(
+                draft.MenuId,
+                operationToken =>
+                {
+                    mutationStarted = true;
+                    return _migration.ConfirmAsync(
+                        draft,
+                        administrator.Id,
+                        bot.Id,
+                        operationToken);
+                },
+                cancellation.Token);
+            if (result.Completed)
+            {
+                RoleMenus.CompletePublish(draft.Id, guild.Id, administrator.Id);
+            }
+
+            await ReplaceResponseAsync(result.Content, cancellation.Token);
+        }
+        catch (OperationCanceledException)
+            when (cancellation.IsCancellationRequested && !RoleMenus.IsShuttingDown)
+        {
+            await SendFreshFeedbackAsync(
+                mutationStarted
+                    ? "Bean Bot ran out of time and could not confirm the migration result. Inspect " +
+                      "the target channel, then rerun `/role-menu migrate` for the same legacy message. " +
+                      "The stable migration ID prevents a second saved role menu from being published."
+                    : "Bean Bot was busy and did not begin this migration. Run `/role-menu migrate` again.");
+        }
+        catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            BeanBotLog.RoleMenuPublicationFailed(_logger, draft.MenuId.ToString(), exception);
+            await SendFreshFeedbackAsync(
+                "Bean Bot couldn't confirm the migration result. Inspect the target channel, then " +
+                "rerun `/role-menu migrate` for the same legacy message. Automatic publication retry was not attempted.");
+        }
+        finally
+        {
+            RoleMenus.ReleasePublish(draft.Id, guild.Id, administrator.Id);
+        }
+    }
+
+    [ComponentInteraction(
+        RoleMenuCustomIds.MigrateCancelPattern,
+        ignoreGroupNames: true,
+        runMode: RunMode.Sync)]
+    public async Task CancelMigrationAsync(string draftIdValue)
+    {
+        using var cancellation = RoleMenus.CreateOperationCancellation();
+        if (!RoleMenuCustomIds.TryParseDraftId(draftIdValue, out var draftId)
+            || Context.Guild is null
+            || Context.Interaction is not SocketMessageComponent component
+            || !IsValidPrivateComponent(
+                component,
+                Context.Guild,
+                ComponentType.Button,
+                RoleMenuCustomIds.MigrateCancel(draftId))
+            || !RoleMenus.CancelDraft(draftId, Context.Guild.Id, Context.User.Id))
+        {
+            await RespondToInvalidComponentAsync(
+                "That migration preview expired, belongs to another administrator, or is already publishing.",
+                cancellation.Token);
+            return;
+        }
+
+        if (Context.Interaction is SocketMessageComponent validComponent)
+        {
+            await RoleMenus.ExecuteInitialResponseAsync(
+                supportsOriginalResponse: true,
+                operationToken => validComponent.UpdateAsync(
+                    properties => SetMessage(
+                        properties,
+                        "Legacy role-panel migration cancelled. The source panel was not changed.",
+                        null,
+                        MessageComponent.Empty),
+                    CreateRequestOptions(operationToken)),
+                operationToken => ReplaceResponseAsync(
+                    "Legacy role-panel migration cancelled. The source panel was not changed.",
+                    operationToken),
+                cancellation.Token);
+            return;
+        }
+
+        await RespondToInvalidComponentAsync(
+            "Legacy role-panel migration cancelled.",
+            cancellation.Token);
+    }
+}

--- a/BeanBot/Discord/RoleMenus/RoleMenuAdminModule.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuAdminModule.cs
@@ -16,26 +16,29 @@ using static BeanBot.Discord.RoleMenus.RoleMenuSetupValidation;
 
 namespace BeanBot.Discord.RoleMenus;
 
-[Group("role-menu", "Create and remove self-assignable role menus.")]
+[Group("role-menu", "Create, migrate, and remove self-assignable role menus.")]
 [CommandContextType(InteractionContextType.Guild)]
 [RequireContext(ContextType.Guild)]
 [RequireUserPermission(GuildPermission.ManageRoles)]
 [DefaultMemberPermissions(GuildPermission.ManageRoles)]
-public sealed class RoleMenuAdminModule : RoleMenuModuleBase
+public sealed partial class RoleMenuAdminModule : RoleMenuModuleBase
 {
     private readonly DiscordRoleMenuClient _discord;
     private readonly RoleMenuAdministrationService _administration;
+    private readonly RoleMenuMigrationService _migration;
     private readonly ILogger<RoleMenuAdminModule> _logger;
 
     public RoleMenuAdminModule(
         RoleMenuInteractionService roleMenuService,
         DiscordRoleMenuClient discord,
         RoleMenuAdministrationService administration,
+        RoleMenuMigrationService migration,
         ILogger<RoleMenuAdminModule> logger)
         : base(roleMenuService)
     {
         _discord = discord ?? throw new ArgumentNullException(nameof(discord));
         _administration = administration ?? throw new ArgumentNullException(nameof(administration));
+        _migration = migration ?? throw new ArgumentNullException(nameof(migration));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 

--- a/BeanBot/Discord/RoleMenus/RoleMenuComponents.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuComponents.cs
@@ -47,13 +47,7 @@ internal static class RoleMenuComponents
         ArgumentNullException.ThrowIfNull(draft);
         ArgumentNullException.ThrowIfNull(roles);
 
-        var roleMentions = string.Join(
-            " ",
-            roles.Select(role => $"<@&{role.Id.ToString(CultureInfo.InvariantCulture)}>"));
-        if (roleMentions.Length == 0)
-        {
-            roleMentions = "No valid roles remain.";
-        }
+        var roleMentions = FormatRoleMentions(roles);
         var selectionMode = draft.SelectionMode == RoleMenuSelectionMode.Exclusive
             ? "Single selection"
             : "Multiple selection";
@@ -81,6 +75,47 @@ internal static class RoleMenuComponents
             .WithButton(
                 "Cancel",
                 RoleMenuCustomIds.CancelPublish(draftId),
+                ButtonStyle.Secondary)
+            .Build();
+
+    internal static Embed BuildMigrationPreviewEmbed(
+        RoleMenuDraft draft,
+        IReadOnlyCollection<RoleMenuRoleSnapshot> roles,
+        string sourceMessageLink)
+    {
+        ArgumentNullException.ThrowIfNull(draft);
+        ArgumentNullException.ThrowIfNull(roles);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceMessageLink);
+
+        return new EmbedBuilder()
+            .WithTitle(draft.Title)
+            .WithDescription(string.IsNullOrWhiteSpace(draft.Description)
+                ? DefaultDescription
+                : draft.Description)
+            .AddField("Legacy source", sourceMessageLink)
+            .AddField("Roles", FormatRoleMentions(roles))
+            .AddField("Mode", "Multiple selection", inline: true)
+            .AddField(
+                "Target channel",
+                $"<#{draft.TargetChannelId.ToString(CultureInfo.InvariantCulture)}>",
+                inline: true)
+            .AddField(
+                "Retirement",
+                "The legacy reaction-role panel and saved configuration stay unchanged. " +
+                "Retire them manually only after verifying this replacement.")
+            .WithFooter("Migration preview • Not published")
+            .Build();
+    }
+
+    internal static MessageComponent BuildMigrationPreviewComponents(Guid draftId)
+        => new ComponentBuilder()
+            .WithButton(
+                "Publish migration",
+                RoleMenuCustomIds.MigrateConfirm(draftId),
+                ButtonStyle.Success)
+            .WithButton(
+                "Cancel",
+                RoleMenuCustomIds.MigrateCancel(draftId),
                 ButtonStyle.Secondary)
             .Build();
 
@@ -212,5 +247,13 @@ internal static class RoleMenuComponents
                 button.CustomId,
                 expectedCustomId,
                 StringComparison.Ordinal));
+    }
+
+    private static string FormatRoleMentions(IReadOnlyCollection<RoleMenuRoleSnapshot> roles)
+    {
+        var roleMentions = string.Join(
+            " ",
+            roles.Select(role => $"<@&{role.Id.ToString(CultureInfo.InvariantCulture)}>"));
+        return roleMentions.Length == 0 ? "No valid roles remain." : roleMentions;
     }
 }

--- a/BeanBot/Discord/RoleMenus/RoleMenuCustomIds.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuCustomIds.cs
@@ -12,6 +12,8 @@ internal static class RoleMenuCustomIds
     internal const string ClearPattern = "role-menu:clear:*:*:*";
     internal const string PublishPattern = "role-menu:publish:*";
     internal const string CancelPublishPattern = "role-menu:cancel-publish:*";
+    internal const string MigrateConfirmPattern = "role-menu:migrate-confirm:*";
+    internal const string MigrateCancelPattern = "role-menu:migrate-cancel:*";
     internal const string DeleteSelectPattern = "role-menu:delete-select:*";
     internal const string DeleteConfirmPattern = "role-menu:delete-confirm:*:*";
     internal const string DeleteCancelPattern = "role-menu:delete-cancel:*";
@@ -36,6 +38,12 @@ internal static class RoleMenuCustomIds
 
     internal static string CancelPublish(Guid draftId)
         => EnsureValid($"role-menu:cancel-publish:{draftId:N}");
+
+    internal static string MigrateConfirm(Guid draftId)
+        => EnsureValid($"role-menu:migrate-confirm:{draftId:N}");
+
+    internal static string MigrateCancel(Guid draftId)
+        => EnsureValid($"role-menu:migrate-cancel:{draftId:N}");
 
     internal static string DeleteSelect(ulong userId)
         => EnsureValid($"role-menu:delete-select:{userId.ToString(CultureInfo.InvariantCulture)}");

--- a/BeanBot/Discord/RoleMenus/RoleMenuDraftRegistry.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuDraftRegistry.cs
@@ -28,7 +28,8 @@ internal sealed record RoleMenuDraft(
     string Description,
     IReadOnlyList<ulong> RoleIds,
     RoleMenuSelectionMode SelectionMode,
-    DateTimeOffset ExpiresAtUtc);
+    DateTimeOffset ExpiresAtUtc,
+    ulong? LegacyReactionRoleMessageId = null);
 
 internal sealed class RoleMenuDraftRegistry
 {
@@ -74,6 +75,59 @@ internal sealed class RoleMenuDraftRegistry
         IReadOnlyCollection<ulong> roleIds,
         RoleMenuSelectionMode selectionMode,
         out RoleMenuDraft? draft)
+        => CreateCore(
+            guildId,
+            userId,
+            targetChannelId,
+            title,
+            description,
+            roleIds,
+            selectionMode,
+            ObjectId.GenerateNewId(),
+            legacyReactionRoleMessageId: null,
+            out draft);
+
+    internal RoleMenuDraftCreateStatus CreateMigration(
+        ulong guildId,
+        ulong userId,
+        ulong targetChannelId,
+        string title,
+        string description,
+        IReadOnlyCollection<ulong> roleIds,
+        ObjectId menuId,
+        ulong legacyReactionRoleMessageId,
+        out RoleMenuDraft? draft)
+    {
+        if (menuId == ObjectId.Empty)
+        {
+            throw new ArgumentException("A deterministic menu ID is required.", nameof(menuId));
+        }
+
+        ArgumentOutOfRangeException.ThrowIfZero(legacyReactionRoleMessageId);
+        return CreateCore(
+            guildId,
+            userId,
+            targetChannelId,
+            title,
+            description,
+            roleIds,
+            RoleMenuSelectionMode.Multiple,
+            menuId,
+            legacyReactionRoleMessageId,
+            out draft);
+    }
+
+    private RoleMenuDraftCreateStatus CreateCore(
+        ulong guildId,
+        ulong userId,
+        ulong targetChannelId,
+        string title,
+        string description,
+        IReadOnlyCollection<ulong> roleIds,
+        RoleMenuSelectionMode selectionMode,
+        ObjectId menuId,
+        ulong? legacyReactionRoleMessageId,
+        out RoleMenuDraft? draft)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(title);
         ArgumentNullException.ThrowIfNull(description);
@@ -105,7 +159,7 @@ internal sealed class RoleMenuDraftRegistry
             var now = _timeProvider.GetUtcNow();
             draft = new RoleMenuDraft(
                 Guid.NewGuid(),
-                ObjectId.GenerateNewId(),
+                menuId,
                 guildId,
                 userId,
                 targetChannelId,
@@ -113,7 +167,8 @@ internal sealed class RoleMenuDraftRegistry
                 description,
                 [.. roleIds],
                 selectionMode,
-                now.Add(_lifetime));
+                now.Add(_lifetime),
+                legacyReactionRoleMessageId);
             _drafts[draft.Id] = new DraftEntry { Draft = draft };
             _draftByOwner[owner] = draft.Id;
             return RoleMenuDraftCreateStatus.Created;

--- a/BeanBot/Discord/RoleMenus/RoleMenuInteractionService.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuInteractionService.cs
@@ -86,6 +86,27 @@ public sealed class RoleMenuInteractionService
             selectionMode,
             out draft);
 
+    internal RoleMenuDraftCreateStatus CreateMigrationDraft(
+        ulong guildId,
+        ulong userId,
+        ulong targetChannelId,
+        string title,
+        string description,
+        IReadOnlyCollection<ulong> roleIds,
+        ObjectId menuId,
+        ulong legacyReactionRoleMessageId,
+        out RoleMenuDraft? draft)
+        => _draftRegistry.CreateMigration(
+            guildId,
+            userId,
+            targetChannelId,
+            title,
+            description,
+            roleIds,
+            menuId,
+            legacyReactionRoleMessageId,
+            out draft);
+
     internal RoleMenuDraftAccessStatus TryBeginPublish(
         Guid draftId,
         ulong guildId,

--- a/BeanBot/Discord/RoleMenus/RoleMenuMigrationIdentity.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuMigrationIdentity.cs
@@ -1,0 +1,27 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using MongoDB.Bson;
+
+namespace BeanBot.Discord.RoleMenus;
+
+internal static class RoleMenuMigrationIdentity
+{
+    internal static ObjectId CreateMenuId(ulong guildId, ulong legacyMessageId)
+    {
+        ArgumentOutOfRangeException.ThrowIfZero(guildId);
+        ArgumentOutOfRangeException.ThrowIfZero(legacyMessageId);
+
+        var source = string.Create(
+            CultureInfo.InvariantCulture,
+            $"legacy-reaction-role:{guildId}:{legacyMessageId}");
+        var digest = SHA256.HashData(Encoding.UTF8.GetBytes(source));
+        var objectIdHex = Convert.ToHexString(digest.AsSpan(0, 12)).ToLowerInvariant();
+        return ObjectId.Parse(objectIdHex);
+    }
+
+    internal static string BuildMessageLink(ulong guildId, ulong channelId, ulong messageId)
+        => string.Create(
+            CultureInfo.InvariantCulture,
+            $"https://discord.com/channels/{guildId}/{channelId}/{messageId}");
+}

--- a/BeanBot/Discord/RoleMenus/RoleMenuMigrationService.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuMigrationService.cs
@@ -2,7 +2,6 @@ using System.Globalization;
 using BeanBot.Persistence.Models;
 using BeanBot.Persistence.Repositories;
 using Discord;
-using MongoDB.Bson;
 using static BeanBot.Discord.RoleMenus.DiscordRoleMenuClient;
 using static BeanBot.Discord.RoleMenus.RoleMenuPresentation;
 using static BeanBot.Discord.RoleMenus.RoleMenuSetupValidation;
@@ -37,7 +36,7 @@ internal sealed class RoleMenuMigrationService
     private readonly LegacyReactionRoleMigrationClient _legacyDiscord;
     private readonly RoleMenuAdministrationService _administration;
 
-    internal RoleMenuMigrationService(
+    public RoleMenuMigrationService(
         ReactionRoleRepository reactionRoles,
         RoleMenuInteractionService roleMenus,
         DiscordRoleMenuClient discord,
@@ -239,7 +238,7 @@ internal sealed class RoleMenuMigrationService
 
         var failure = publication.CanRetry
             ? "Bean Bot confirmed that the attempted role-menu panel was rolled back and no migration was saved. " +
-              "You may retry this preview after correcting the underlying problem."
+              "Run `/role-menu migrate` again after correcting the underlying problem."
             : FormatMigrationPublicationFailure(publication.Status);
         return new RoleMenuMigrationConfirmationResult(
             failure,
@@ -323,7 +322,6 @@ internal sealed class RoleMenuMigrationService
                 sourceChannelId,
                 roleIds,
                 roleValidation,
-                administrator,
                 bot,
                 panel.SuggestedTitle);
     }
@@ -413,18 +411,16 @@ internal sealed class RoleMenuMigrationService
         ulong SourceChannelId,
         IReadOnlyList<ulong>? RoleIds,
         RoleMenuRoleValidationResult? RoleValidation,
-        IGuildUser? Administrator,
         IGuildUser? Bot,
         string? SuggestedTitle)
     {
         internal static ValidatedLegacySource Invalid(string errorMessage)
-            => new(false, errorMessage, 0, null, null, null, null, null);
+            => new(false, errorMessage, 0, null, null, null, null);
 
         internal static ValidatedLegacySource Valid(
             ulong sourceChannelId,
             IReadOnlyList<ulong> roleIds,
             RoleMenuRoleValidationResult roleValidation,
-            IGuildUser administrator,
             IGuildUser bot,
             string? suggestedTitle)
             => new(
@@ -433,7 +429,6 @@ internal sealed class RoleMenuMigrationService
                 sourceChannelId,
                 roleIds,
                 roleValidation,
-                administrator,
                 bot,
                 suggestedTitle);
     }

--- a/BeanBot/Discord/RoleMenus/RoleMenuMigrationService.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuMigrationService.cs
@@ -1,0 +1,440 @@
+using System.Globalization;
+using BeanBot.Persistence.Models;
+using BeanBot.Persistence.Repositories;
+using Discord;
+using MongoDB.Bson;
+using static BeanBot.Discord.RoleMenus.DiscordRoleMenuClient;
+using static BeanBot.Discord.RoleMenus.RoleMenuPresentation;
+using static BeanBot.Discord.RoleMenus.RoleMenuSetupValidation;
+
+namespace BeanBot.Discord.RoleMenus;
+
+internal sealed record RoleMenuMigrationRequest(
+    ulong LegacyMessageId,
+    ulong? TargetChannelId,
+    ulong? TargetChannelGuildId,
+    ChannelType? TargetChannelType,
+    string? Title,
+    string? Description);
+
+internal sealed record RoleMenuMigrationPreviewResult(
+    string Content,
+    RoleMenuDraft? Draft = null,
+    IReadOnlyCollection<RoleMenuRoleSnapshot>? Roles = null,
+    string? SourceMessageLink = null,
+    RoleMenuSettings? ExistingMenu = null);
+
+internal sealed record RoleMenuMigrationConfirmationResult(
+    string Content,
+    bool Completed,
+    RoleMenuPublicationResult? Publication = null);
+
+internal sealed class RoleMenuMigrationService
+{
+    private readonly ReactionRoleRepository _reactionRoles;
+    private readonly RoleMenuInteractionService _roleMenus;
+    private readonly DiscordRoleMenuClient _discord;
+    private readonly LegacyReactionRoleMigrationClient _legacyDiscord;
+    private readonly RoleMenuAdministrationService _administration;
+
+    internal RoleMenuMigrationService(
+        ReactionRoleRepository reactionRoles,
+        RoleMenuInteractionService roleMenus,
+        DiscordRoleMenuClient discord,
+        LegacyReactionRoleMigrationClient legacyDiscord,
+        RoleMenuAdministrationService administration)
+    {
+        _reactionRoles = reactionRoles ?? throw new ArgumentNullException(nameof(reactionRoles));
+        _roleMenus = roleMenus ?? throw new ArgumentNullException(nameof(roleMenus));
+        _discord = discord ?? throw new ArgumentNullException(nameof(discord));
+        _legacyDiscord = legacyDiscord ?? throw new ArgumentNullException(nameof(legacyDiscord));
+        _administration = administration ?? throw new ArgumentNullException(nameof(administration));
+    }
+
+    internal async Task<RoleMenuMigrationPreviewResult> CreatePreviewAsync(
+        RoleMenuMigrationRequest request,
+        ulong guildId,
+        ulong administratorId,
+        ulong botUserId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var menuId = RoleMenuMigrationIdentity.CreateMenuId(guildId, request.LegacyMessageId);
+        var existing = await _roleMenus.GetAsync(menuId, guildId, cancellationToken);
+        if (existing is not null)
+        {
+            return CreateExistingResult(existing, request.LegacyMessageId, guildId);
+        }
+
+        var validation = await LoadValidatedSourceAsync(
+            request.LegacyMessageId,
+            guildId,
+            administratorId,
+            botUserId,
+            cancellationToken);
+        if (!validation.IsValid)
+        {
+            return new RoleMenuMigrationPreviewResult(validation.ErrorMessage);
+        }
+
+        var targetChannelId = request.TargetChannelId ?? validation.SourceChannelId;
+        if (request.TargetChannelId is not null
+            && (request.TargetChannelGuildId != guildId
+                || request.TargetChannelType != ChannelType.Text))
+        {
+            return new RoleMenuMigrationPreviewResult(
+                "Choose a normal text channel from this server as the migration target.");
+        }
+
+        var targetChannel = await _discord.GetGuildTextChannelAsync(
+            guildId,
+            targetChannelId,
+            CreateRequestOptions(cancellationToken));
+        if (targetChannel is null)
+        {
+            return new RoleMenuMigrationPreviewResult(
+                "The target channel no longer exists or is not a normal text channel in this server.");
+        }
+
+        var permissionFailure = GetChannelPermissionFailure(validation.Bot!, targetChannel);
+        if (permissionFailure is not null)
+        {
+            return new RoleMenuMigrationPreviewResult(permissionFailure);
+        }
+
+        var title = request.Title?.Trim();
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            title = validation.SuggestedTitle;
+        }
+
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            return new RoleMenuMigrationPreviewResult(
+                "Bean Bot recognized the legacy panel, but it has no usable `Role Group:` label. " +
+                "Run the command again with an explicit `title` before migrating it.");
+        }
+
+        if (title.Length > RoleMenuConstants.MaximumTitleLength)
+        {
+            return new RoleMenuMigrationPreviewResult(
+                $"The panel title must be 1–{RoleMenuConstants.MaximumTitleLength} characters.");
+        }
+
+        var description = request.Description?.Trim() ?? string.Empty;
+        if (description.Length > RoleMenuConstants.MaximumDescriptionLength)
+        {
+            return new RoleMenuMigrationPreviewResult(
+                $"The description cannot exceed {RoleMenuConstants.MaximumDescriptionLength} characters.");
+        }
+
+        var createStatus = _roleMenus.CreateMigrationDraft(
+            guildId,
+            administratorId,
+            targetChannelId,
+            title,
+            description,
+            validation.RoleIds!,
+            menuId,
+            request.LegacyMessageId,
+            out var draft);
+        if (createStatus != RoleMenuDraftCreateStatus.Created || draft is null)
+        {
+            return new RoleMenuMigrationPreviewResult(createStatus == RoleMenuDraftCreateStatus.AlreadyPublishing
+                ? "Your previous role-menu preview is still publishing. Wait for it to finish before starting a migration."
+                : "Bean Bot is already holding the maximum number of role-menu previews. Try again after another preview expires.");
+        }
+
+        return new RoleMenuMigrationPreviewResult(
+            "Review this private migration preview. The legacy reaction-role message and its saved " +
+            "configuration will stay unchanged after publication until you retire them manually.",
+            draft,
+            validation.RoleValidation!.Roles,
+            RoleMenuMigrationIdentity.BuildMessageLink(
+                guildId,
+                validation.SourceChannelId,
+                request.LegacyMessageId));
+    }
+
+    internal async Task<RoleMenuMigrationConfirmationResult> ConfirmAsync(
+        RoleMenuDraft draft,
+        ulong administratorId,
+        ulong botUserId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(draft);
+        if (draft.LegacyReactionRoleMessageId is not { } legacyMessageId)
+        {
+            return new RoleMenuMigrationConfirmationResult(
+                "That preview is not a legacy reaction-role migration.",
+                Completed: false);
+        }
+
+        var existing = await _roleMenus.GetAsync(draft.MenuId, draft.GuildId, cancellationToken);
+        if (existing is not null)
+        {
+            var existingResult = CreateExistingResult(existing, legacyMessageId, draft.GuildId);
+            return new RoleMenuMigrationConfirmationResult(
+                existingResult.Content,
+                Completed: IsExpectedMigration(existing, legacyMessageId));
+        }
+
+        var validation = await LoadValidatedSourceAsync(
+            legacyMessageId,
+            draft.GuildId,
+            administratorId,
+            botUserId,
+            cancellationToken);
+        if (!validation.IsValid)
+        {
+            return new RoleMenuMigrationConfirmationResult(
+                "Migration stopped during the final safety check: " + validation.ErrorMessage,
+                Completed: false);
+        }
+
+        if (!validation.RoleIds!.SequenceEqual(draft.RoleIds))
+        {
+            return new RoleMenuMigrationConfirmationResult(
+                "The legacy role configuration changed after this preview was created. Nothing was " +
+                "published; run `/role-menu migrate` again to review the current roles.",
+                Completed: false);
+        }
+
+        var targetChannel = await _discord.GetGuildTextChannelAsync(
+            draft.GuildId,
+            draft.TargetChannelId,
+            CreateRequestOptions(cancellationToken));
+        if (targetChannel is null)
+        {
+            return new RoleMenuMigrationConfirmationResult(
+                "The target channel no longer exists or is no longer a normal text channel in this server.",
+                Completed: false);
+        }
+
+        var permissionFailure = GetChannelPermissionFailure(validation.Bot!, targetChannel);
+        if (permissionFailure is not null)
+        {
+            return new RoleMenuMigrationConfirmationResult(permissionFailure, Completed: false);
+        }
+
+        var publication = await _administration.PublishAsync(
+            draft,
+            targetChannel,
+            botUserId,
+            cancellationToken);
+        if (publication.Status == RoleMenuPublicationStatus.Published
+            && publication.MessageId is { } publishedMessageId)
+        {
+            var link = RoleMenuMigrationIdentity.BuildMessageLink(
+                draft.GuildId,
+                draft.TargetChannelId,
+                publishedMessageId);
+            return new RoleMenuMigrationConfirmationResult(
+                $"Migration published as role menu `{draft.MenuId}`: {link}\n" +
+                "The legacy reaction-role panel and configuration were left unchanged. After you " +
+                "verify the new menu, retire the legacy panel deliberately to avoid offering two active controls.",
+                Completed: true,
+                publication);
+        }
+
+        var failure = publication.CanRetry
+            ? "Bean Bot confirmed that the attempted role-menu panel was rolled back and no migration was saved. " +
+              "You may retry this preview after correcting the underlying problem."
+            : FormatMigrationPublicationFailure(publication.Status);
+        return new RoleMenuMigrationConfirmationResult(
+            failure,
+            Completed: publication.IsTerminal,
+            publication);
+    }
+
+    private async Task<ValidatedLegacySource> LoadValidatedSourceAsync(
+        ulong legacyMessageId,
+        ulong guildId,
+        ulong administratorId,
+        ulong botUserId,
+        CancellationToken cancellationToken)
+    {
+        var settings = await _reactionRoles.GetRoleSetting(legacyMessageId, cancellationToken);
+        if (settings is null)
+        {
+            return ValidatedLegacySource.Invalid(
+                "No saved legacy reaction-role configuration exists for that message ID.");
+        }
+
+        if (!RoleMenuCustomIds.TryParseSnowflake(settings.GuildId, out var sourceGuildId)
+            || sourceGuildId != guildId)
+        {
+            return ValidatedLegacySource.Invalid(
+                "That legacy reaction-role configuration belongs to a different server or is malformed.");
+        }
+
+        if (!RoleMenuCustomIds.TryParseSnowflake(settings.ChannelId, out var sourceChannelId)
+            || !RoleMenuCustomIds.TryParseSnowflake(settings.MessageId, out var persistedMessageId)
+            || persistedMessageId != legacyMessageId)
+        {
+            return ValidatedLegacySource.Invalid(
+                "The saved legacy reaction-role channel/message identity is malformed. Nothing was migrated.");
+        }
+
+        if (!TryParseLegacyRoleIds(settings, out var roleIds, out var roleParseError))
+        {
+            return ValidatedLegacySource.Invalid(roleParseError);
+        }
+
+        var requestOptions = CreateRequestOptions(cancellationToken);
+        var administrator = await _discord.GetGuildUserAsync(
+            guildId,
+            administratorId,
+            requestOptions);
+        var bot = await _discord.GetGuildUserAsync(guildId, botUserId, requestOptions);
+        if (administrator is null || bot is null)
+        {
+            return ValidatedLegacySource.Invalid(
+                "Bean Bot couldn't refresh the current administrator/bot role hierarchy. Try again in a moment.");
+        }
+
+        var roleValidation = ValidateRoles(roleIds, administrator, bot);
+        if (!roleValidation.IsValid)
+        {
+            return ValidatedLegacySource.Invalid(FormatRoleValidationFailure(roleValidation));
+        }
+
+        var panel = await _legacyDiscord.ReadSourcePanelAsync(
+            guildId,
+            sourceChannelId,
+            legacyMessageId,
+            botUserId,
+            roleIds,
+            cancellationToken);
+        var panelError = panel.Status switch
+        {
+            LegacyReactionRolePanelLookupStatus.Found => null,
+            LegacyReactionRolePanelLookupStatus.ChannelMissing =>
+                "The saved legacy source channel no longer exists. The source record was left unchanged.",
+            LegacyReactionRolePanelLookupStatus.MessageMissing =>
+                "The saved legacy source message no longer exists. The source record was left unchanged.",
+            _ =>
+                "The saved message does not positively match Bean Bot's legacy `Role Group:` panel shape. " +
+                "Nothing was migrated and no title was inferred."
+        };
+        return panelError is not null
+            ? ValidatedLegacySource.Invalid(panelError)
+            : ValidatedLegacySource.Valid(
+                sourceChannelId,
+                roleIds,
+                roleValidation,
+                administrator,
+                bot,
+                panel.SuggestedTitle);
+    }
+
+    private static bool TryParseLegacyRoleIds(
+        ReactionRoleSettings settings,
+        out IReadOnlyList<ulong> roleIds,
+        out string errorMessage)
+    {
+        var parsed = new List<ulong>(settings.RoleEmotePairs.Count);
+        foreach (var pair in settings.RoleEmotePairs)
+        {
+            if (!RoleMenuCustomIds.TryParseSnowflake(pair.RoleId, out var roleId))
+            {
+                roleIds = [];
+                errorMessage =
+                    "The legacy configuration contains a malformed role ID. Nothing was migrated.";
+                return false;
+            }
+
+            parsed.Add(roleId);
+        }
+
+        if (parsed.Count is < 1 or > RoleMenuConstants.MaximumRoles)
+        {
+            roleIds = [];
+            errorMessage =
+                $"The legacy configuration must contain 1–{RoleMenuConstants.MaximumRoles} roles before it can be migrated.";
+            return false;
+        }
+
+        roleIds = parsed;
+        errorMessage = string.Empty;
+        return true;
+    }
+
+    private static RoleMenuMigrationPreviewResult CreateExistingResult(
+        RoleMenuSettings existing,
+        ulong legacyMessageId,
+        ulong guildId)
+    {
+        if (!IsExpectedMigration(existing, legacyMessageId))
+        {
+            return new RoleMenuMigrationPreviewResult(
+                "Bean Bot found a role-menu ID collision for this legacy source. No migration was attempted; " +
+                "inspect the saved role-menu configuration before retrying.",
+                ExistingMenu: existing);
+        }
+
+        var link = RoleMenuCustomIds.TryParseSnowflake(existing.ChannelId, out var channelId)
+                   && RoleMenuCustomIds.TryParseSnowflake(existing.MessageId, out var messageId)
+            ? RoleMenuMigrationIdentity.BuildMessageLink(guildId, channelId, messageId)
+            : null;
+        var suffix = link is null
+            ? "Its saved channel/message identity is malformed, so Bean Bot cannot build a message link."
+            : link;
+        return new RoleMenuMigrationPreviewResult(
+            $"That legacy panel was already migrated as role menu `{existing.Id}`. {suffix}",
+            ExistingMenu: existing);
+    }
+
+    private static bool IsExpectedMigration(RoleMenuSettings settings, ulong legacyMessageId)
+        => string.Equals(
+            settings.MigratedFromReactionRoleMessageId,
+            legacyMessageId.ToString(CultureInfo.InvariantCulture),
+            StringComparison.Ordinal);
+
+    private static string FormatMigrationPublicationFailure(RoleMenuPublicationStatus status)
+        => status switch
+        {
+            RoleMenuPublicationStatus.PanelOutcomeUnknown =>
+                "Discord reported an error while publishing, and Bean Bot could not confirm whether " +
+                "the migrated panel was created. Automatic retry is disabled. Inspect the target " +
+                "channel and saved role-menu state before trying this migration again.",
+            RoleMenuPublicationStatus.PersistenceAbsentRollbackFailed =>
+                "Bean Bot confirmed the migration settings were not saved but could not remove the " +
+                "new panel. Automatic retry is disabled; remove the orphaned panel before retrying.",
+            _ =>
+                "Bean Bot could not confirm whether MongoDB saved the migrated role menu. The panel " +
+                "was left in place and automatic retry is disabled. Inspect the target channel and " +
+                "saved role-menu state before retrying."
+        };
+
+    private sealed record ValidatedLegacySource(
+        bool IsValid,
+        string ErrorMessage,
+        ulong SourceChannelId,
+        IReadOnlyList<ulong>? RoleIds,
+        RoleMenuRoleValidationResult? RoleValidation,
+        IGuildUser? Administrator,
+        IGuildUser? Bot,
+        string? SuggestedTitle)
+    {
+        internal static ValidatedLegacySource Invalid(string errorMessage)
+            => new(false, errorMessage, 0, null, null, null, null, null);
+
+        internal static ValidatedLegacySource Valid(
+            ulong sourceChannelId,
+            IReadOnlyList<ulong> roleIds,
+            RoleMenuRoleValidationResult roleValidation,
+            IGuildUser administrator,
+            IGuildUser bot,
+            string? suggestedTitle)
+            => new(
+                true,
+                string.Empty,
+                sourceChannelId,
+                roleIds,
+                roleValidation,
+                administrator,
+                bot,
+                suggestedTitle);
+    }
+}

--- a/BeanBot/Discord/RoleMenus/RoleMenuMigrationService.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuMigrationService.cs
@@ -28,7 +28,7 @@ internal sealed record RoleMenuMigrationConfirmationResult(
     bool Completed,
     RoleMenuPublicationResult? Publication = null);
 
-internal sealed class RoleMenuMigrationService
+public sealed class RoleMenuMigrationService
 {
     private readonly ReactionRoleRepository _reactionRoles;
     private readonly RoleMenuInteractionService _roleMenus;

--- a/BeanBot/Discord/RoleMenus/RoleMenuPublicationSettings.cs
+++ b/BeanBot/Discord/RoleMenus/RoleMenuPublicationSettings.cs
@@ -19,7 +19,8 @@ internal static class RoleMenuPublicationSettings
             draft.Title,
             draft.Description,
             draft.RoleIds.Select(roleId => roleId.ToString(CultureInfo.InvariantCulture)),
-            draft.SelectionMode);
+            draft.SelectionMode,
+            draft.LegacyReactionRoleMessageId?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
         settings.CreatedAtUtc = existingCreatedAtUtc;
         return settings;
     }
@@ -47,6 +48,11 @@ internal static class RoleMenuPublicationSettings
                && string.Equals(settings.Title, draft.Title, StringComparison.Ordinal)
                && string.Equals(settings.Description, draft.Description, StringComparison.Ordinal)
                && settings.SelectionMode == draft.SelectionMode
+               && string.Equals(
+                   settings.MigratedFromReactionRoleMessageId,
+                   draft.LegacyReactionRoleMessageId?.ToString(CultureInfo.InvariantCulture)
+                       ?? string.Empty,
+                   StringComparison.Ordinal)
                && settings.RoleIds.SequenceEqual(
                    draft.RoleIds.Select(roleId => roleId.ToString(CultureInfo.InvariantCulture)),
                    StringComparer.Ordinal);

--- a/BeanBot/Persistence/Models/RoleMenuSettings.cs
+++ b/BeanBot/Persistence/Models/RoleMenuSettings.cs
@@ -19,6 +19,7 @@ public sealed class RoleMenuSettings
     private string _messageId = string.Empty;
     private string _title = string.Empty;
     private string _description = string.Empty;
+    private string _migratedFromReactionRoleMessageId = string.Empty;
 
     [BsonId]
     [JsonPropertyName("id")]
@@ -77,6 +78,15 @@ public sealed class RoleMenuSettings
     [JsonPropertyName("selectionMode")]
     public RoleMenuSelectionMode SelectionMode { get; init; }
 
+    [BsonElement("migratedFromReactionRoleMessageId")]
+    [BsonIgnoreIfDefault]
+    [JsonPropertyName("migratedFromReactionRoleMessageId")]
+    public string MigratedFromReactionRoleMessageId
+    {
+        get => _migratedFromReactionRoleMessageId;
+        init => _migratedFromReactionRoleMessageId = value ?? string.Empty;
+    }
+
     [BsonElement("createdAtUtc")]
     [BsonDateTimeOptions(Kind = DateTimeKind.Utc)]
     [JsonPropertyName("createdAtUtc")]
@@ -97,7 +107,8 @@ public sealed class RoleMenuSettings
         string title,
         string description,
         IEnumerable<string> roleIds,
-        RoleMenuSelectionMode selectionMode)
+        RoleMenuSelectionMode selectionMode,
+        string migratedFromReactionRoleMessageId = "")
     {
         if (id == ObjectId.Empty)
         {
@@ -112,5 +123,7 @@ public sealed class RoleMenuSettings
         Description = description ?? throw new ArgumentNullException(nameof(description));
         RoleIds = [.. roleIds ?? throw new ArgumentNullException(nameof(roleIds))];
         SelectionMode = selectionMode;
+        MigratedFromReactionRoleMessageId = migratedFromReactionRoleMessageId
+            ?? throw new ArgumentNullException(nameof(migratedFromReactionRoleMessageId));
     }
 }

--- a/BeanBot/Persistence/Models/RoleMenuSettings.cs
+++ b/BeanBot/Persistence/Models/RoleMenuSettings.cs
@@ -79,6 +79,7 @@ public sealed class RoleMenuSettings
     public RoleMenuSelectionMode SelectionMode { get; init; }
 
     [BsonElement("migratedFromReactionRoleMessageId")]
+    [BsonDefaultValue("")]
     [BsonIgnoreIfDefault]
     [JsonPropertyName("migratedFromReactionRoleMessageId")]
     public string MigratedFromReactionRoleMessageId

--- a/docs/role-menus.md
+++ b/docs/role-menus.md
@@ -1,10 +1,10 @@
 # Dropdown role menus
 
-BeanBot can publish persistent Discord panels that let members add or remove an administrator-approved set of roles. These panels are separate from the existing reaction-role system; legacy reaction-role messages and commands continue to work unchanged.
+BeanBot can publish persistent Discord panels that let members add or remove an administrator-approved set of roles. These panels coexist with the existing reaction-role system; legacy reaction-role messages and commands continue to work unchanged until an administrator deliberately retires them.
 
 ## Requirements
 
-The administrator running `/role-menu create` or `/role-menu delete` must:
+The administrator running `/role-menu create`, `/role-menu migrate`, or `/role-menu delete` must:
 
 - run the command in a server, not a direct message;
 - have the server-level **Manage Roles** permission; and
@@ -27,7 +27,21 @@ Discord does not allow BeanBot to assign `@everyone`, integration-managed roles,
 
 The preview expires after 10 minutes. BeanBot holds at most 64 previews at once and replaces an administrator's previous preview in the same server when they create a new one. A failed persistence write rolls back the newly posted panel when Discord permits it. If BeanBot cannot confirm whether Discord posted the panel or MongoDB saved its settings, it closes the preview and disables automatic retry to avoid creating a duplicate. Inspect the target channel, remove any orphaned panel, and confirm the saved state before creating a replacement.
 
-Each public panel contains a stable **Manage Roles** button and its menu ID in the embed footer. Saved settings include the server, channel, message, title, description, allowlisted role IDs, selection mode, and UTC timestamps, so published panels continue to work after BeanBot restarts.
+Each public panel contains a stable **Manage Roles** button and its menu ID in the embed footer. Saved settings include the server, channel, message, title, description, allowlisted role IDs, selection mode, optional legacy-migration provenance, and UTC timestamps, so published panels continue to work after BeanBot restarts.
+
+## Migrate a legacy reaction-role panel
+
+Use `/role-menu migrate legacy-message-id:<id>` to prepare one saved legacy reaction-role panel for migration. This is intentionally one panel at a time; BeanBot does not scan or bulk-convert legacy configuration.
+
+The command looks up the exact saved reaction-role record for that message ID and positively identifies the current Discord message as a BeanBot legacy `Role Group:` panel before offering a private preview. When the legacy footer contains a usable role-group label, BeanBot suggests it as the new menu title. You may supply a replacement `title`, optional `description`, and optional `target-channel` directly on the command. If no target is supplied, the replacement defaults to the legacy panel's channel.
+
+Legacy reaction-role behavior maps to a **multiple-selection** role menu: the persisted role allowlist is preserved, while the old emoji IDs are intentionally discarded because dropdown role menus no longer use reaction emoji as controls. The preview shows the exact legacy source message, roles, target channel, and retirement warning before anything is published.
+
+Selecting **Publish migration** performs the safety checks again from current state. BeanBot reloads the persisted legacy configuration and source message, revalidates administrator and bot hierarchy, verifies the roles have not changed since the preview, and checks target-channel permissions before using the normal role-menu publication workflow. If any of that state changed, publication stops and the administrator is asked to create a fresh preview.
+
+Migration uses a deterministic role-menu ID derived from the server and legacy source message and stores the source message ID with the new menu. This provenance makes rerunning the same migration idempotent across restarts and serializes concurrent confirmations through the normal per-menu lifecycle lock. If Discord or MongoDB returns an ambiguous publication result, BeanBot does not blindly retry the write; inspect the target channel and persisted role-menu state, then rerun the migration for the same source so the stable identity can reconcile the result rather than creating a second saved replacement.
+
+Migration **does not delete, disable, or edit the legacy reaction-role message or its saved configuration**. Verify the new dropdown panel first, then deliberately retire the old panel through the existing legacy administration workflow. Until you do, both controls may remain active.
 
 ## Member behavior
 
@@ -50,7 +64,7 @@ Deletion requires a private confirmation. BeanBot deletes a matching BeanBot-own
 
 Use a test server with BeanBot's role below one test role and above two other test roles.
 
-1. Confirm `/role-menu create` is unavailable to a member without **Manage Roles** and cannot run in a direct message.
+1. Confirm `/role-menu create`, `/role-menu migrate`, and `/role-menu delete` are unavailable to a member without **Manage Roles** and cannot run in a direct message.
 2. Confirm setup rejects `@everyone`, a managed role, the role above BeanBot, and a role at or above a non-owner administrator.
 3. Publish a two-role multiple menu and confirm the preview is private while the panel is public in the selected channel.
 4. Open the same panel as two different members and confirm each receives an independent private selector with only their own current menu roles preselected.
@@ -60,14 +74,17 @@ Use a test server with BeanBot's role below one test role and above two other te
 8. Restart BeanBot and confirm the remaining panels still work from their persisted configuration.
 9. Delete a panel through `/role-menu delete`, then confirm its old controls cannot mutate roles.
 10. Temporarily remove BeanBot's hierarchy or permissions and confirm operations fail privately without exposing exception details or changing unrelated roles.
-11. Use an existing legacy reaction-role panel and confirm its reactions still add and remove roles exactly as before.
+11. Migrate an existing legacy reaction-role panel. Confirm the preview is private, maps the roles to multiple-selection mode, and does not modify the source panel or source persistence.
+12. Rerun migration for the same legacy message after publication and confirm BeanBot reports the existing replacement rather than publishing another one.
+13. Change or remove a legacy role between preview and confirmation and confirm migration stops before publishing. Restore the source, create a fresh preview, and verify the replacement.
+14. Retire the legacy panel only after verifying the dropdown replacement, and confirm the new menu continues to work independently.
 
 ## Code organization
 
-`RoleMenuAdminModule` and `RoleMenuMemberModule` validate Discord control bindings and acknowledge interactions before starting work. Their shared `RoleMenuModuleBase` handles private responses, mention suppression, and acknowledgement reconciliation.
+`RoleMenuAdminModule` and `RoleMenuMemberModule` validate Discord control bindings and acknowledge interactions before starting work. Migration interaction handlers are a partial continuation of the same `RoleMenuAdminModule`, so Discord registers exactly one `/role-menu` command group. Their shared `RoleMenuModuleBase` handles private responses, mention suppression, and acknowledgement reconciliation.
 
-`RoleMenuAdministrationService` prepares drafts and connects publication and deletion to persistence. `RoleMenuMemberService` loads selectors and applies member choices through the mutation coordinator. These services take IDs and submitted values, without an interaction context. Each member operation keeps its own Discord member reference, so concurrent requests cannot share a mutation target.
+`RoleMenuAdministrationService` prepares ordinary creation drafts and connects publication and deletion to persistence. `RoleMenuMigrationService` performs exact legacy-source lookup, validation, preview creation, final revalidation, and durable idempotency before delegating publication to the same administration workflow. `LegacyReactionRoleMigrationClient` contains the read-only Discord lookup used to positively identify the source panel. `RoleMenuMemberService` loads selectors and applies member choices through the mutation coordinator. These services take IDs and submitted values, without an interaction context. Each member operation keeps its own Discord member reference, so concurrent requests cannot share a mutation target.
 
-`DiscordRoleMenuClient` contains Discord REST reads and mutations. `RoleMenuSetupValidation` and `RoleMenuPresentation` keep validation and result text separate from transport. The publication, deletion, and member workflows retain their independently tested rules for ambiguous outcomes, rollback, final-state reconciliation, and cancellation. `RoleMenuInteractionService` supplies the shared bounded execution, draft, persistence, and lock operations used by those entry points.
+`DiscordRoleMenuClient` contains Discord REST reads and mutations. `RoleMenuSetupValidation` and `RoleMenuPresentation` keep validation and result text separate from transport. The publication, deletion, migration, and member workflows retain their independently tested rules for ambiguous outcomes, rollback, final-state reconciliation, and cancellation. `RoleMenuInteractionService` supplies the shared bounded execution, draft, persistence, and lock operations used by those entry points.
 
 Shutdown closes normal interaction, busy-response, and command-registration admission. If a Discord request ignores cancellation and outlives the drain timeout, its ownership remains visible to the application, which skips Discord stop/disposal until the request actually completes. A late `Ready` event cannot restart command registration after shutdown.

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -8,9 +8,10 @@ BeanBot supports Discord application commands alongside the existing message-com
 - `/pun` uses the same cached `IPunProvider` as the legacy `%pun` command.
 - `/help` summarizes the slash-command surface and points users to `%help` for the complete legacy command list.
 - `/role-menu create` opens a native Discord setup form for an administrator with **Manage Roles**.
+- `/role-menu migrate legacy-message-id:<id> [target-channel] [title] [description]` opens a private, revalidated preview for replacing one saved legacy reaction-role panel with a multiple-selection dropdown role menu. The legacy panel and configuration are left unchanged until an administrator retires them deliberately.
 - `/role-menu delete [menu-id]` removes a published dropdown role panel and its saved configuration. The optional exact ID supports servers with more than 25 menus.
 
-Role-menu setup and deletion are server-only. Members manage their own allowlisted roles from each published panel without needing **Manage Roles**. See [Dropdown role menus](role-menus.md) for the full workflow and operational checks.
+Role-menu creation, migration, and deletion are server-only. Members manage their own allowlisted roles from each published panel without needing **Manage Roles**. See [Dropdown role menus](role-menus.md) for the full workflow and operational checks.
 
 The existing `%`, `succ `, and mention-prefix commands remain supported and are not replaced by slash commands.
 


### PR DESCRIPTION
Closes #194

## Summary
- add `/role-menu migrate legacy-message-id:<id>` for one-at-a-time conversion of saved legacy reaction-role panels into native role menus
- positively identify the existing BeanBot legacy panel and show a private preview before publication
- map legacy role allowlists to `Multiple` mode while intentionally discarding obsolete emoji IDs
- re-read and revalidate the saved source, live Discord panel, administrator/bot hierarchy, roles, and target permissions at confirmation time
- preserve the legacy panel/configuration until an administrator deliberately retires it
- use a deterministic role-menu ID plus persisted source provenance so reruns/restarts/concurrent confirmations reconcile to the same migration identity instead of creating another saved replacement
- reuse the existing role-menu publication/reconciliation workflow so ambiguous Discord writes are not blindly retried

## Implementation notes
- migration lives in the existing `RoleMenuAdminModule` command group and keeps the same guild-only / `Manage Roles` authorization surface
- source lookup is exact by persisted legacy message ID; no unbounded candidate scan or bulk migration path was added
- the preview is bounded by the existing role-menu draft registry and is private/ephemeral
- final confirmation runs under the existing bounded per-menu mutation coordinator, reloads legacy persistence, rechecks the source panel identity and role set, and then delegates publication to `RoleMenuAdministrationService`
- `RoleMenuSettings.migratedFromReactionRoleMessageId` is additive/backward-compatible and is carried through publication matching/reconciliation
- ordinary non-migrated role-menu documents omit that migration-only BSON field; migrated menus persist the exact source message ID for restart-safe idempotency
- successful migration never edits or deletes legacy reaction-role persistence or its Discord message

## Tests and docs
- deterministic migration identity and message links
- positive/negative legacy panel recognition and title suggestion
- migration draft/provenance persistence behavior, including omission of empty provenance on normal menus
- preview mapping, cross-guild rejection, stale role-set revalidation, and already-migrated restart/idempotency behavior
- existing role-menu publication, persistence reconciliation, mutation-coordinator, role validation, interaction lifecycle, and legacy reaction-role suites remain part of the full repository gate
- role-menu operational and slash-command documentation covers migration, temporary dual-panel operation, ambiguous outcomes, manual validation, and safe retirement

## Review-found fix
A fresh review found that `[BsonIgnoreIfDefault]` alone treats `null` as the default for `string`, so non-migrated menus would still serialize `migratedFromReactionRoleMessageId: ""`. The field now declares an explicit empty-string BSON default and a regression test proves ordinary role-menu documents omit the migration-only field. The review thread is resolved.

## Verification
Fresh Verifier result: **PASS** against issue #194, its acceptance criteria, the complete 23-file final diff, current `develop`, and exact-head CI.

Exact source head: `7c7d4fe30ce7ff34ae342582fe113a4f67bb0a67`
Base / target: `develop` at `9a157b8008fb05405433bf6bb6ec2b3a0d88efc3`
Branch relation: 36 commits ahead / 0 behind.

Required exact-head checks:
- Repository Verification #428 — **PASS** (`Full repository verification`, exact checkout of `7c7d4fe30ce7ff34ae342582fe113a4f67bb0a67`)
- CodeQL #263 — **PASS**
- Dependency Review #221 — **PASS**

The repository-owned verification job completed its full deterministic verification step successfully. Local focused/fast/full execution is not claimed in this automation runtime; exact-head GitHub Actions supplied the repository-authorized deterministic gate evidence.

Fresh independent Reviewer result after the repair: **CLEAN**. Review focused on consequential correctness, Discord lifecycle/concurrency, duplicate publication risk, bounded waits/retries, cancellation, persistence semantics, source immutability, migration idempotency, security/authorization, Docker/runtime compatibility, dependency/release regressions, test quality, and unrelated scope. No consequential finding remains, and there are **0 unresolved review threads**.

## Remaining manual validation
Smoke-test in a Discord test guild:
1. Preview and publish a known legacy panel.
2. Confirm the preview is ephemeral and the replacement keeps the intended role allowlist in multiple-selection mode.
3. Verify the old reaction-role panel and saved legacy configuration remain unchanged after publication.
4. Rerun migration for the same source and confirm BeanBot reports the existing replacement rather than publishing another saved migration.
5. Change/remove a source role or target permission between preview and confirmation and confirm publication stops safely.
6. After validating the replacement, retire the legacy panel explicitly through the existing legacy administration path.

No merge, auto-merge, release creation, or unrelated refactor is part of this PR.